### PR TITLE
fix: recover from stale Stripe customer IDs

### DIFF
--- a/app/api/create-checkout-session/route.ts
+++ b/app/api/create-checkout-session/route.ts
@@ -83,6 +83,21 @@ export async function POST(request: NextRequest) {
 
     let customerId = profile?.stripe_customer_id;
 
+    // Verify the stored customer still exists in Stripe (may have been deleted or be from a different mode)
+    if (customerId) {
+      try {
+        await stripe.customers.retrieve(customerId);
+      } catch (stripeErr) {
+        console.error(`[create-checkout-session] Stale Stripe customer ${customerId}, will recreate:`, stripeErr);
+        Sentry.captureMessage(`Stale Stripe customer ID: ${customerId}`, {
+          level: 'warning',
+          tags: { route: 'create-checkout-session' },
+          extra: { userId: user.id },
+        });
+        customerId = undefined;
+      }
+    }
+
     // H5: Create Stripe customer if needed — use service role for atomic update
     if (!customerId) {
       const adminClient = getSupabaseServiceRole();

--- a/app/api/customer-portal/route.ts
+++ b/app/api/customer-portal/route.ts
@@ -50,6 +50,25 @@ export async function POST(request: NextRequest) {
   });
 
   try {
+    // Verify customer exists in Stripe before creating portal session
+    try {
+      const customer = await stripe.customers.retrieve(profile.stripe_customer_id);
+      if (customer.deleted) {
+        throw new Error('Customer deleted');
+      }
+    } catch {
+      console.error(`[customer-portal] Stale Stripe customer: ${profile.stripe_customer_id}`);
+      Sentry.captureMessage(`Stale Stripe customer ID on portal access: ${profile.stripe_customer_id}`, {
+        level: 'warning',
+        tags: { route: 'customer-portal' },
+        extra: { userId: user.id },
+      });
+      return NextResponse.json(
+        { error: 'Your billing account could not be found. Please contact us at support@airwaylab.app.' },
+        { status: 404 }
+      );
+    }
+
     // M3: Use env var for origin
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://airwaylab.app';
 


### PR DESCRIPTION
## Summary
- **Checkout route**: verifies stored `stripe_customer_id` exists in Stripe before using it. If stale (deleted, wrong mode), automatically creates a new customer and updates the profile.
- **Portal route**: verifies customer exists before creating portal session. Returns clear error with support contact if stale.
- Both fire Sentry warnings for visibility.

Fixes: `No such customer: 'cus_U7Pao9SmU7HaFo'`

## Test plan
- [ ] Delete a test customer in Stripe dashboard, then try checkout — should auto-recover
- [ ] Delete a test customer, then try "Manage subscription" — should show support contact error
- [ ] Verify Sentry receives warning-level alerts for stale customers

🤖 Generated with [Claude Code](https://claude.com/claude-code)