### PR TITLE
fix: show oximetry re-upload button in restored sessions

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -594,6 +594,11 @@ function AnalyzePageInner() {
                       ? handleOximetryUpload
                       : undefined
                   }
+                  onReUpload={
+                    !isDemo && !currentNight.oximetry && sdFilesRef.current.length === 0
+                      ? handleReset
+                      : undefined
+                  }
                 />
               </ErrorBoundary>
             </TabsContent>
@@ -639,6 +644,11 @@ function AnalyzePageInner() {
                   onUploadOximetry={
                     !isDemo && !currentNight.oximetry && sdFilesRef.current.length > 0
                       ? handleOximetryUpload
+                      : undefined
+                  }
+                  onReUpload={
+                    !isDemo && !currentNight.oximetry && sdFilesRef.current.length === 0
+                      ? handleReset
                       : undefined
                   }
                 />

--- a/components/dashboard/next-steps.tsx
+++ b/components/dashboard/next-steps.tsx
@@ -11,6 +11,7 @@ interface Props {
   hasOximetry: boolean;
   nightCount: number;
   onUploadOximetry?: () => void;
+  onReUpload?: () => void;
 }
 
 interface Step {
@@ -20,7 +21,7 @@ interface Step {
   actionLabel?: string;
 }
 
-export function NextSteps({ selectedNight, hasOximetry, nightCount, onUploadOximetry }: Props) {
+export function NextSteps({ selectedNight, hasOximetry, nightCount, onUploadOximetry, onReUpload }: Props) {
   const THRESHOLDS = useThresholds();
   const steps: Step[] = [];
 
@@ -44,8 +45,8 @@ export function NextSteps({ selectedNight, hasOximetry, nightCount, onUploadOxim
   if (!hasOximetry) {
     steps.push({
       text: 'Add pulse oximetry data for deeper analysis — oxygen desaturations and heart rate patterns reveal what flow data alone can\'t.',
-      onClick: onUploadOximetry ?? (() => window.scrollTo({ top: 0, behavior: 'smooth' })),
-      actionLabel: onUploadOximetry ? 'Upload oximetry CSV' : 'Upload with oximetry data',
+      onClick: onUploadOximetry ?? onReUpload ?? (() => window.scrollTo({ top: 0, behavior: 'smooth' })),
+      actionLabel: onUploadOximetry ? 'Upload oximetry CSV' : 'Re-upload with oximetry',
     });
   }
 

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -55,10 +55,11 @@ interface Props {
   previousNight: NightResult | null;
   therapyChangeDate: string | null;
   onUploadOximetry?: () => void;
+  onReUpload?: () => void;
   isDemo?: boolean;
 }
 
-export function OverviewTab({ nights, selectedNight, previousNight, therapyChangeDate, onUploadOximetry, isDemo = false }: Props) {
+export function OverviewTab({ nights, selectedNight, previousNight, therapyChangeDate, onUploadOximetry, onReUpload, isDemo = false }: Props) {
   const THRESHOLDS = useThresholds();
   const n = selectedNight;
   const p = previousNight;
@@ -238,6 +239,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         hasOximetry={!!n.oximetry}
         nightCount={nights.length}
         onUploadOximetry={onUploadOximetry}
+        onReUpload={onReUpload}
       />
 
       {/* Night Info Bar */}
@@ -465,37 +467,42 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
       )}
 
       {/* Oximetry Empty State */}
-      {!n.oximetry && (
-        <Card
-          className={`border-dashed border-border/50 ${
-            onUploadOximetry ? 'cursor-pointer transition-colors hover:border-border hover:bg-card/50' : ''
-          }`}
-          onClick={onUploadOximetry}
-          role={onUploadOximetry ? 'button' : undefined}
-          tabIndex={onUploadOximetry ? 0 : undefined}
-          onKeyDown={onUploadOximetry ? (e: React.KeyboardEvent) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              onUploadOximetry();
-            }
-          } : undefined}
-        >
-          <CardContent className="flex items-center gap-3 py-6">
-            <HeartPulse className="h-5 w-5 text-muted-foreground/50" />
-            <div>
-              <p className="text-sm font-medium text-muted-foreground">No Oximetry Data</p>
-              <p className="text-xs text-muted-foreground/70">
-                {onUploadOximetry
-                  ? 'Click to upload a Viatom/Checkme O2 Max CSV for SpO\u2082 and heart rate analysis.'
-                  : 'Upload a Viatom/Checkme O2 Max CSV alongside your SD card for SpO\u2082 and heart rate analysis.'}
-              </p>
-            </div>
-            {onUploadOximetry && (
-              <Upload className="ml-auto h-4 w-4 text-muted-foreground/40" />
-            )}
-          </CardContent>
-        </Card>
-      )}
+      {!n.oximetry && (() => {
+        const clickHandler = onUploadOximetry ?? onReUpload;
+        return (
+          <Card
+            className={`border-dashed border-border/50 ${
+              clickHandler ? 'cursor-pointer transition-colors hover:border-border hover:bg-card/50' : ''
+            }`}
+            onClick={clickHandler}
+            role={clickHandler ? 'button' : undefined}
+            tabIndex={clickHandler ? 0 : undefined}
+            onKeyDown={clickHandler ? (e: React.KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                clickHandler();
+              }
+            } : undefined}
+          >
+            <CardContent className="flex items-center gap-3 py-6">
+              <HeartPulse className="h-5 w-5 text-muted-foreground/50" />
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">No Oximetry Data</p>
+                <p className="text-xs text-muted-foreground/70">
+                  {onUploadOximetry
+                    ? 'Click to upload a Viatom/Checkme O2 Max CSV for SpO\u2082 and heart rate analysis.'
+                    : onReUpload
+                      ? 'Click to re-upload your SD card with an oximetry CSV for SpO\u2082 and heart rate analysis.'
+                      : 'Upload a Viatom/Checkme O2 Max CSV alongside your SD card for SpO\u2082 and heart rate analysis.'}
+                </p>
+              </div>
+              {clickHandler && (
+                <Upload className="ml-auto h-4 w-4 text-muted-foreground/40" />
+              )}
+            </CardContent>
+          </Card>
+        );
+      })()}
 
       {/* Share Prompts (real data only) */}
       <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={isDemo} />

--- a/components/dashboard/oximetry-tab.tsx
+++ b/components/dashboard/oximetry-tab.tsx
@@ -15,9 +15,10 @@ interface Props {
   previousNight: NightResult | null;
   nights?: NightResult[];
   onUploadOximetry?: () => void;
+  onReUpload?: () => void;
 }
 
-export function OximetryTab({ selectedNight, previousNight, nights = [], onUploadOximetry }: Props) {
+export function OximetryTab({ selectedNight, previousNight, nights = [], onUploadOximetry, onReUpload }: Props) {
   const THRESHOLDS = useThresholds();
   const ox = selectedNight.oximetry;
   const pOx = previousNight?.oximetry;
@@ -57,6 +58,13 @@ export function OximetryTab({ selectedNight, previousNight, nights = [], onUploa
               className="mt-2 rounded-lg border border-dashed border-primary/30 bg-primary/[0.04] px-4 py-2.5 text-xs font-medium text-primary transition-colors hover:border-primary/50 hover:bg-primary/[0.08]"
             >
               Upload Oximetry CSV
+            </button>
+          ) : onReUpload ? (
+            <button
+              onClick={onReUpload}
+              className="mt-2 rounded-lg border border-dashed border-primary/30 bg-primary/[0.04] px-4 py-2.5 text-xs font-medium text-primary transition-colors hover:border-primary/50 hover:bg-primary/[0.08]"
+            >
+              Re-upload SD Card with Oximetry
             </button>
           ) : (
             <p className="mt-1 text-[11px] text-muted-foreground/60">


### PR DESCRIPTION
## Summary
- In restored sessions (loaded from localStorage), the SD `File` objects are not in memory, so the oximetry upload button was hidden — users saw only passive text with no way to add oximetry
- Added `onReUpload` prop to `OximetryTab`, `OverviewTab`, and `NextSteps` that shows a "Re-upload SD Card with Oximetry" button linking back to the upload screen
- When SD files are available (fresh analysis), the existing direct CSV upload flow works as before

## Test plan
- [ ] Open restored session (57+ nights from cache) → Oximetry tab shows "Re-upload SD Card with Oximetry" button
- [ ] Click the button → returns to upload screen
- [ ] Fresh analysis (SD files in memory) → still shows "Upload Oximetry CSV" direct upload button
- [ ] Demo mode → no upload buttons shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)