### PR TITLE
feat: add social proof counter to contribution nudge dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Contribution nudge social proof**: Post-upload contribution dialog now shows a live counter of how many people have already contributed and total nights, fetched from `/api/stats` (`contribution-nudge-social-proof`)
 - **AI credits synced from server**: Community tier AI credit count now reflects actual server-side usage instead of unreliable localStorage counter — clearing browser data no longer resets the display (`ai-credits-tracking-and-messaging`)
 - **Community funding messaging**: AI insights CTA explains that analyses are funded out of pocket, with warm invitation to support the project
 - **Unsupported data alerts**: Sentry warnings for unsupported oximetry formats and failed SD card parses, enabling prioritised format support (`unsupported-data-alerts`)

--- a/__tests__/contribution-nudge-social-proof.test.tsx
+++ b/__tests__/contribution-nudge-social-proof.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { ContributionNudgeDialog } from '@/components/upload/contribution-nudge-dialog';
+
+// Mock the focus trap hook — it just returns a ref
+vi.mock('@/hooks/use-focus-trap', () => ({
+  useFocusTrap: () => ({ current: null }),
+}));
+
+// Helpers
+function mockFetchStats(stats: { totalContributions: number; totalContributedNights: number }) {
+  global.fetch = vi.fn().mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve(stats),
+  });
+}
+
+function mockFetchFailure() {
+  global.fetch = vi.fn().mockRejectedValueOnce(new Error('Network error'));
+}
+
+function mockFetchZero() {
+  mockFetchStats({ totalContributions: 0, totalContributedNights: 0 });
+}
+
+const defaultProps = {
+  nightCount: 59,
+  onContribute: vi.fn(),
+  onDismiss: vi.fn(),
+};
+
+describe('ContributionNudgeDialog social proof', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders without social proof when stats fetch fails', async () => {
+    mockFetchFailure();
+    render(<ContributionNudgeDialog {...defaultProps} />);
+
+    // Dialog renders
+    expect(screen.getByText(/could help thousands/)).toBeInTheDocument();
+
+    // Wait for fetch to settle, then verify no social proof
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByText(/people have contributed/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/person has contributed/)).not.toBeInTheDocument();
+  });
+
+  it('renders social proof line when totalContributions > 0', async () => {
+    mockFetchStats({ totalContributions: 42, totalContributedNights: 1280 });
+    render(<ContributionNudgeDialog {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/people have contributed/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/42/)).toBeInTheDocument();
+    expect(screen.getByText(/1,280/)).toBeInTheDocument();
+  });
+
+  it('hides social proof when totalContributions is 0', async () => {
+    mockFetchZero();
+    render(<ContributionNudgeDialog {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByText(/people have contributed/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/person has contributed/)).not.toBeInTheDocument();
+  });
+
+  it('uses singular grammar for 1 person and 1 night', async () => {
+    mockFetchStats({ totalContributions: 1, totalContributedNights: 1 });
+    render(<ContributionNudgeDialog {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/person has contributed/)).toBeInTheDocument();
+    });
+
+    // Should use "night" not "nights" — check the parent span's full text
+    expect(screen.getByText(/night so far$/)).toBeInTheDocument();
+    expect(screen.queryByText(/nights so far/)).not.toBeInTheDocument();
+  });
+
+  it('uses plural grammar for multiple people and nights', async () => {
+    mockFetchStats({ totalContributions: 42, totalContributedNights: 1280 });
+    render(<ContributionNudgeDialog {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/people have contributed/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/nights so far/)).toBeInTheDocument();
+  });
+
+  it('contribute and dismiss callbacks work regardless of stats state', async () => {
+    mockFetchStats({ totalContributions: 10, totalContributedNights: 50 });
+    const onContribute = vi.fn();
+    const onDismiss = vi.fn();
+
+    render(
+      <ContributionNudgeDialog
+        nightCount={59}
+        onContribute={onContribute}
+        onDismiss={onDismiss}
+      />
+    );
+
+    // Wait for stats to load
+    await waitFor(() => {
+      expect(screen.getByText(/people have contributed/)).toBeInTheDocument();
+    });
+
+    // Click contribute
+    fireEvent.click(screen.getByRole('button', { name: /yes, contribute/i }));
+    expect(onContribute).toHaveBeenCalledOnce();
+
+    // Click dismiss
+    fireEvent.click(screen.getByRole('button', { name: /not this time/i }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/components/upload/contribution-nudge-dialog.tsx
+++ b/components/upload/contribution-nudge-dialog.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import { useEffect } from 'react';
-import { Heart, Shield, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Heart, HeartHandshake, Shield, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
+
+interface ContributionStats {
+  totalContributions: number;
+  totalContributedNights: number;
+}
 
 /**
  * Modal shown after analysis completes when the user has NOT opted in to
@@ -20,6 +25,7 @@ export function ContributionNudgeDialog({
   onDismiss: () => void;
 }) {
   const focusTrapRef = useFocusTrap(true);
+  const [stats, setStats] = useState<ContributionStats | null>(null);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -28,6 +34,20 @@ export function ContributionNudgeDialog({
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [onDismiss]);
+
+  useEffect(() => {
+    fetch('/api/stats', { signal: AbortSignal.timeout(3000) })
+      .then((r) => { if (!r.ok) throw new Error('fetch failed'); return r.json(); })
+      .then((data) => {
+        if (data.totalContributions > 0) {
+          setStats({
+            totalContributions: data.totalContributions,
+            totalContributedNights: data.totalContributedNights ?? 0,
+          });
+        }
+      })
+      .catch(() => { /* non-critical */ });
+  }, []);
 
   return (
     <div className="fixed inset-0 z-[90] flex items-center justify-center bg-background/70 backdrop-blur-sm" role="dialog" aria-modal="true" aria-labelledby="contribution-nudge-title">
@@ -54,6 +74,22 @@ export function ContributionNudgeDialog({
             raw data leaves your device, ever.
           </p>
         </div>
+
+        {stats && (
+          <div className="flex items-center gap-1.5 text-sm text-muted-foreground animate-fade-in-up">
+            <HeartHandshake className="h-4 w-4 shrink-0 text-primary/70" />
+            <span>
+              <strong className="font-semibold text-foreground">
+                {stats.totalContributions.toLocaleString()}
+              </strong>{' '}
+              {stats.totalContributions === 1 ? 'person has' : 'people have'} contributed{' '}
+              <strong className="font-semibold text-foreground">
+                {stats.totalContributedNights.toLocaleString()}
+              </strong>{' '}
+              {stats.totalContributedNights === 1 ? 'night' : 'nights'} so far
+            </span>
+          </div>
+        )}
 
         <div className="flex w-full flex-col gap-2.5 sm:flex-row sm:justify-center">
           <Button

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- Adds a live counter to the post-upload contribution nudge dialog showing how many people have already contributed and total nights contributed
- Fetches from existing `/api/stats` endpoint (3s timeout, silent fallback)
- Hidden when stats unavailable, fetch fails, or zero contributions — dialog works exactly as before

## Changes
- `components/upload/contribution-nudge-dialog.tsx` — fetch stats on mount, render social proof line with HeartHandshake icon
- `__tests__/contribution-nudge-social-proof.test.tsx` — 6 tests (fetch failure, social proof visible, zero hiding, singular/plural grammar, callback functionality)
- `vitest.config.ts` — esbuild JSX config for `.tsx` test support
- `CHANGELOG.md` — entry added

## Test plan
- [ ] Upload SD card data, verify social proof line appears in nudge dialog
- [ ] Verify correct singular/plural grammar
- [ ] Verify dialog still works (contribute + dismiss) while stats loading
- [ ] Verify dialog works normally when `/api/stats` is unreachable
- [ ] `npm test` — 300/300 passing
- [ ] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)