### PR TITLE
fix: improve metric tooltips, add Combined FL explanation, add divergence insight

### DIFF
--- a/components/dashboard/flow-analysis-tab.tsx
+++ b/components/dashboard/flow-analysis-tab.tsx
@@ -61,7 +61,7 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
             format="int"
             threshold={THRESHOLDS.watRegularity}
             previousValue={p?.wat.regularityScore}
-            tooltip="Measures breathing pattern consistency using Sample Entropy. Higher scores mean more repetitive patterns, which on PAP may signal persistent flow limitation."
+            tooltip="Measures breathing pattern predictability via Sample Entropy. Higher = more repetitive = worse. On PAP therapy, repetitive breathing often indicates the airway is persistently narrowed, causing uniform restricted breaths. Lower scores reflect healthy natural variability."
             onClick={clickable ? () => openMetric('Regularity', (x) => x.wat.regularityScore, { unit: '%', threshold: THRESHOLDS.watRegularity }) : undefined}
           />
           <MetricCard
@@ -81,8 +81,10 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
               <strong className="text-foreground">FL Score</strong> measures the median
               tidal volume ratio — higher values indicate greater flow limitation.{' '}
               <strong className="text-foreground">Regularity</strong> uses Sample Entropy
-              to quantify breathing pattern consistency — higher scores indicate more
-              repetitive patterns, which during PAP therapy may signal persistent flow limitation.{' '}
+              to quantify breathing pattern predictability — higher scores mean more
+              repetitive breathing, which is <em>worse</em> on PAP therapy (it suggests persistent
+              airway narrowing causing uniform restricted breaths). Lower scores reflect healthy
+              natural breath-to-breath variability.{' '}
               <strong className="text-foreground">Periodicity</strong> uses FFT on minute
               ventilation to detect cyclic breathing patterns.
             </p>
@@ -122,7 +124,7 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
             unit="/hr"
             threshold={THRESHOLDS.reraIndex}
             previousValue={p?.ned.reraIndex}
-            tooltip="Respiratory Effort-Related Arousals per hour — brief awakenings from breathing effort. Lower is better."
+            tooltip="Respiratory Effort-Related Arousals per hour. Detected by finding sequences of 3–15 breaths where NED >20% or Tpeak/Ti >0.40, then validated by rising NED slope, recovery breath (NED <10%), or max NED >34%. Each validated sequence counts as one RERA event. Lower is better."
             onClick={clickable ? () => openMetric('RERA Index', (x) => x.ned.reraIndex, { unit: '/hr', threshold: THRESHOLDS.reraIndex }) : undefined}
           />
           <MetricCard
@@ -139,7 +141,7 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
             unit="/hr"
             threshold={THRESHOLDS.eai}
             previousValue={p?.ned.estimatedArousalIndex}
-            tooltip="Estimated arousals per hour, derived from breathing pattern changes. Lower means less fragmented sleep."
+            tooltip="Estimated arousals per hour. Detects sudden spikes in respiratory rate (>20% above baseline) or tidal volume (>30% above baseline) compared to a 120-second rolling window. A 15-second refractory period prevents double-counting. Lower means less fragmented sleep."
             onClick={clickable ? () => openMetric('Est. Arousal Index', (x) => x.ned.estimatedArousalIndex, { unit: '/hr', threshold: THRESHOLDS.eai }) : undefined}
           />
         </div>
@@ -279,14 +281,23 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
       </Card>
 
       {/* Breath Stats */}
-      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border/50 bg-card/50 px-4 py-3 text-xs text-muted-foreground sm:gap-4">
-        <span>
-          Total breaths: <strong className="text-foreground">{n.ned.breathCount}</strong>
-        </span>
-        <span>
-          Combined FL:{' '}
-          <strong className="text-foreground">{n.ned.combinedFLPct.toFixed(0)}%</strong>
-        </span>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="flex items-center gap-3 rounded-lg border border-border/50 bg-card/50 px-4 py-3 text-xs text-muted-foreground">
+          <span>
+            Total breaths: <strong className="text-foreground">{n.ned.breathCount}</strong>
+          </span>
+        </div>
+        <MetricCard
+          label="Combined FL"
+          value={n.ned.combinedFLPct}
+          unit="%"
+          format="int"
+          threshold={THRESHOLDS.combinedFL}
+          previousValue={p?.ned.combinedFLPct}
+          compact
+          tooltip="Percentage of breaths classified as flow-limited by either NED (≥34%) or Flatness Index (≥0.85). Combines both detection methods to catch obstruction that either metric alone might miss. Lower is better."
+          onClick={clickable ? () => openMetric('Combined FL', (x) => x.ned.combinedFLPct, { unit: '%', threshold: THRESHOLDS.combinedFL, description: 'Percentage of breaths classified as flow-limited by either NED (≥34%) or Flatness Index (≥0.85). Combines both detection methods to catch obstruction that either metric alone might miss.' }) : undefined}
+        />
       </div>
 
       {/* Metric Detail Modal */}

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -162,6 +162,26 @@ function singleNightInsights(n: NightResult, prev: NightResult | null): Insight[
     });
   }
 
+  // Metric divergence: Glasgow/NED low but WAT FL high (or vice versa)
+  const watFLL = getTrafficLight(n.wat.flScore, THRESHOLDS.watFL);
+  if (gl === 'good' && nedL === 'good' && (watFLL === 'bad' || watFLL === 'warn')) {
+    insights.push({
+      id: 'metric-divergence-wat-high',
+      type: 'info',
+      title: 'WAT FL elevated despite low Glasgow/NED',
+      body: `WAT FL Score of ${Math.round(n.wat.flScore)}% detects inspiratory flow shape flattening that Glasgow (${fmt(n.glasgow.overall)}) and NED (${fmt(n.ned.nedMean)}%) did not flag. These tools measure different aspects of flow limitation — WAT focuses on waveform flatness, while Glasgow and NED use other criteria. This pattern may indicate subtle or intermittent obstruction.`,
+      category: 'wat',
+    });
+  } else if ((gl === 'bad' || nedL === 'bad') && watFLL === 'good') {
+    insights.push({
+      id: 'metric-divergence-wat-low',
+      type: 'info',
+      title: 'Low WAT FL despite elevated Glasgow/NED',
+      body: `WAT FL Score of ${Math.round(n.wat.flScore)}% is normal, but Glasgow (${fmt(n.glasgow.overall)}) or NED (${fmt(n.ned.nedMean)}%) are elevated. The obstruction pattern may not involve classic waveform flattening — Glasgow detects skew, spikes, and multi-peak patterns that WAT does not measure.`,
+      category: 'wat',
+    });
+  }
+
   // WAT periodicity
   if (n.wat.periodicityIndex > 40) {
     insights.push({


### PR DESCRIPTION
Address community feedback (r/UARS):
- Clarify Regularity tooltip: explicitly state higher = worse on PAP therapy
- Upgrade Combined FL from plain text to MetricCard with tooltip explaining
  the NED ≥34% OR FI ≥0.85 detection logic
- Add metric divergence insight when Glasgow/NED and WAT FL disagree,
  explaining that different tools measure different aspects of flow limitation
- Expand RERA Index and EAI tooltips with calculation methodology details

https://claude.ai/code/session_01BmSvKx9YJo7mwy4WXSqEME