### PR TITLE
Enable RLS policies on data_contributions and waitlist tables

### DIFF
--- a/supabase/migrations/003_enable_rls_policies.sql
+++ b/supabase/migrations/003_enable_rls_policies.sql
@@ -1,0 +1,31 @@
+-- ============================================================
+-- Enable RLS on public.data_contributions and public.waitlist
+-- Resolves Supabase lint: "RLS Disabled in Public" for both tables
+-- ============================================================
+
+-- 1. data_contributions
+-- RLS was defined in 001_initial_schema.sql but may not be active;
+-- re-enable (idempotent) and ensure a restrictive policy exists.
+alter table public.data_contributions enable row level security;
+
+-- Re-create service-role-only policy (drop first to avoid duplicate errors)
+drop policy if exists "Service role full access" on public.data_contributions;
+
+create policy "Service role full access" on public.data_contributions
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+
+-- 2. waitlist
+-- Table exists in production but was not created via migrations.
+-- Enable RLS and restrict access to service_role only (the /api/subscribe
+-- route uses SUPABASE_SERVICE_ROLE_KEY which bypasses RLS).
+alter table public.waitlist enable row level security;
+
+drop policy if exists "Service role full access" on public.waitlist;
+
+create policy "Service role full access" on public.waitlist
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
This migration enables Row Level Security (RLS) on the `public.data_contributions` and `public.waitlist` tables, and establishes restrictive service-role-only access policies for both. This resolves Supabase lint warnings about RLS being disabled on public tables.

## Key Changes
- **data_contributions table**: Re-enabled RLS and created a service-role-only policy to ensure only backend services with the service role key can access this table
- **waitlist table**: Enabled RLS (table exists in production but was not created via migrations) and restricted access to service role only, aligning with the `/api/subscribe` endpoint's use of `SUPABASE_SERVICE_ROLE_KEY`
- Both tables now have identical "Service role full access" policies that allow all operations (SELECT, INSERT, UPDATE, DELETE) only when `auth.role() = 'service_role'`

## Implementation Details
- Policies are created idempotently by dropping existing policies before recreation to avoid duplicate key errors
- The service-role-only approach ensures that direct client access is blocked while allowing backend API routes to perform necessary operations using the service role key
- This follows security best practices by making public tables restrictive by default

https://claude.ai/code/session_01G1ALhBU4RoSm3bsn7AHye1