### PR TITLE
chore: build-time version check guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to AirwayLab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-03-09
+
+### Added
+
+- **Auth + Stripe subscription system** — full authentication flow with Supabase Auth (magic links), Stripe checkout for Supporter ($9/mo) and Champion ($25/mo) tiers, customer portal, and webhook-driven tier sync
+- **Cloud storage system** — raw SD card file upload with consent, deduplication, and waveform loading from cloud when local files unavailable
+- **Flow waveform browser** — interactive waveform viewer with scroll-zoom, drag-pan, keyboard navigation, pressure overlay, and event markers
+- **Changelog page** — user-facing `/changelog` route parsed from this file
+- **Feedback widget** — floating feedback form (feature requests, bug reports, questions) stored in Supabase
+- **Data contribution opt-in** — anonymised breathing scores contributed to research dataset with explicit consent
+- **20 Plausible analytics events** — conversion funnel (upload → analysis → pricing → checkout), engagement (tabs, exports, thresholds, feedback), and retention signals (returning users, cloud sync, AI upsell)
+- **Build-time version check** — `scripts/check-version.mjs` fails the build if `package.json` version has no matching CHANGELOG entry
+
+### Changed
+
+- **Generalised CPAP → PAP** — all user-facing references updated to cover BiPAP/ASV users
+- **Pricing page CRO improvements** — yearly monthly-equivalent pricing, value-oriented copy, FAQ section
+- **Demo AI insights** — static pre-generated insights for demo mode with support CTA
+
+### Fixed
+
+- **Browser freeze on large SD cards** — raised night cap to 3 years, added chunked processing
+- **Synthetic waveforms** — show synthetic waveform when SD files unavailable instead of dead end; don't show for real data
+- **Checkout error handling** — graceful fallback when Stripe price IDs are missing
+- **Combined metric explanations** — render as separate paragraphs instead of merged text
+- **GitHub stars rate limiting** — proxied through server API to avoid client-side 403s
+
+### Security
+
+- **Auth hardening** — account deletion, health check endpoint, deployment safeguards
+- **RLS enforcement** — enabled on `data_contributions` and `waitlist` tables
+- **API logging** — `console.warn` on all 4xx rejections for audit trail
+
 ## [0.5.0] - 2026-03-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node scripts/check-version.mjs && next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",

--- a/scripts/check-version.mjs
+++ b/scripts/check-version.mjs
@@ -1,0 +1,29 @@
+/**
+ * Build-time check: package.json version must have a matching CHANGELOG.md entry.
+ * Prevents deploying a version bump without documenting what changed.
+ *
+ * Usage: node scripts/check-version.mjs
+ * Exits 1 on mismatch, 0 on match.
+ */
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const changelog = readFileSync('CHANGELOG.md', 'utf8');
+
+const match = changelog.match(/^## \[(\d+\.\d+\.\d+)\]/m);
+const changelogVersion = match?.[1];
+
+if (!changelogVersion) {
+  console.error('❌ Could not find any version entry in CHANGELOG.md');
+  process.exit(1);
+}
+
+if (pkg.version !== changelogVersion) {
+  console.error(
+    `❌ Version mismatch: package.json is ${pkg.version} but CHANGELOG.md latest is ${changelogVersion}\n` +
+    `   → Update CHANGELOG.md with a ## [${pkg.version}] entry before deploying.`
+  );
+  process.exit(1);
+}
+
+console.log(`✓ Version ${pkg.version} matches CHANGELOG.md`);


### PR DESCRIPTION
## Summary
- Adds `scripts/check-version.mjs` — fails `npm run build` if `package.json` version has no matching `CHANGELOG.md` entry
- Wires check into build script so Vercel deploys fail on version/changelog drift
- Adds missing `## [0.6.0]` changelog entry (auth, Stripe, cloud storage, waveform browser, analytics, etc.)

## Test plan
- [x] `node scripts/check-version.mjs` passes with matching versions
- [x] Mismatch correctly exits with code 1 and clear error message
- [x] `npm run build` passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)