### PR TITLE
feat: auth hardening, account menu & deployment safeguards

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,10 +1,11 @@
 # AirwayLab Environment Variables
 # Copy to .env.local. All optional — app works without them.
+# NOTE: Supabase URL + anon key must BOTH be set (or both unset).
 
 # Plausible Analytics (privacy-first, no cookies)
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=airwaylab.app
 
-# Supabase (auth + data)
+# Supabase (auth + data) — these two MUST be set as a pair
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_URL=https://your-project.supabase.co

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,14 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - name: Verify auth env vars are paired
+        run: |
+          if [ -n "$NEXT_PUBLIC_SUPABASE_URL" ] && [ -z "$NEXT_PUBLIC_SUPABASE_ANON_KEY" ]; then
+            echo "::error::NEXT_PUBLIC_SUPABASE_URL is set but NEXT_PUBLIC_SUPABASE_ANON_KEY is missing"
+            exit 1
+          fi
+          if [ -z "$NEXT_PUBLIC_SUPABASE_URL" ] && [ -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" ]; then
+            echo "::error::NEXT_PUBLIC_SUPABASE_ANON_KEY is set but NEXT_PUBLIC_SUPABASE_URL is missing"
+            exit 1
+          fi
       - run: npm run build

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const checks: Record<string, boolean> = {};
+  const version = process.env.npm_package_version ?? 'unknown';
+
+  // Supabase connectivity
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (supabaseUrl && supabaseKey) {
+    try {
+      const sb = createClient(supabaseUrl, supabaseKey);
+      // Lightweight auth health check — doesn't need a session
+      const { error } = await sb.auth.getSession();
+      checks.supabase = !error;
+    } catch {
+      checks.supabase = false;
+    }
+  } else {
+    checks.supabase = false;
+  }
+
+  // Stripe connectivity
+  const stripeKey = process.env.STRIPE_SECRET_KEY;
+  if (stripeKey) {
+    try {
+      const res = await fetch('https://api.stripe.com/v1/balance', {
+        headers: { Authorization: `Bearer ${stripeKey}` },
+      });
+      checks.stripe = res.ok;
+    } catch {
+      checks.stripe = false;
+    }
+  } else {
+    checks.stripe = false;
+  }
+
+  const allHealthy = Object.values(checks).every(Boolean);
+
+  return NextResponse.json(
+    {
+      status: allHealthy ? 'ok' : 'degraded',
+      version,
+      timestamp: new Date().toISOString(),
+      checks,
+    },
+    { status: allHealthy ? 200 : 503 }
+  );
+}

