### PR TITLE
feat: static demo AI insights + support CTA

### DIFF
--- a/components/dashboard/ai-insights-cta.tsx
+++ b/components/dashboard/ai-insights-cta.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Sparkles, X } from 'lucide-react';
+import { useAuth } from '@/lib/auth/auth-context';
+import { getAIRemaining } from '@/lib/auth/feature-gate';
+
+interface Props {
+  isDemo?: boolean;
+}
+
+/**
+ * Contextual CTA below AI insights explaining costs and encouraging support.
+ *
+ * Three states:
+ * - Demo mode: explain AI is funded out of pocket, nudge to upload own data
+ * - Community tier: show remaining analyses, nudge to support
+ * - Paid users: hidden
+ */
+export function AIInsightsCTA({ isDemo = false }: Props) {
+  const { tier, isPaid } = useAuth();
+  const [dismissed, setDismissed] = useState(false);
+
+  // Don't show to paid users or if dismissed this session
+  if (isPaid) return null;
+  if (dismissed) return null;
+
+  const aiRemaining = getAIRemaining(tier);
+
+  return (
+    <div className="relative flex items-start gap-2 rounded-md border border-primary/10 bg-primary/[0.03] px-3 py-2">
+      <Sparkles className="mt-0.5 h-3 w-3 shrink-0 text-primary/50" />
+
+      <div className="min-w-0 flex-1 text-[11px] leading-relaxed text-muted-foreground/70">
+        {isDemo ? (
+          <p>
+            These AI insights are powered by Claude and funded out of pocket.{' '}
+            <Link
+              href="/analyze"
+              className="font-medium text-primary/70 underline underline-offset-2 hover:text-primary"
+            >
+              Upload your own data
+            </Link>{' '}
+            to get personalized AI analysis of your therapy.
+          </p>
+        ) : (
+          <p>
+            Each AI analysis costs real money to run.
+            {aiRemaining > 0 && (
+              <span className="font-medium text-foreground/60">
+                {' '}{aiRemaining} free {aiRemaining === 1 ? 'analysis' : 'analyses'} left this month.
+              </span>
+            )}{' '}
+            <Link
+              href="/pricing"
+              className="font-medium text-primary/70 underline underline-offset-2 hover:text-primary"
+            >
+              Support AirwayLab
+            </Link>{' '}
+            to fund continued development.
+          </p>
+        )}
+      </div>
+
+      <button
+        onClick={() => setDismissed(true)}
+        className="shrink-0 rounded p-0.5 text-muted-foreground/30 transition-colors hover:text-muted-foreground"
+        aria-label="Dismiss"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -8,6 +8,8 @@ import { useThresholds } from '@/components/common/thresholds-provider';
 import type { NightResult } from '@/lib/types';
 import { generateInsights, type Insight } from '@/lib/insights';
 import { fetchAIInsights } from '@/lib/ai-insights-client';
+import { DEMO_AI_INSIGHTS } from '@/lib/demo-ai-insights';
+import { AIInsightsCTA } from '@/components/dashboard/ai-insights-cta';
 import { Badge } from '@/components/ui/badge';
 import Link from 'next/link';
 import { HeartPulse, TrendingDown, TrendingUp, AlertCircle, Info, CheckCircle, ChevronRight, Upload, Sparkles, Loader2, ArrowRight } from 'lucide-react';
@@ -111,6 +113,12 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
     };
   }, [hasAIAccess, isDemo, nights, selectedNight, therapyChangeDate]);
 
+  // Demo mode: load static AI insights instantly (no API call, no credits)
+  useEffect(() => {
+    if (!isDemo) return;
+    setAiInsights(DEMO_AI_INSIGHTS);
+  }, [isDemo]);
+
   // Track session count for new-user UX (expand explanations for first 5 sessions)
   const [isNewUser, setIsNewUser] = useState(false);
   useEffect(() => {
@@ -181,6 +189,11 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
             );
           })}
         </div>
+      )}
+
+      {/* AI Insights CTA (demo or community tier) */}
+      {aiInsights && aiInsights.length > 0 && (
+        <AIInsightsCTA isDemo={isDemo} />
       )}
 
       {/* Rule-based Insights Panel */}

--- a/lib/demo-ai-insights.ts
+++ b/lib/demo-ai-insights.ts
@@ -1,0 +1,42 @@
+// ============================================================
+// AirwayLab — Static Demo AI Insights
+// Pre-computed insights for demo mode. Never calls the AI API.
+// References values from SAMPLE_NIGHTS in lib/sample-data.ts.
+// ============================================================
+
+import type { Insight } from './insights';
+
+/**
+ * Curated AI insights for demo mode that showcase cross-engine
+ * correlation analysis — the differentiator vs rule-based insights.
+ */
+export const DEMO_AI_INSIGHTS: Insight[] = [
+  {
+    id: 'demo-ai-therapy',
+    type: 'positive',
+    title: 'Pressure increase correlating with multi-metric improvement',
+    body: 'The EPAP 8\u200A\u2192\u200A10 change on Jan 14 shows a correlated response across engines: Glasgow dropped from 2.6 to the 1.2\u20131.8 range, and flat-top scoring fell from 0.48 to 0.22 \u2014 consistent with reduced inspiratory flow limitation. Discuss the sustained improvement with your clinician at your next review.',
+    category: 'therapy',
+  },
+  {
+    id: 'demo-ai-ned',
+    type: 'warning',
+    title: 'NED worsening pattern may indicate REM-related obstruction',
+    body: 'Despite overall improvement post-settings-change, NED combined shows a rising H1\u200A\u2192\u200AH2 trend (from 16% up to 22%) that correlates with an ODI-3 shift from 3.4 to 5.0/hr on nights with oximetry data. This pattern is consistent with REM-phase residual obstruction. Worth discussing positional or pressure-response strategies with your clinician.',
+    category: 'ned',
+  },
+  {
+    id: 'demo-ai-wat',
+    type: 'info',
+    title: 'WAT and NED convergence after settings change',
+    body: 'Pre-change, WAT FL (48%) and NED combined (38%) showed a 10-point gap suggesting different sensitivity to obstruction type. Post-change, both narrowed to 32%/22% \u2014 the converging scores suggest the pressure increase is addressing the dominant flow-limitation mechanism rather than masking it. A positive signal for your current settings.',
+    category: 'wat',
+  },
+  {
+    id: 'demo-ai-oximetry',
+    type: 'actionable',
+    title: 'Elevated arousal index driving coupled HR-desaturation events',
+    body: 'The estimated arousal index of 12.4/hr is generating coupled heart-rate and desaturation events at 1.4/hr (HR Clin 10), which is above the 1.0/hr threshold. This coupling pattern suggests RERA-driven arousals rather than frank apneas. Discuss whether RERA-focused titration adjustments could reduce sleep fragmentation with your clinician.',
+    category: 'oximetry',
+  },
+];


### PR DESCRIPTION
## Summary
- Demo mode now serves 4 pre-computed AI insights instantly instead of calling the AI API, eliminating wasted credits on sample data
- Adds a contextual CTA below AI insights: demo users see "funded out of pocket" + upload nudge, community tier sees remaining analyses + support link, paid users see nothing
- CTA is dismissible per session, uses community framing language (not SaaS upsell)

## Test plan
- [ ] Visit `/analyze?demo` — AI insights appear instantly with no loading spinner
- [ ] Confirm no network request to `/api/ai-insights` in demo mode
- [ ] CTA shows demo copy ("powered by Claude and funded out of pocket")
- [ ] Dismiss button hides the CTA
- [ ] `npx tsc --noEmit` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)