### PR TITLE
fix: combine duplicate 'What this means' buttons

### DIFF
--- a/components/common/metric-explanation.tsx
+++ b/components/common/metric-explanation.tsx
@@ -27,9 +27,13 @@ export function MetricExplanation({ text, defaultExpanded = false }: Props) {
         )}
       </button>
       {expanded && (
-        <p className="mt-1.5 rounded-lg bg-muted/30 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
-          {text}
-        </p>
+        <div className="mt-1.5 rounded-lg bg-muted/30 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+          {text.split('\n\n').map((paragraph, i) => (
+            <p key={i} className={i > 0 ? 'mt-2' : undefined}>
+              {paragraph}
+            </p>
+          ))}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Combined two stacked `MetricExplanation` components (EAI + NED) into one, preventing duplicate "What this means" buttons
- Updated `MetricExplanation` to render `\n\n`-separated text as distinct paragraphs

## Test plan
- [ ] Open analyze page with data loaded
- [ ] Verify single "What this means" button appears below NED/EAI metrics
- [ ] Expand it and confirm both explanations render as separate paragraphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)