### PR TITLE
fix: handle PKCE code verifier missing error gracefully

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -47,6 +47,7 @@ import {
   Star,
   Moon,
   CheckCircle2,
+  X,
 } from 'lucide-react';
 
 export default function AnalyzePage() {
@@ -93,6 +94,27 @@ function AnalyzePageInner() {
   const [showDemoStar, setShowDemoStar] = useState(false);
   const demoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [lifetimeNights, setLifetimeNights] = useState(0);
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  // Handle auth error from callback redirect
+  useEffect(() => {
+    const error = searchParams.get('auth_error');
+    if (!error) return;
+
+    if (error === 'pkce_expired') {
+      setAuthError('Your sign-in link opened in a different browser or app. Please try signing in again from this browser.');
+    } else {
+      setAuthError('Sign-in failed. Please try again.');
+    }
+
+    // Clean up URL param
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('auth_error');
+    const cleanUrl = params.toString()
+      ? `${window.location.pathname}?${params.toString()}`
+      : window.location.pathname;
+    window.history.replaceState({}, '', cleanUrl);
+  }, [searchParams]);
 
   // Load lifetime night count from localStorage
   useEffect(() => {
@@ -329,6 +351,21 @@ function AnalyzePageInner() {
 
   return (
     <div className="container mx-auto px-4 py-6 sm:py-8">
+      {/* Auth error banner */}
+      {authError && (
+        <div className="mb-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+          <span className="flex-1">{authError}</span>
+          <button
+            onClick={() => setAuthError(null)}
+            className="shrink-0 rounded p-0.5 text-amber-400 hover:text-amber-200"
+            aria-label="Dismiss"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+
       {/* Header */}
       <div className="mb-6 sm:mb-8">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -62,6 +62,24 @@ export async function GET(request: NextRequest) {
   const { error } = await supabase.auth.exchangeCodeForSession(code);
 
   if (error) {
+    // PKCE verifier missing is expected on iOS (cross-context cookie partitioning)
+    // and when users open magic links in a different browser/device.
+    // Downgrade to warning instead of alerting as an exception.
+    const isPKCEError = error.name === 'AuthPKCECodeVerifierMissingError'
+      || error.message?.includes('PKCE code verifier');
+
+    if (isPKCEError) {
+      console.error('[auth/callback] PKCE verifier missing — user likely opened magic link in a different context');
+      Sentry.captureMessage('PKCE code verifier missing during auth callback', {
+        level: 'warning',
+        tags: { route: 'auth-callback' },
+        extra: {
+          userAgent: request.headers.get('user-agent') ?? 'unknown',
+        },
+      });
+      return NextResponse.redirect(`${origin}/analyze?auth_error=pkce_expired`);
+    }
+
     console.error('[auth/callback] Code exchange failed:', error.message);
     Sentry.captureException(error, {
       tags: { route: 'auth-callback' },


### PR DESCRIPTION
Downgrade AuthPKCECodeVerifierMissingError from Sentry exception to
warning level. This error is expected on iOS when magic links open in
a different browser context (e.g. Mail app → Safari). Also adds a
user-facing auth error banner on the analyze page so users know to
try signing in again.

https://claude.ai/code/session_012osAtrY4KidNHsbCQQtCAH