--- a/app/api/request-account-deletion/route.ts
+++ b/app/api/request-account-deletion/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server';
+import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
+import { validateOrigin } from '@/lib/csrf';
+
+/** Account deletion requests: 3 per hour per IP */
+const deletionRateLimiter = new RateLimiter({
+  windowMs: 3_600_000,
+  max: 3,
+});
+
+export async function POST(request: NextRequest) {
+  // CSRF protection
+  if (!validateOrigin(request)) {
+    return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
+  }
+
+  // Rate limiting
+  const ip = getRateLimitKey(request);
+  if (deletionRateLimiter.isLimited(ip)) {
+    return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
+  }
+
+  // Auth check
+  const supabase = getSupabaseServer();
+  if (!supabase) {
+    return NextResponse.json({ error: 'Auth not configured' }, { status: 503 });
+  }
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Insert deletion request via service role (bypasses RLS for write)
+  const serviceRole = getSupabaseServiceRole();
+  if (!serviceRole) {
+    return NextResponse.json({ error: 'Service not configured' }, { status: 503 });
+  }
+
+  try {
+    const { error: insertError } = await serviceRole
+      .from('account_deletion_requests')
+      .insert({
+        user_id: user.id,
+        email: user.email,
+        status: 'pending',
+      });
+
+    if (insertError) {
+      console.error('[request-account-deletion] Insert failed:', insertError.message);
+      Sentry.captureException(insertError, {
+        tags: { route: 'request-account-deletion' },
+        extra: { userId: user.id },
+      });
+      return NextResponse.json({ error: 'Failed to submit request' }, { status: 500 });
+    }
+
+    // Notify via Sentry so the team sees it in monitoring
+    Sentry.captureMessage(`Account deletion requested by ${user.email}`, {
+      level: 'info',
+      tags: { route: 'request-account-deletion' },
+      extra: { userId: user.id, email: user.email },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    Sentry.captureException(err, { tags: { route: 'request-account-deletion' } });
+    console.error('[request-account-deletion] Error:', err);
+    return NextResponse.json({ error: 'Failed to submit request' }, { status: 500 });
+  }
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -6,6 +6,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
 
 /**
  * Validate the `next` redirect parameter to prevent open redirect attacks.
@@ -62,8 +63,15 @@ export async function GET(request: NextRequest) {
 
   if (error) {
     console.error('[auth/callback] Code exchange failed:', error.message);
+    Sentry.captureException(error, {
+      tags: { route: 'auth-callback' },
+      extra: { hasCode: true },
+    });
     return NextResponse.redirect(`${origin}/analyze?auth_error=true`);
   }
 
-  return NextResponse.redirect(`${origin}${next}`);
+  // Add auth=success param so the client-side AuthProvider can detect
+  // a fresh login and retry session pickup if needed.
+  const separator = next.includes('?') ? '&' : '?';
+  return NextResponse.redirect(`${origin}${next}${separator}auth=success`);
 }

--- a/components/auth/auth-modal.tsx
+++ b/components/auth/auth-modal.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from 'react';
 import { useAuth } from '@/lib/auth/auth-context';
 import { X, Mail, Loader2, Shield } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import * as Sentry from '@sentry/nextjs';
 
 interface Props {
   open: boolean;
@@ -30,7 +31,12 @@ export function AuthModal({ open, onClose }: Props) {
       setLoading(false);
 
       if (signInError) {
-        // L2: Show specific error messages instead of generic fallback
+        Sentry.captureMessage(`Auth modal sign-in error: ${signInError}`, {
+          level: 'warning',
+          tags: { context: 'auth-modal' },
+          extra: { emailDomain: trimmed.split('@')[1] },
+        });
+
         if (signInError.toLowerCase().includes('rate limit') || signInError.toLowerCase().includes('too many')) {
           setError('Too many sign-in attempts. Please wait a minute and try again.');
         } else if (signInError.toLowerCase().includes('invalid') && signInError.toLowerCase().includes('email')) {

--- a/components/auth/user-menu.tsx
+++ b/components/auth/user-menu.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { useAuth, type Tier } from '@/lib/auth/auth-context';
-import { User, LogOut, CreditCard, Crown, Heart, Loader2 } from 'lucide-react';
+import { User, LogOut, CreditCard, Crown, Heart, Loader2, Trash2 } from 'lucide-react';
 
 const TIER_CONFIG: Record<Tier, { label: string; color: string; icon: typeof Heart }> = {
   community: { label: 'Community', color: 'text-muted-foreground', icon: User },
@@ -16,6 +16,7 @@ export function UserMenu() {
   const [open, setOpen] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
   const [portalError, setPortalError] = useState(false);
+  const [deleteState, setDeleteState] = useState<'idle' | 'confirm' | 'loading' | 'done' | 'error'>('idle');
   const menuRef = useRef<HTMLDivElement>(null);
 
   // Close on click outside
@@ -46,6 +47,24 @@ export function UserMenu() {
     setOpen(false);
     await signOut();
   }, [signOut]);
+
+  const handleDeleteRequest = useCallback(async () => {
+    setDeleteState('loading');
+    try {
+      const res = await fetch('/api/request-account-deletion', {
+        method: 'POST',
+        credentials: 'same-origin',
+      });
+      if (res.ok) {
+        setDeleteState('done');
+      } else {
+        setDeleteState('error');
+      }
+    } catch {
+      console.error('[user-menu] Failed to request account deletion');
+      setDeleteState('error');
+    }
+  }, []);
 
   const handlePortal = useCallback(async () => {
     setPortalLoading(true);
@@ -135,6 +154,57 @@ export function UserMenu() {
           </div>
 
           <div className="border-t border-border/50 py-1">
+            {deleteState === 'done' ? (
+              <p className="px-3 py-2 text-[10px] leading-snug text-emerald-400">
+                Deletion request received. We&apos;ll process it within 30 days.
+              </p>
+            ) : deleteState === 'confirm' ? (
+              <div className="px-3 py-2">
+                <p className="text-[10px] leading-snug text-muted-foreground">
+                  Are you sure? This will send a deletion request to our team.
+                </p>
+                <div className="mt-1.5 flex gap-2">
+                  <button
+                    onClick={handleDeleteRequest}
+                    className="rounded bg-red-500/10 px-2 py-1 text-[10px] font-medium text-red-400 transition-colors hover:bg-red-500/20"
+                  >
+                    Yes, delete my account
+                  </button>
+                  <button
+                    onClick={() => setDeleteState('idle')}
+                    className="rounded px-2 py-1 text-[10px] text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : deleteState === 'error' ? (
+              <div className="px-3 py-2">
+                <p className="text-[10px] text-red-400">
+                  Could not submit request. Please try again.
+                </p>
+                <button
+                  onClick={() => setDeleteState('idle')}
+                  className="mt-1 text-[10px] text-muted-foreground underline"
+                >
+                  Dismiss
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setDeleteState('confirm')}
+                disabled={deleteState === 'loading'}
+                className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-red-400 disabled:opacity-50"
+              >
+                {deleteState === 'loading' ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Trash2 className="h-3.5 w-3.5" />
+                )}
+                Request account deletion
+              </button>
+            )}
+
             <button
               onClick={handleSignOut}
               className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -60,17 +60,17 @@ export function Header() {
             </a>
 
             {/* Auth: sign in or user menu */}
-            {!isLoading && (
-              user ? (
-                <UserMenu />
-              ) : (
-                <button
-                  onClick={() => setAuthModalOpen(true)}
-                  className="ml-0.5 rounded-md bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/20 sm:ml-1 sm:px-3 sm:py-2 sm:text-sm"
-                >
-                  Sign in
-                </button>
-              )
+            {isLoading ? (
+              <div className="ml-0.5 h-6 w-6 animate-pulse rounded-full bg-muted/50 sm:ml-1" />
+            ) : user ? (
+              <UserMenu />
+            ) : (
+              <button
+                onClick={() => setAuthModalOpen(true)}
+                className="ml-0.5 rounded-md bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/20 sm:ml-1 sm:px-3 sm:py-2 sm:text-sm"
+              >
+                Sign in
+              </button>
             )}
           </nav>
         </div>

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
 import { getSupabaseBrowser } from '@/lib/supabase/client';
 import type { User, Session, AuthChangeEvent } from '@supabase/supabase-js';
+import * as Sentry from '@sentry/nextjs';
 
 export type Tier = 'community' | 'supporter' | 'champion';
 
@@ -61,6 +62,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (profileError) {
       console.error('[auth-context] Failed to fetch profile:', profileError.message);
+      Sentry.captureException(profileError, { tags: { context: 'auth-profile-fetch' } });
       return;
     }
 
@@ -88,6 +90,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (subError) {
       console.error('[auth-context] Failed to fetch subscription:', subError.message);
+      Sentry.captureException(subError, { tags: { context: 'auth-subscription-fetch' } });
       setSubscription(null);
       return;
     }
@@ -120,8 +123,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     // Get initial session
-    supabase.auth.getSession().then((result: { data: { session: Session | null } }) => {
-      const initialSession = result.data.session;
+    supabase.auth.getSession().then(async (result: { data: { session: Session | null } }) => {
+      let initialSession = result.data.session;
+
+      // If we just came back from a magic link redirect (auth=success param),
+      // but getSession() didn't find a session yet, retry with getUser()
+      // which reads the cookie set by the auth callback route.
+      if (!initialSession && typeof window !== 'undefined') {
+        const params = new URLSearchParams(window.location.search);
+        if (params.has('auth')) {
+          const { data: { user: freshUser } } = await supabase.auth.getUser();
+          if (freshUser) {
+            const { data: { session: freshSession } } = await supabase.auth.getSession();
+            initialSession = freshSession;
+          }
+          // Clean up the URL param without triggering a navigation
+          params.delete('auth');
+          const cleanUrl = params.toString()
+            ? `${window.location.pathname}?${params.toString()}`
+            : window.location.pathname;
+          window.history.replaceState({}, '', cleanUrl);
+        }
+      }
+
       setSession(initialSession);
       setUser(initialSession?.user ?? null);
       if (initialSession?.user) {
@@ -163,6 +187,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     });
 
     if (error) {
+      Sentry.captureException(error, {
+        tags: { context: 'auth-sign-in' },
+        extra: { emailDomain: email.split('@')[1] },
+      });
       return { error: error.message };
     }
     return { error: null };

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -53,6 +53,16 @@ export const serverEnv = {
  */
 export function validateServerEnv() {
   const warnings: string[] = [];
+  const errors: string[] = [];
+
+  // Supabase auth requires both client-side vars as a pair
+  const hasSupabaseUrl = !!env.NEXT_PUBLIC_SUPABASE_URL;
+  const hasSupabaseKey = !!env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (hasSupabaseUrl !== hasSupabaseKey) {
+    errors.push(
+      `NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must both be set (or both unset). Auth will not work.`
+    );
+  }
 
   if (serverEnv.ANTHROPIC_API_KEY && !serverEnv.AI_INSIGHTS_API_KEY) {
     warnings.push(
@@ -62,13 +72,13 @@ export function validateServerEnv() {
 
   if (serverEnv.SUPABASE_URL && !serverEnv.SUPABASE_SERVICE_ROLE_KEY) {
     warnings.push(
-      'SUPABASE_URL is set but SUPABASE_SERVICE_ROLE_KEY is missing — waitlist capture will fail.'
+      'SUPABASE_URL is set but SUPABASE_SERVICE_ROLE_KEY is missing — service role operations will fail.'
     );
   }
 
   if (serverEnv.SUPABASE_SERVICE_ROLE_KEY && !serverEnv.SUPABASE_URL) {
     warnings.push(
-      'SUPABASE_SERVICE_ROLE_KEY is set but SUPABASE_URL is missing — waitlist capture will fail.'
+      'SUPABASE_SERVICE_ROLE_KEY is set but SUPABASE_URL is missing — service role operations will fail.'
     );
   }
 
@@ -80,6 +90,13 @@ export function validateServerEnv() {
 
   for (const w of warnings) {
     console.warn(`[env] ⚠️  ${w}`);
+  }
+
+  if (errors.length > 0) {
+    for (const e of errors) {
+      console.error(`[env] ❌ ${e}`);
+    }
+    throw new Error(`[env] Environment validation failed:\n${errors.join('\n')}`);
   }
 
   return warnings;

--- a/supabase/migrations/005_account_deletion_requests.sql
+++ b/supabase/migrations/005_account_deletion_requests.sql
@@ -1,0 +1,27 @@
+-- 005: Account deletion requests
+-- Stores user-initiated account deletion requests for manual processing.
+
+create table if not exists public.account_deletion_requests (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  email       text not null,
+  reason      text,
+  status      text not null default 'pending'
+                check (status in ('pending', 'approved', 'rejected', 'completed')),
+  created_at  timestamptz not null default now()
+);
+
+-- RLS: users can insert their own requests, only service role can read/update
+alter table public.account_deletion_requests enable row level security;
+
+create policy "Users can request their own deletion"
+  on public.account_deletion_requests
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users can view their own requests"
+  on public.account_deletion_requests
+  for select
+  to authenticated
+  using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

- **Fix magic link login visibility**: After clicking magic link, users now see their logged-in state immediately. Auth callback appends `?auth=success` param, and AuthProvider retries session pickup when detected.
- **Sentry error capture across auth flow**: Auth callback exchange failures, profile/subscription fetch errors, sign-in errors, and modal errors are all captured in Sentry.
- **Account deletion request flow**: Users can request account deletion from their menu. Inserts into `account_deletion_requests` table + Sentry info alert. Includes rate limiting (3/hr), CSRF protection, and confirmation UI.
- **Health check endpoint**: `GET /api/health` checks Supabase and Stripe connectivity, returns status + version.
- **Env var hardening**: Supabase URL and anon key must both be set or both unset — throws a build error if mismatched. CI also validates this.
- **Header loading state**: Shows a pulse placeholder during auth check instead of hiding the entire auth area.

## Files changed

| File | Change |
|------|--------|
| `app/auth/callback/route.ts` | Sentry capture + `?auth=success` redirect param |
| `lib/auth/auth-context.tsx` | Sentry captures + session retry on `auth=success` |
| `components/auth/auth-modal.tsx` | Sentry capture on sign-in error |
| `components/layout/header.tsx` | Loading placeholder during auth check |
| `components/auth/user-menu.tsx` | Account deletion request UI |
| `app/api/request-account-deletion/route.ts` | **New** — deletion request endpoint |
| `supabase/migrations/005_account_deletion_requests.sql` | **New** — DB table + RLS |
| `app/api/health/route.ts` | **New** — health check endpoint |
| `lib/env.ts` | Paired Supabase var validation (throws on mismatch) |
| `.github/workflows/ci.yml` | Env var presence check in build step |
| `.env.local.example` | Updated documentation |

## Test plan

- [ ] Sign in via magic link → verify header shows UserMenu immediately after redirect
- [ ] Check Sentry for auth-related captures after a sign-in flow
- [ ] Click user avatar → "Request account deletion" → confirm → verify success message
- [ ] Check `account_deletion_requests` table in Supabase for new row
- [ ] Hit `GET /api/health` → verify JSON response with checks
- [ ] Remove one Supabase env var → verify build fails with clear error
- [ ] Run CI pipeline → verify env check step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)