### PR TITLE
feat: add user-facing changelog page at /changelog

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,0 +1,130 @@
+import type { Metadata } from 'next';
+import { Sparkles, Wrench, Bug, Shield, Accessibility, Package } from 'lucide-react';
+import { parseChangelog } from '@/lib/changelog-parser';
+
+export const metadata: Metadata = {
+  title: "What's New — AirwayLab",
+  description:
+    "See what's new in AirwayLab. Latest features, improvements, and bug fixes — explained in plain language.",
+  openGraph: {
+    title: "What's New — AirwayLab",
+    description:
+      "See what's new in AirwayLab. Latest features, improvements, and bug fixes.",
+    type: 'website',
+    url: 'https://airwaylab.app/changelog',
+  },
+  alternates: {
+    canonical: 'https://airwaylab.app/changelog',
+  },
+};
+
+const CATEGORY_ICONS: Record<string, { icon: typeof Sparkles; color: string }> = {
+  New: { icon: Sparkles, color: 'text-emerald-400' },
+  Improved: { icon: Wrench, color: 'text-blue-400' },
+  'Bug Fixes': { icon: Bug, color: 'text-amber-400' },
+  Accessibility: { icon: Accessibility, color: 'text-violet-400' },
+  Security: { icon: Shield, color: 'text-rose-400' },
+};
+
+const DEFAULT_ICON = { icon: Package, color: 'text-muted-foreground' };
+
+export default function ChangelogPage() {
+  const versions = parseChangelog();
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8 sm:py-12">
+      {/* Header */}
+      <div className="mb-10">
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+          What&apos;s New
+        </h1>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          A summary of new features, improvements, and fixes in each update.
+          This page updates automatically with every release.
+        </p>
+      </div>
+
+      {/* Timeline */}
+      <div className="relative flex flex-col gap-10">
+        {/* Vertical line */}
+        <div
+          className="absolute left-[7px] top-2 bottom-2 w-px bg-border/50 sm:left-[9px]"
+          aria-hidden="true"
+        />
+
+        {versions.map((version, vIdx) => (
+          <section key={version.version} aria-label={`Version ${version.version}`}>
+            {/* Version header */}
+            <div className="relative mb-4 flex items-center gap-3">
+              {/* Timeline dot */}
+              <div
+                className={`relative z-10 h-4 w-4 shrink-0 rounded-full border-2 sm:h-5 sm:w-5 ${
+                  vIdx === 0
+                    ? 'border-primary bg-primary/20'
+                    : 'border-border bg-background'
+                }`}
+                aria-hidden="true"
+              />
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <h2 className="text-lg font-bold tracking-tight sm:text-xl">
+                  {version.version}
+                </h2>
+                <time
+                  dateTime={version.date}
+                  className="text-xs text-muted-foreground"
+                >
+                  {version.dateFormatted}
+                </time>
+                {vIdx === 0 && (
+                  <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-primary">
+                    Latest
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Categories */}
+            <div className="ml-5 flex flex-col gap-4 border-l border-transparent pl-4 sm:ml-6 sm:pl-5">
+              {version.categories.map((category) => {
+                const { icon: Icon, color } =
+                  CATEGORY_ICONS[category.label] ?? DEFAULT_ICON;
+
+                return (
+                  <div key={category.label}>
+                    <div className="mb-2 flex items-center gap-2">
+                      <Icon className={`h-3.5 w-3.5 ${color}`} />
+                      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        {category.label}
+                      </h3>
+                    </div>
+                    <ul className="flex flex-col gap-2">
+                      {category.entries.map((entry, eIdx) => (
+                        <li key={eIdx} className="flex gap-3 text-sm">
+                          <span
+                            className="mt-2 h-1 w-1 shrink-0 rounded-full bg-muted-foreground/40"
+                            aria-hidden="true"
+                          />
+                          <div>
+                            <span className="font-medium text-foreground">
+                              {entry.title}
+                            </span>
+                            {entry.description && (
+                              <span className="text-muted-foreground">
+                                {' — '}
+                                {entry.description}
+                              </span>
+                            )}
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -34,6 +34,9 @@ export function Footer() {
               <Link href="/about" className="transition-colors hover:text-foreground">
                 About &amp; Methodology
               </Link>
+              <Link href="/changelog" className="transition-colors hover:text-foreground">
+                What&apos;s New
+              </Link>
               <a
                 href="https://github.com/airwaylab-app/airwaylab"
                 target="_blank"

--- a/lib/changelog-parser.ts
+++ b/lib/changelog-parser.ts
@@ -1,0 +1,151 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface ChangelogEntry {
+  title: string;
+  description: string | null;
+}
+
+export interface ChangelogVersion {
+  version: string;
+  date: string;
+  dateFormatted: string;
+  categories: {
+    label: string;
+    entries: ChangelogEntry[];
+  }[];
+}
+
+/**
+ * User-friendly category labels. Technical "Keep a Changelog" categories
+ * are mapped to plain-language headings non-technical users can understand.
+ */
+const CATEGORY_MAP: Record<string, string> = {
+  Added: 'New',
+  Changed: 'Improved',
+  Fixed: 'Bug Fixes',
+  'Improved (Accessibility)': 'Accessibility',
+  Security: 'Security',
+  Deprecated: 'Deprecated',
+  Removed: 'Removed',
+};
+
+/**
+ * Strips markdown formatting and technical jargon to produce a short,
+ * user-readable summary from a CHANGELOG.md bullet point.
+ *
+ * Strategy:
+ *  - Extract the **bold title** as the entry title
+ *  - Take the first clause after the em-dash (—) as a plain-English description
+ *  - Drop code references, file paths, and implementation details
+ */
+function parseEntry(raw: string): ChangelogEntry {
+  // Remove leading "- " and trim
+  const line = raw.replace(/^-\s*/, '').trim();
+
+  // Extract bold title: **Some Title**
+  const boldMatch = line.match(/\*\*(.+?)\*\*/);
+  const title = boldMatch ? boldMatch[1] : line;
+
+  // Get description: text after the bold part, cleaned up
+  let description: string | null = null;
+  if (boldMatch) {
+    const afterBold = line.slice(line.indexOf('**', 2) + 2).trim();
+    // Remove leading em-dash or colon
+    const cleaned = afterBold.replace(/^[—–:\s]+/, '').trim();
+    if (cleaned) {
+      // Take only the first sentence and strip code/technical markers
+      const firstSentence = cleaned
+        .split(/\.\s/)[0]
+        .replace(/`[^`]+`/g, '') // Remove inline code
+        .replace(/\([^)]*\)/g, '') // Remove parenthetical technical refs
+        .replace(/\s{2,}/g, ' ') // Collapse whitespace
+        .trim();
+
+      // Only keep the description if it's genuinely informative (not just technical)
+      if (firstSentence.length > 10 && !/^(via|in|from|using)\s/i.test(firstSentence)) {
+        description = firstSentence.endsWith('.') ? firstSentence : `${firstSentence}.`;
+      }
+    }
+  }
+
+  return { title, description };
+}
+
+/**
+ * Reads and parses CHANGELOG.md into structured, user-friendly data.
+ * Called at build time by the server component — the result is baked into
+ * the static page, so the changelog updates automatically on every deployment.
+ */
+export function parseChangelog(): ChangelogVersion[] {
+  const filePath = path.join(process.cwd(), 'CHANGELOG.md');
+  const raw = fs.readFileSync(filePath, 'utf-8');
+
+  const versions: ChangelogVersion[] = [];
+  let currentVersion: ChangelogVersion | null = null;
+  let currentCategory: string | null = null;
+  let currentEntryLines: string[] = [];
+
+  const flushEntry = () => {
+    if (currentEntryLines.length > 0 && currentVersion && currentCategory) {
+      const fullLine = currentEntryLines.join(' ');
+      const entry = parseEntry(fullLine);
+      const cat = currentVersion.categories.find((c) => c.label === currentCategory);
+      if (cat) {
+        cat.entries.push(entry);
+      }
+      currentEntryLines = [];
+    }
+  };
+
+  for (const line of raw.split('\n')) {
+    // Version header: ## [0.5.0] - 2026-03-08
+    const versionMatch = line.match(/^## \[(\d+\.\d+\.\d+)\]\s*-\s*(\d{4}-\d{2}-\d{2})/);
+    if (versionMatch) {
+      flushEntry();
+      const [, version, date] = versionMatch;
+      const dateFormatted = new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+      currentVersion = { version, date, dateFormatted, categories: [] };
+      currentCategory = null;
+      versions.push(currentVersion);
+      continue;
+    }
+
+    // Category header: ### Added, ### Changed, ### Fixed, etc.
+    const categoryMatch = line.match(/^### (.+)/);
+    if (categoryMatch && currentVersion) {
+      flushEntry();
+      const rawCategory = categoryMatch[1].trim();
+      const label = CATEGORY_MAP[rawCategory] ?? rawCategory;
+      currentCategory = label;
+      currentVersion.categories.push({ label, entries: [] });
+      continue;
+    }
+
+    // Entry line: starts with "- "
+    if (line.match(/^- /) && currentVersion && currentCategory) {
+      flushEntry();
+      currentEntryLines = [line];
+      continue;
+    }
+
+    // Continuation line (indented, part of a multi-line entry) — skip sub-bullets
+    if (line.match(/^\s{2,}-\s/)) {
+      // Sub-bullets are implementation details — skip them
+      continue;
+    }
+
+    // Other continuation text
+    if (line.trim() && currentEntryLines.length > 0) {
+      currentEntryLines.push(line.trim());
+    }
+  }
+
+  flushEntry();
+
+  return versions;
+}


### PR DESCRIPTION
Parses CHANGELOG.md at build time into a user-friendly "What's New" page
with a timeline layout. Technical jargon is stripped and categories are
renamed to plain language (Added→New, Changed→Improved, Fixed→Bug Fixes).
Updates automatically on every deployment since the server component reads
the markdown file during next build.

https://claude.ai/code/session_01WcsNoKrDXSUAfLRPzgeuYj