### PR TITLE
feat: remove 1095-night cap on data contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AI credits synced from server**: Community tier AI credit count now reflects actual server-side usage instead of unreliable localStorage counter — clearing browser data no longer resets the display (`ai-credits-tracking-and-messaging`)
 - **Community funding messaging**: AI insights CTA explains that analyses are funded out of pocket, with warm invitation to support the project
 - **Unsupported data alerts**: Sentry warnings for unsupported oximetry formats and failed SD card parses, enabling prioritised format support (`unsupported-data-alerts`)
+- **Unlimited data contribution**: Removed 1095-night cap — all nights are submitted automatically via chunked batches of 1000 with shared `contributionId` (`unlimited-first-contribution`)
 
 ### Improved
 

--- a/__tests__/contribute.test.ts
+++ b/__tests__/contribute.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { NightResult } from '@/lib/types';
+
+// ── Mock fetch ──────────────────────────────────────────────
+const fetchMock = vi.fn();
+globalThis.fetch = fetchMock;
+
+// ── Mock localStorage ───────────────────────────────────────
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+  getItem: vi.fn((key: string) => storage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => { storage.set(key, value); }),
+  removeItem: vi.fn((key: string) => { storage.delete(key); }),
+  clear: vi.fn(() => { storage.clear(); }),
+  get length() { return storage.size; },
+  key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+// ── Mock crypto.randomUUID ──────────────────────────────────
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid-1234' });
+
+import { contributeNights, trackContributedDates } from '@/lib/contribute';
+
+// ── Helpers ─────────────────────────────────────────────────
+function makeNight(dateStr: string): NightResult {
+  return {
+    dateStr,
+    durationHours: 7,
+    sessionCount: 1,
+    settings: {
+      deviceModel: 'AirSense 10',
+      papMode: 'CPAP',
+      epap: 10,
+      ipap: 10,
+      pressureSupport: 0,
+      riseTime: 1,
+      trigger: 'Med',
+      cycle: 'Med',
+      easyBreathe: 'On',
+    },
+    glasgow: {
+      overall: 3.5,
+      skew: 0.5,
+      spike: 0.3,
+      flatTop: 0.4,
+      topHeavy: 0.2,
+      multiPeak: 0.3,
+      noPause: 0.5,
+      inspirRate: 0.4,
+      multiBreath: 0.6,
+      variableAmp: 0.5,
+    },
+    wat: {
+      flScore: 45,
+      regularityScore: 1.2,
+      periodicityIndex: 0.05,
+    },
+    ned: {
+      breathCount: 500,
+      nedMean: 25,
+      nedMedian: 22,
+      nedP95: 55,
+      nedClearFLPct: 30,
+      nedBorderlinePct: 20,
+      fiMean: 0.6,
+      fiFL85Pct: 15,
+      tpeakMean: 0.35,
+      mShapePct: 8,
+      reraIndex: 5,
+      reraCount: 35,
+      h1NedMean: 28,
+      h2NedMean: 22,
+      combinedFLPct: 50,
+      estimatedArousalIndex: 12,
+    },
+    oximetry: null,
+  } as unknown as NightResult;
+}
+
+function makeNights(count: number): NightResult[] {
+  return Array.from({ length: count }, (_, i) =>
+    makeNight(`2025-01-${String(i + 1).padStart(2, '0')}`)
+  );
+}
+
+describe('contributeNights', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    storage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('sends all nights in one request when ≤ 1000', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+    const nights = makeNights(500);
+    const result = await contributeNights(nights);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(true);
+    expect(result.totalSent).toBe(500);
+  });
+
+  it('chunks 2500 nights into 3 requests (1000+1000+500)', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+    const nights = makeNights(2500);
+    const result = await contributeNights(nights);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result.totalSent).toBe(2500);
+
+    // Verify chunk sizes via request bodies
+    const bodies = fetchMock.mock.calls.map(
+      (call) => JSON.parse((call[1] as RequestInit).body as string).nights.length
+    );
+    expect(bodies).toEqual([1000, 1000, 500]);
+  });
+
+  it('all chunks share the same contributionId', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+    const nights = makeNights(2500);
+    const result = await contributeNights(nights);
+
+    const ids = fetchMock.mock.calls.map(
+      (call) => JSON.parse((call[1] as RequestInit).body as string).contributionId
+    );
+    expect(ids.every((id: string) => id === ids[0])).toBe(true);
+    expect(result.contributionId).toBe(ids[0]);
+  });
+
+  it('fires onProgress callback after each chunk', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+    const nights = makeNights(2500);
+    const progress: Array<[number, number]> = [];
+    await contributeNights(nights, (sent, total) => progress.push([sent, total]));
+
+    expect(progress).toEqual([
+      [1000, 2500],
+      [2000, 2500],
+      [2500, 2500],
+    ]);
+  });
+
+  it('throws on chunk failure but previous chunks were sent', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const nights = makeNights(1500);
+    await expect(contributeNights(nights)).rejects.toThrow('Contribution failed (batch 2)');
+
+    // First chunk was still sent
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('trackContributedDates', () => {
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('stores date strings in localStorage', () => {
+    const nights = [makeNight('2025-01-01'), makeNight('2025-01-02')];
+    trackContributedDates(nights);
+
+    const stored = JSON.parse(storage.get('airwaylab_contributed_dates') || '[]');
+    expect(stored).toContain('2025-01-01');
+    expect(stored).toContain('2025-01-02');
+    expect(storage.get('airwaylab_contributed_nights')).toBe('2');
+  });
+
+  it('deduplicates dates across calls', () => {
+    trackContributedDates([makeNight('2025-01-01')]);
+    trackContributedDates([makeNight('2025-01-01'), makeNight('2025-01-02')]);
+
+    const stored = JSON.parse(storage.get('airwaylab_contributed_dates') || '[]');
+    expect(stored).toHaveLength(2);
+    expect(storage.get('airwaylab_contributed_nights')).toBe('2');
+  });
+});

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -31,6 +31,7 @@ import { SAMPLE_NIGHTS, SAMPLE_THERAPY_CHANGE_DATE } from '@/lib/sample-data';
 import type { AnalysisState, NightResult } from '@/lib/types';
 import { loadPersistedResults, persistResults, clearPersistedResults } from '@/lib/persistence';
 import { events } from '@/lib/analytics';
+import { contributeNights, trackContributedDates } from '@/lib/contribute';
 import { clearManifest } from '@/lib/file-manifest';
 import {
   RotateCcw,
@@ -260,26 +261,9 @@ function AnalyzePageInner() {
   );
 
   const submitContribution = useCallback((nightsToSubmit: NightResult[]) => {
-    // Cap at 1095 most recent nights to stay within server limits
-    const toSubmit = nightsToSubmit.length > 1095
-      ? nightsToSubmit.slice(0, 1095)
-      : nightsToSubmit;
-    fetch('/api/contribute-data', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ nights: toSubmit }),
-    }).then((res) => {
-      if (res.ok) {
-        try {
-          const storedDates: string[] = JSON.parse(localStorage.getItem('airwaylab_contributed_dates') || '[]');
-          const dateSet = new Set(storedDates);
-          for (const n of nightsToSubmit) dateSet.add(n.dateStr);
-          const updated = Array.from(dateSet);
-          localStorage.setItem('airwaylab_contributed_dates', JSON.stringify(updated));
-          localStorage.setItem('airwaylab_contributed_nights', String(updated.length));
-        } catch { /* noop */ }
-      }
-    }).catch(() => { /* non-critical */ });
+    contributeNights(nightsToSubmit)
+      .then(() => trackContributedDates(nightsToSubmit))
+      .catch(() => { /* non-critical */ });
   }, []);
 
   const handleNudgeContribute = useCallback(() => {

--- a/app/api/contribute-data/route.ts
+++ b/app/api/contribute-data/route.ts
@@ -5,11 +5,11 @@ import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import type { NightResult } from '@/lib/types';
 
-const limiter = new RateLimiter({ windowMs: 3_600_000, max: 3 });
+const limiter = new RateLimiter({ windowMs: 3_600_000, max: 10 });
 
 // ── Validation ───────────────────────────────────────────────
-const MAX_NIGHTS = 1095; // ~3 years of nightly data
-const MAX_PAYLOAD_BYTES = 6_144_000; // 6 MB (supports ~3 years of nightly data)
+const MAX_NIGHTS_PER_CHUNK = 1000; // max nights per request (client chunks larger datasets)
+const MAX_PAYLOAD_BYTES = 3_145_728; // 3 MB (supports ~1000 anonymised nights with headroom)
 
 function isValidNight(n: unknown): n is NightResult {
   if (!n || typeof n !== 'object') return false;
@@ -152,13 +152,16 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { nights } = body as { nights: unknown[] };
+    const { nights, contributionId: clientContributionId } = body as {
+      nights: unknown[];
+      contributionId?: string;
+    };
 
     // Validate
-    if (!Array.isArray(nights) || nights.length === 0 || nights.length > MAX_NIGHTS) {
+    if (!Array.isArray(nights) || nights.length === 0 || nights.length > MAX_NIGHTS_PER_CHUNK) {
       console.warn(`[contribute-data] 400 invalid night count: ${Array.isArray(nights) ? nights.length : 'not array'}`);
       return NextResponse.json(
-        { error: `Expected 1–${MAX_NIGHTS} nights.` },
+        { error: `Expected 1–${MAX_NIGHTS_PER_CHUNK} nights per request.` },
         { status: 400 }
       );
     }
@@ -174,8 +177,11 @@ export async function POST(request: NextRequest) {
     // Anonymise
     const anonymised = nights.map((n, i) => anonymiseNight(n as NightResult, i));
 
-    // Generate a random contribution ID (not linked to user identity)
-    const contributionId = crypto.randomUUID();
+    // Use client-provided contributionId for chunked submissions, or generate one
+    const contributionId =
+      typeof clientContributionId === 'string' && clientContributionId.length > 0
+        ? clientContributionId
+        : crypto.randomUUID();
 
     const supabase = getSupabaseAdmin();
 

--- a/components/dashboard/data-contribution.tsx
+++ b/components/dashboard/data-contribution.tsx
@@ -4,10 +4,10 @@ import { useState, useCallback, useEffect } from 'react';
 import { Users, Loader2, X, Shield, Heart } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { events } from '@/lib/analytics';
+import { contributeNights, trackContributedDates } from '@/lib/contribute';
 import type { NightResult } from '@/lib/types';
 
 const DISMISS_KEY = 'airwaylab_contribute_dismissed';
-const CONTRIBUTED_NIGHTS_KEY = 'airwaylab_contributed_nights';
 
 interface Props {
   nights: NightResult[];
@@ -66,30 +66,10 @@ export function DataContribution({ nights, isDemo = false }: Props) {
   const handleContribute = useCallback(async () => {
     setStatus('sending');
     try {
-      // Cap at 1095 most recent nights to stay within server limits
-      const toSubmit = nights.length > 1095
-        ? nights.slice(0, 1095)
-        : nights;
-      const res = await fetch('/api/contribute-data', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ nights: toSubmit }),
-      });
-
-      if (res.ok) {
-        setStatus('success');
-        events.contributionOptedIn();
-        try {
-          const storedDates: string[] = JSON.parse(localStorage.getItem('airwaylab_contributed_dates') || '[]');
-          const dateSet = new Set(storedDates);
-          for (const n of nights) dateSet.add(n.dateStr);
-          const updated = Array.from(dateSet);
-          localStorage.setItem('airwaylab_contributed_dates', JSON.stringify(updated));
-          localStorage.setItem(CONTRIBUTED_NIGHTS_KEY, String(updated.length));
-        } catch { /* noop */ }
-      } else {
-        setStatus('error');
-      }
+      await contributeNights(nights);
+      setStatus('success');
+      events.contributionOptedIn();
+      trackContributedDates(nights);
     } catch {
       setStatus('error');
     }

--- a/lib/contribute.ts
+++ b/lib/contribute.ts
@@ -1,0 +1,64 @@
+// ============================================================
+// AirwayLab — Data Contribution Client
+// Submits anonymised analysis results in chunks.
+// No night count cap — large datasets are chunked automatically.
+// ============================================================
+
+import type { NightResult } from './types';
+
+const CHUNK_SIZE = 1000;
+
+export interface ContributionResult {
+  ok: boolean;
+  totalSent: number;
+  contributionId: string;
+}
+
+/**
+ * Contribute anonymised night data to the community dataset.
+ * Automatically chunks large datasets into multiple requests
+ * sharing a single contributionId for grouping.
+ */
+export async function contributeNights(
+  nights: NightResult[],
+  onProgress?: (sent: number, total: number) => void
+): Promise<ContributionResult> {
+  const contributionId = crypto.randomUUID();
+  let totalSent = 0;
+
+  for (let i = 0; i < nights.length; i += CHUNK_SIZE) {
+    const chunk = nights.slice(i, i + CHUNK_SIZE);
+    const res = await fetch('/api/contribute-data', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ nights: chunk, contributionId }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Contribution failed (batch ${Math.floor(i / CHUNK_SIZE) + 1})`);
+    }
+
+    totalSent += chunk.length;
+    onProgress?.(totalSent, nights.length);
+  }
+
+  return { ok: true, totalSent, contributionId };
+}
+
+/**
+ * Update localStorage with contributed date strings for dedup.
+ */
+export function trackContributedDates(nights: NightResult[]): void {
+  try {
+    const storedDates: string[] = JSON.parse(
+      localStorage.getItem('airwaylab_contributed_dates') || '[]'
+    );
+    const dateSet = new Set(storedDates);
+    for (const n of nights) dateSet.add(n.dateStr);
+    const updated = Array.from(dateSet);
+    localStorage.setItem('airwaylab_contributed_dates', JSON.stringify(updated));
+    localStorage.setItem('airwaylab_contributed_nights', String(updated.length));
+  } catch {
+    // localStorage may be unavailable
+  }
+}


### PR DESCRIPTION
## Summary
- Removes 1095-night cap on data contributions — all nights submitted via chunked batches of 1000
- New `lib/contribute.ts` with `contributeNights()` helper and `trackContributedDates()`
- Simplified contribution logic in analyze page and data-contribution component
- Rate limit increased from 3 to 10 requests/hour for chunked submissions
- Rebased onto main (supersedes #42)

## Test plan
- [x] 288 tests pass (7 new for contribution chunking)
- [x] TypeScript: clean
- [x] Build: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)