### PR TITLE
fix: oximetry CSV dates not matching nights due to UTC conversion

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -284,7 +284,7 @@ function AnalyzePageInner() {
     clearManifest();
   }, [isDemo]);
 
-  const { status, progress, error } = state;
+  const { status, progress, error, warning } = state;
 
   // Memoize derived data to stabilize references across renders
   const nights = useMemo<NightResult[]>(() =>
@@ -491,6 +491,17 @@ function AnalyzePageInner() {
               <p className="text-sm text-muted-foreground">
                 <span className="font-medium text-foreground">Oximetry data added</span>
                 {' '}&mdash; SpO&#8322; and heart rate analysis is now included in your results. Check the Oximetry tab for details.
+              </p>
+            </div>
+          )}
+
+          {/* Oximetry warning (no nights matched) */}
+          {warning && !isDemo && (
+            <div className="flex items-center gap-2.5 rounded-xl border border-yellow-500/20 bg-yellow-500/5 px-4 py-3 animate-fade-in-up">
+              <AlertCircle className="h-4 w-4 shrink-0 text-yellow-500" />
+              <p className="text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">Warning</span>
+                {' '}&mdash; {warning}
               </p>
             </div>
           )}

--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -26,6 +26,7 @@ const initialState: AnalysisState = {
   nights: [],
   error: null,
   therapyChangeDate: null,
+  warning: null,
 };
 
 export class AnalysisOrchestrator {
@@ -157,6 +158,16 @@ export class AnalysisOrchestrator {
       const merged = mergeNights(cachedNights, newNights);
       const therapyChangeDate = detectTherapyChange(merged);
 
+      // ── Check if oximetry matched any nights ──
+      let warning: string | null = null;
+      if (hasNewOximetry) {
+        const nightsWithOx = merged.filter((n) => n.oximetry !== null);
+        if (nightsWithOx.length === 0) {
+          warning = 'Oximetry CSV was uploaded but could not be matched to any night. Check that the recording date in your CSV matches one of your SD card nights.';
+          console.error('[orchestrator] Oximetry warning:', warning);
+        }
+      }
+
       // ── Save manifest + results ──
       saveManifest(buildManifest(sdArr));
       persistResults(merged, therapyChangeDate);
@@ -165,6 +176,7 @@ export class AnalysisOrchestrator {
         status: 'complete',
         nights: merged,
         therapyChangeDate,
+        warning,
         progress: { current: 1, total: 1, stage: 'Complete' },
       });
 

--- a/lib/parsers/night-grouper.ts
+++ b/lib/parsers/night-grouper.ts
@@ -60,20 +60,25 @@ function determineSleepNight(edf: EDFFile): string {
       // Before noon → belongs to previous night
       const prev = new Date(edf.recordingDate);
       prev.setDate(prev.getDate() - 1);
-      return prev.toISOString().split('T')[0];
+      return localDateStr(prev);
     }
     return filenameDate;
   }
 
   // Final fallback: use recording date with time heuristic
   if (hour >= 18) {
-    return edf.recordingDate.toISOString().split('T')[0];
+    return localDateStr(edf.recordingDate);
   } else if (hour < 12) {
     const prev = new Date(edf.recordingDate);
     prev.setDate(prev.getDate() - 1);
-    return prev.toISOString().split('T')[0];
+    return localDateStr(prev);
   }
-  return edf.recordingDate.toISOString().split('T')[0];
+  return localDateStr(edf.recordingDate);
+}
+
+/** Format a Date as YYYY-MM-DD in local time (not UTC) */
+function localDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
 /**

--- a/lib/parsers/oximetry-csv-parser.ts
+++ b/lib/parsers/oximetry-csv-parser.ts
@@ -95,7 +95,9 @@ export function parseOximetryCSV(csvText: string): ParsedOximetry {
   } else {
     nightDate = startTime;
   }
-  const dateStr = nightDate.toISOString().split('T')[0];
+  // Use local date components — toISOString() converts to UTC which causes
+  // off-by-one mismatches with DATALOG folder dates (stored in local time)
+  const dateStr = `${nightDate.getFullYear()}-${String(nightDate.getMonth() + 1).padStart(2, '0')}-${String(nightDate.getDate()).padStart(2, '0')}`;
 
   return {
     samples,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -171,6 +171,8 @@ export interface AnalysisState {
   nights: NightResult[];
   error: string | null;
   therapyChangeDate: string | null;
+  /** Non-fatal warning (e.g. oximetry CSV uploaded but no nights matched) */
+  warning: string | null;
 }
 
 export interface WorkerMessage {

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -147,9 +147,21 @@ async function processFiles(
       try {
         const parsed = parseOximetryCSV(csv);
         oximetryByDate.set(parsed.dateStr, parsed);
-      } catch {
-        // Skip unparseable oximetry files
+      } catch (err) {
+        console.error('[oximetry] Failed to parse CSV:', err instanceof Error ? err.message : String(err));
       }
+    }
+  }
+
+  // Log oximetry matching diagnostics
+  if (oximetryCSVs && oximetryCSVs.length > 0) {
+    const oxDates = Array.from(oximetryByDate.keys());
+    const nightDates = nightGroups.map((g) => g.nightDate);
+    const matched = oxDates.filter((d) => nightDates.includes(d));
+    if (matched.length === 0) {
+      console.error(`[oximetry] No date matches. Oximetry dates: [${oxDates.join(', ')}], Night dates: [${nightDates.slice(0, 5).join(', ')}${nightDates.length > 5 ? '...' : ''}]`);
+    } else {
+      console.error(`[oximetry] Matched ${matched.length}/${oxDates.length} oximetry files to nights`);
     }
   }
 


### PR DESCRIPTION
## Summary
- **Root cause**: `toISOString().split('T')[0]` converts dates to UTC, causing off-by-one mismatches with DATALOG folder dates (which are local-time strings). For CET/CEST users, an oximetry recording at 11pm local would become the next day in UTC.
- Fixed in both `oximetry-csv-parser.ts` and `night-grouper.ts` fallback paths
- Added warning banner when uploaded oximetry CSV matches zero nights
- Added diagnostic logging in the worker for oximetry date matching

## Test plan
- [ ] Upload SD card + oximetry CSV from a CET timezone recording
- [ ] Verify oximetry tab shows data for the matched night
- [ ] Upload oximetry CSV with a date that doesn't match any night → verify yellow warning banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)