### PR TITLE
fix: prevent browser freeze on large SD cards and raise night cap to 3 years

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -186,9 +186,9 @@ function AnalyzePageInner() {
   );
 
   const submitContribution = useCallback((nightsToSubmit: NightResult[]) => {
-    // Cap at 365 most recent nights to stay within server limits
-    const toSubmit = nightsToSubmit.length > 365
-      ? nightsToSubmit.slice(0, 365)
+    // Cap at 1095 most recent nights to stay within server limits
+    const toSubmit = nightsToSubmit.length > 1095
+      ? nightsToSubmit.slice(0, 1095)
       : nightsToSubmit;
     fetch('/api/contribute-data', {
       method: 'POST',

--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -47,7 +47,7 @@ const RequestBodySchema = z.object({
     wat: z.object({ flScore: z.number() }).passthrough(),
     ned: z.object({ nedMean: z.number() }).passthrough(),
     oximetry: z.object({}).passthrough().nullable().optional(),
-  }).passthrough()).min(1).max(365),
+  }).passthrough()).min(1).max(1095),
   selectedNightIndex: z.number().int().min(0),
   therapyChangeDate: z.string().nullable(),
 });

--- a/app/api/contribute-data/route.ts
+++ b/app/api/contribute-data/route.ts
@@ -19,8 +19,8 @@ function isRateLimited(ip: string): boolean {
 }
 
 // ── Validation ───────────────────────────────────────────────
-const MAX_NIGHTS = 365;
-const MAX_PAYLOAD_BYTES = 2_048_000; // 2 MB
+const MAX_NIGHTS = 1095; // ~3 years of nightly data
+const MAX_PAYLOAD_BYTES = 6_144_000; // 6 MB (supports ~3 years of nightly data)
 
 function isValidNight(n: unknown): n is NightResult {
   if (!n || typeof n !== 'object') return false;

--- a/app/api/track-analysis/route.ts
+++ b/app/api/track-analysis/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: Request) {
     if (
       typeof nightCount !== 'number' ||
       nightCount < 1 ||
-      nightCount > 365 ||
+      nightCount > 1095 ||
       typeof hasOximetry !== 'boolean' ||
       typeof isDemo !== 'boolean'
     ) {

--- a/components/dashboard/data-contribution.tsx
+++ b/components/dashboard/data-contribution.tsx
@@ -64,9 +64,9 @@ export function DataContribution({ nights, isDemo = false }: Props) {
   const handleContribute = useCallback(async () => {
     setStatus('sending');
     try {
-      // Cap at 365 most recent nights to stay within server limits
-      const toSubmit = nights.length > 365
-        ? nights.slice(0, 365)
+      // Cap at 1095 most recent nights to stay within server limits
+      const toSubmit = nights.length > 1095
+        ? nights.slice(0, 1095)
         : nights;
       const res = await fetch('/api/contribute-data', {
         method: 'POST',

--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -178,15 +178,15 @@ export class AnalysisOrchestrator {
     oximetryCSVs?: string[]
   ): Promise<NightResult[]> {
     return new Promise((resolve, reject) => {
-      // Safety timeout — 5 minutes is generous for even large SD cards
-      const WORKER_TIMEOUT_MS = 5 * 60 * 1000;
+      // Safety timeout — 10 minutes to handle multi-year SD cards (800+ files)
+      const WORKER_TIMEOUT_MS = 10 * 60 * 1000;
       let settled = false;
 
       const timeout = setTimeout(() => {
         if (!settled) {
           settled = true;
           this.terminate();
-          reject(new Error('Analysis timed out after 5 minutes. Your data may be too large or in an unsupported format.'));
+          reject(new Error('Analysis timed out after 10 minutes. Your data may be too large or in an unsupported format.'));
         }
       }, WORKER_TIMEOUT_MS);
 

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -53,6 +53,20 @@ function postProgress(current: number, total: number, stage: string): void {
   self.postMessage(msg);
 }
 
+/**
+ * Yield control back to the event loop so the worker thread
+ * doesn't starve the browser of message processing.
+ * Called between batches of CPU-intensive work.
+ */
+function yieldControl(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** How many EDF files to parse before yielding */
+const PARSE_BATCH_SIZE = 25;
+/** How many nights to analyze before yielding */
+const ANALYZE_BATCH_SIZE = 10;
+
 async function processFiles(
   files: { buffer: ArrayBuffer; path: string }[],
   oximetryCSVs?: string[]
@@ -96,9 +110,11 @@ async function processFiles(
 
   postProgress(1, brpFiles.length + 2, 'Parsing EDF files...');
 
-  // Step 3: Parse all BRP.edf files
+  // Step 3: Parse BRP.edf files in batches, yielding between batches
+  // to prevent the worker from locking up the browser on large SD cards
   const parsedEdfs: EDFFile[] = [];
-  for (const brp of brpFiles) {
+  for (let i = 0; i < brpFiles.length; i++) {
+    const brp = brpFiles[i];
     const fileData = files.find((f) => f.path === brp.path);
     if (!fileData) continue;
     try {
@@ -106,6 +122,12 @@ async function processFiles(
       parsedEdfs.push(edf);
     } catch {
       // Skip unparseable files
+    }
+
+    // Yield every PARSE_BATCH_SIZE files and report progress
+    if ((i + 1) % PARSE_BATCH_SIZE === 0) {
+      postProgress(1, brpFiles.length + 2, `Parsing EDF files (${i + 1}/${brpFiles.length})...`);
+      await yieldControl();
     }
   }
 
@@ -131,12 +153,17 @@ async function processFiles(
     }
   }
 
-  // Step 6: Run all engines per night
+  // Step 6: Run all engines per night, yielding periodically
   const nights: NightResult[] = [];
 
   for (let i = 0; i < nightGroups.length; i++) {
     const group = nightGroups[i];
     postProgress(i + 3, nightGroups.length + 2, `Analyzing night ${group.nightDate}...`);
+
+    // Yield every ANALYZE_BATCH_SIZE nights to keep the worker responsive
+    if (i > 0 && i % ANALYZE_BATCH_SIZE === 0) {
+      await yieldControl();
+    }
 
     // Get settings for this night
     const settings = getSettingsForDate(dailySettings, group.nightDate) ?? {


### PR DESCRIPTION
The analysis worker parsed all EDF files in a tight synchronous loop,
which locked up the browser when processing 800+ files (~2 years of data).

- Add periodic yielding (setTimeout(0)) during EDF parsing and night
  analysis in the worker to keep the browser responsive
- Raise the 365-night cap to 1095 (~3 years) across all API endpoints
  and client-side submission code
- Increase worker timeout from 5 to 10 minutes for large datasets
- Increase contribution payload limit from 2MB to 6MB

Fixes user report of system lockup when scanning SD card with 2yr of data.

https://claude.ai/code/session_01HDNGXq662kzNT3pU5y6o6L