### PR TITLE
fix: onboarding quick wins — mobile CTAs, guidance, export feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 
 - **Persistent contribution consent**: Remember opt-in status across sessions — returning users see a compact "Contributing data, thank you" confirmation instead of being asked again (persistent-contribution-consent)
+- **Mobile-first landing CTAs**: Demo is now the primary CTA on mobile, with a note that uploading requires a desktop computer (`onboarding-quick-wins`)
+- **"Start here" guidance**: New users see a brief callout above metrics explaining Glasgow Index and traffic light colours (`onboarding-quick-wins`)
+- **Export download feedback**: CSV and JSON export buttons show "Downloaded!" confirmation for 2 seconds (`onboarding-quick-wins`)
+- **Inclusive community sharing**: Share prompts now name ApneaBoard, Reddit, CPAPtalk, and "your favourite sleep community" (`onboarding-quick-wins`)
+- **Upload page reorder**: Demo CTA moved above consent sections for discoverability (`onboarding-quick-wins`)
 
 ### Fixed
 

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -412,17 +412,7 @@ function AnalyzePageInner() {
         <div className="mx-auto max-w-lg">
           <FileUpload onFilesSelected={handleFiles} />
 
-          {/* Cloud storage consent — shown for eligible users */}
-          <div className="mt-4">
-            <StorageConsent onChange={(v) => { storageConsentRef.current = v; }} />
-          </div>
-
-          {/* Data contribution opt-in — shown during upload for higher conversion */}
-          <div className="mt-4">
-            <ContributionOptIn onChange={(v) => { contributeOptInRef.current = v; }} />
-          </div>
-
-          {/* Demo CTA */}
+          {/* Demo CTA — shown immediately after upload for discoverability */}
           <div className="mt-6 flex flex-col items-center gap-2">
             <div className="flex items-center gap-3 text-[11px] text-muted-foreground/50">
               <div className="h-px flex-1 bg-border/50" />
@@ -441,6 +431,16 @@ function AnalyzePageInner() {
             <p className="text-[11px] text-muted-foreground/50">
               See what AirwayLab looks like with 5 nights of example data
             </p>
+          </div>
+
+          {/* Cloud storage consent — shown for eligible users */}
+          <div className="mt-4">
+            <StorageConsent onChange={(v) => { storageConsentRef.current = v; }} />
+          </div>
+
+          {/* Data contribution opt-in — shown during upload for higher conversion */}
+          <div className="mt-4">
+            <ContributionOptIn onChange={(v) => { contributeOptInRef.current = v; }} />
           </div>
         </div>
       )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -178,16 +178,34 @@ export default function Home() {
               </p>
 
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-                <Link href="/analyze">
-                  <Button size="lg" className="w-full gap-2 shadow-glow sm:w-auto">
-                    <Upload className="h-4 w-4" /> Upload Your SD Card
-                  </Button>
-                </Link>
-                <Link href="/analyze?demo">
-                  <Button variant="outline" size="lg" className="w-full gap-2 sm:w-auto">
+                {/* Mobile: Demo primary, Upload secondary */}
+                <Link href="/analyze?demo" className="sm:hidden">
+                  <Button size="lg" className="w-full gap-2 shadow-glow">
                     <Play className="h-4 w-4" /> See Demo
                   </Button>
                 </Link>
+                <Link href="/analyze" className="sm:hidden">
+                  <Button variant="outline" size="lg" className="w-full gap-2">
+                    <Upload className="h-4 w-4" /> Upload Your SD Card
+                  </Button>
+                </Link>
+                {/* Desktop: Upload primary, Demo secondary */}
+                <Link href="/analyze" className="hidden sm:block">
+                  <Button size="lg" className="gap-2 shadow-glow">
+                    <Upload className="h-4 w-4" /> Upload Your SD Card
+                  </Button>
+                </Link>
+                <Link href="/analyze?demo" className="hidden sm:block">
+                  <Button variant="outline" size="lg" className="gap-2">
+                    <Play className="h-4 w-4" /> See Demo
+                  </Button>
+                </Link>
+                <p className="text-[11px] text-muted-foreground/60 sm:hidden">
+                  Uploading requires a desktop computer with an SD card reader.
+                </p>
+                <div className="sm:hidden">
+                  <EmailOptIn variant="inline" source="landing-mobile-reminder" />
+                </div>
               </div>
               <Link
                 href="/about"
@@ -324,7 +342,7 @@ export default function Home() {
               <h3 className="text-sm font-semibold">Accessible to Everyone</h3>
             </div>
             <p className="text-xs leading-relaxed text-muted-foreground">
-              Not just patients with technical skills. Not just those who can afford specialist clinics. Everyone on PAP therapy deserves to know if their treatment is actually working beyond a single number.
+              Not just people with technical skills. Not just those who can afford specialist clinics. Everyone on PAP therapy deserves to know if their treatment is actually working beyond a single number.
             </p>
           </div>
           <div className="rounded-xl border border-border/50 bg-card/50 p-5 sm:p-6">
@@ -729,7 +747,7 @@ export default function Home() {
           </p>
           <Link href="/analyze">
             <Button size="lg" className="gap-2 shadow-glow">
-              Get Started <ArrowRight className="h-4 w-4" />
+              <Upload className="h-4 w-4" /> Upload Your SD Card
             </Button>
           </Link>
           <div className="mt-2">

--- a/components/dashboard/export-buttons.tsx
+++ b/components/dashboard/export-buttons.tsx
@@ -110,18 +110,35 @@ function safeOpenPDF(nights: NightResult[]): void {
 export const ExportButtons = memo(function ExportButtons({ nights, selectedNight }: Props) {
   const { tier } = useAuth();
   const pdfAllowed = canAccess('pdf_report', tier);
+  const [downloaded, setDownloaded] = useState<string | null>(null);
+
+  const handleCSV = useCallback(() => {
+    safeExportCSV(nights);
+    setDownloaded('csv');
+    setTimeout(() => setDownloaded(null), 2000);
+  }, [nights]);
+
+  const handleJSON = useCallback(() => {
+    safeExportJSON(nights);
+    setDownloaded('json');
+    setTimeout(() => setDownloaded(null), 2000);
+  }, [nights]);
 
   return (
     <TooltipProvider>
       <div className="flex gap-2">
         <Tooltip>
           <TooltipTrigger
-            onClick={() => safeExportCSV(nights)}
+            onClick={handleCSV}
             aria-label={`Export ${nights.length} night${nights.length !== 1 ? 's' : ''} as CSV spreadsheet`}
             className="inline-flex h-8 items-center gap-1.5 rounded-md border border-input bg-background px-3 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
           >
-            <Download className="h-3 w-3" />
-            <span className="hidden sm:inline">Spreadsheet </span>CSV
+            {downloaded === 'csv' ? (
+              <Check className="h-3 w-3 text-emerald-500" />
+            ) : (
+              <Download className="h-3 w-3" />
+            )}
+            <span className="hidden sm:inline">Spreadsheet </span>{downloaded === 'csv' ? 'Downloaded!' : 'CSV'}
           </TooltipTrigger>
           <TooltipContent>
             All metrics for {nights.length} night{nights.length !== 1 ? 's' : ''} — opens in Excel, Google Sheets
@@ -130,12 +147,16 @@ export const ExportButtons = memo(function ExportButtons({ nights, selectedNight
 
         <Tooltip>
           <TooltipTrigger
-            onClick={() => safeExportJSON(nights)}
+            onClick={handleJSON}
             aria-label={`Export ${nights.length} night${nights.length !== 1 ? 's' : ''} as JSON data`}
             className="inline-flex h-8 items-center gap-1.5 rounded-md border border-input bg-background px-3 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
           >
-            <Download className="h-3 w-3" />
-            <span className="hidden sm:inline">Raw Data </span>JSON
+            {downloaded === 'json' ? (
+              <Check className="h-3 w-3 text-emerald-500" />
+            ) : (
+              <Download className="h-3 w-3" />
+            )}
+            <span className="hidden sm:inline">Raw Data </span>{downloaded === 'json' ? 'Downloaded!' : 'JSON'}
           </TooltipTrigger>
           <TooltipContent>
             Full structured data for programmatic use

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -68,7 +68,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
   const { user, tier, isPaid } = useAuth();
 
   const [aiInsights, setAiInsights] = useState<Insight[] | null>(null);
-  const [aiRemainingCredits, setAiRemainingCredits] = useState<number | undefined>(undefined);
+  const [serverRemainingCredits, setAiRemainingCredits] = useState<number | undefined>(undefined);
   const [aiLoading, setAiLoading] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -196,7 +196,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
 
       {/* AI Insights CTA (demo or community tier) */}
       {aiInsights && aiInsights.length > 0 && (
-        <AIInsightsCTA isDemo={isDemo} remainingCredits={aiRemainingCredits} />
+        <AIInsightsCTA isDemo={isDemo} remainingCredits={serverRemainingCredits} />
       )}
 
       {/* Rule-based Insights Panel */}
@@ -262,6 +262,18 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           <Badge variant="outline">PS {n.settings.pressureSupport}</Badge>
         )}
       </div>
+
+      {/* Start-here guidance for new users */}
+      {isNewUser && (
+        <div className="flex items-start gap-2.5 rounded-lg border border-primary/10 bg-primary/[0.03] px-4 py-3">
+          <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary/60" />
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            <span className="font-medium text-foreground">Start with Glasgow Index</span> — it scores your overall breathing pattern on a 0–8 scale.
+            Green means normal, amber means worth monitoring, red means discuss with your clinician.
+            Click any metric for a detailed trend view.
+          </p>
+        </div>
+      )}
 
       {/* Key Metrics Grid */}
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4 stagger-children">
@@ -516,7 +528,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
 
       {/* Upgrade prompt for community users */}
       {!isPaid && (
-        <UpgradePrompt feature="AI-powered therapy insights and detailed metric explanations are available to supporters." remainingCredits={aiRemainingCredits} />
+        <UpgradePrompt feature="AI-powered therapy insights and detailed metric explanations are available to supporters." remainingCredits={serverRemainingCredits} />
       )}
 
       {/* Metric Detail Modal */}

--- a/components/dashboard/share-prompts.tsx
+++ b/components/dashboard/share-prompts.tsx
@@ -77,7 +77,7 @@ export function SharePrompts({ nights, selectedNight, isDemo }: Props) {
             <div>
               <p className="text-sm font-medium">Share with the community</p>
               <p className="text-xs text-muted-foreground">
-                Posting your results on ApneaBoard or Reddit helps others understand their data too.
+                Posting your results on ApneaBoard, Reddit, CPAPtalk, or your favourite sleep community helps others understand their data too.
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-2">
@@ -92,7 +92,7 @@ export function SharePrompts({ nights, selectedNight, isDemo }: Props) {
                     <Check className="h-3 w-3 text-emerald-500" /> Copied!
                   </>
                 ) : (
-                  'Copy for Reddit / ApneaBoard'
+                  'Copy for Forum Post'
                 )}
               </Button>
             </div>


### PR DESCRIPTION
## Summary
- Mobile-first hero CTAs: demo primary on mobile, upload primary on desktop
- New user guidance callout for Glasgow Index (shown for first 5 sessions)
- Export download feedback: 2-second "Downloaded!" confirmation
- Inclusive community sharing copy (ApneaBoard, Reddit, CPAPtalk)
- Upload page reorder: Demo CTA above consent sections
- Rebased onto main (supersedes #43)

## Test plan
- [x] 288 tests pass
- [x] TypeScript: clean
- [x] Build: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)