### PR TITLE
feat: Sentry alerts for unsupported data submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **AI credits synced from server**: Community tier AI credit count now reflects actual server-side usage instead of unreliable localStorage counter — clearing browser data no longer resets the display (`ai-credits-tracking-and-messaging`)
 - **Community funding messaging**: AI insights CTA explains that analyses are funded out of pocket, with warm invitation to support the project
+- **Unsupported data alerts**: Sentry warnings for unsupported oximetry formats and failed SD card parses, enabling prioritised format support (`unsupported-data-alerts`)
 
 ### Improved
 

--- a/__tests__/api-routes.test.ts
+++ b/__tests__/api-routes.test.ts
@@ -319,6 +319,117 @@ describe('POST /api/feedback', () => {
       })
     );
   });
+
+  it('tags oximetry format requests as unsupported_format with warning level', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    await callRoute({
+      message: 'Oximetry format request (device: Wellue O2 Ring)\n\n1 unsupported file uploaded.',
+      type: 'feature',
+      page: '/analyze',
+    });
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'New unsupported_format submission',
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ feedback_type: 'unsupported_format' }),
+      })
+    );
+  });
+
+  it('does not tag non-oximetry feature requests as unsupported_format', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    await callRoute({ message: 'Please add PDF export filters', type: 'feature' });
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'New feature submission',
+      expect.objectContaining({
+        tags: expect.objectContaining({ feedback_type: 'feature' }),
+      })
+    );
+  });
+
+  it('does not include email in Sentry extra', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    await callRoute({ message: 'Hello there test!', email: 'user@example.com', type: 'feedback' });
+    const captureCall = (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(captureCall[1].extra).not.toHaveProperty('email');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// SUBMIT ERROR DATA
+// ═══════════════════════════════════════════════════════════════
+
+describe('POST /api/submit-error-data', () => {
+  async function callRoute(body: Record<string, unknown>) {
+    vi.resetModules();
+    const { POST } = await import('@/app/api/submit-error-data/route');
+    return POST(makeRequest(body));
+  }
+
+  it('accepts valid error submission', async () => {
+    const res = await callRoute({
+      fileNames: ['BRP.edf', 'STR.edf'],
+      errorMessage: 'No valid BRP.edf files could be parsed',
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  it('fires Sentry warning with unsupported_data tag', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    await callRoute({
+      fileNames: ['BRP.edf'],
+      errorMessage: 'No valid BRP.edf files could be parsed',
+      userAgent: 'Mozilla/5.0',
+    });
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Unsupported data submission',
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({
+          route: 'submit-error-data',
+          error_type: 'unsupported_data',
+        }),
+        extra: expect.objectContaining({
+          fileNames: ['BRP.edf'],
+          errorMessage: expect.any(String),
+          userAgent: 'Mozilla/5.0',
+        }),
+      })
+    );
+  });
+
+  it('does not include email in Sentry extra', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    await callRoute({
+      fileNames: ['test.edf'],
+      errorMessage: 'Parse failed',
+      email: 'user@example.com',
+    });
+    const captureCall = (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(captureCall[1].extra).not.toHaveProperty('email');
+  });
+
+  it('does not fire Sentry alert when rate limited', async () => {
+    mockIsLimited.mockReturnValueOnce(true);
+    const Sentry = await import('@sentry/nextjs');
+    const res = await callRoute({
+      fileNames: ['test.edf'],
+      errorMessage: 'Parse failed',
+    });
+    expect(res.status).toBe(429);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing file names', async () => {
+    const res = await callRoute({ errorMessage: 'Something broke' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects missing error message', async () => {
+    const res = await callRoute({ fileNames: ['test.edf'] });
+    expect(res.status).toBe(400);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -105,13 +105,17 @@ export async function POST(request: NextRequest) {
       console.info(`[feedback] ${cleanType}: ${message.slice(0, 100)} (Supabase not configured)`);
     }
 
+    // Distinguish unsupported oximetry format requests from general feedback
+    const isFormatRequest = typeof message === 'string' && message.startsWith('Oximetry format request');
+    const alertType = isFormatRequest ? 'unsupported_format' : cleanType;
+    const alertLevel = isFormatRequest || cleanType === 'bug' ? 'warning' : 'info';
+
     // Alert via Sentry so new submissions show up on our radar
-    Sentry.captureMessage(`New ${cleanType} submission`, {
-      level: cleanType === 'bug' ? 'warning' : 'info',
-      tags: { route: 'feedback', feedback_type: cleanType },
+    Sentry.captureMessage(`New ${alertType} submission`, {
+      level: alertLevel,
+      tags: { route: 'feedback', feedback_type: alertType },
       extra: {
         message: message.trim().slice(0, 500),
-        email: typeof email === 'string' ? email.trim() || null : null,
         page: cleanPage,
       },
     });

--- a/app/api/submit-error-data/route.ts
+++ b/app/api/submit-error-data/route.ts
@@ -85,6 +85,17 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Alert so unsupported format submissions are visible in Sentry
+    Sentry.captureMessage('Unsupported data submission', {
+      level: 'warning',
+      tags: { route: 'submit-error-data', error_type: 'unsupported_data' },
+      extra: {
+        fileNames: sanitizedFiles.slice(0, 10),
+        errorMessage: errorMessage.slice(0, 500),
+        userAgent: userAgent?.slice(0, 200) || null,
+      },
+    });
+
     return NextResponse.json({ ok: true });
   } catch (err) {
     Sentry.captureException(err, { tags: { route: 'submit-error-data' } });


### PR DESCRIPTION
## Summary
- Fires Sentry warnings when users submit unsupported oximetry formats or failed SD card parses
- Tags alerts with `unsupported_format` and `unsupported_data` for structured routing
- Removes email from Sentry extra (privacy)
- Rebased onto main after PR #44 merge (supersedes #41)

## Test plan
- [x] 281 tests pass (9 new)
- [x] TypeScript: clean
- [x] Build: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)