### PR TITLE
fix: explain amber warnings in Machine Settings Timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to AirwayLab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Improved
+
+- **Settings timeline change explanation**: Amber-highlighted rows in the Machine Settings Timeline now explain what changed — visible "Changed: EPAP, IPAP" text on desktop (matching mobile), subtitle describing the highlighting pattern, and tooltips on warning icons (`settings-timeline-change-explanation`)
+
 ## [Unreleased] — Platform Audit (2026-03-10)
 
 ### Added

--- a/__tests__/settings-timeline.test.tsx
+++ b/__tests__/settings-timeline.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { SettingsTimeline } from '@/components/dashboard/settings-timeline';
+import type { NightResult, MachineSettings } from '@/lib/types';
+
+function makeSettings(overrides: Partial<MachineSettings> = {}): MachineSettings {
+  return {
+    deviceModel: 'AirSense 10',
+    epap: 10,
+    ipap: 14,
+    pressureSupport: 4,
+    papMode: 'APAP',
+    riseTime: 2,
+    trigger: 'Medium',
+    cycle: 'Medium',
+    easyBreathe: false,
+    ...overrides,
+  };
+}
+
+function makeNight(dateStr: string, settings?: Partial<MachineSettings>): NightResult {
+  return {
+    date: new Date(dateStr),
+    dateStr,
+    durationHours: 7,
+    sessionCount: 1,
+    settings: makeSettings(settings),
+    glasgow: {
+      overall: 3, skew: 0.5, spike: 0.3, flatTop: 0.4, topHeavy: 0.2,
+      multiPeak: 0.3, noPause: 0.4, inspirRate: 0.5, multiBreath: 0.4, variableAmp: 0.3,
+    },
+    wat: { flScore: 30, regularityScore: 0.5, periodicityIndex: 0.1 },
+    ned: {
+      breathCount: 500, nedMean: 20, nedMedian: 18, nedP95: 45,
+      nedClearFLPct: 15, nedBorderlinePct: 10, fiMean: 0.7, fiFL85Pct: 12,
+      tpeakMean: 0.35, mShapePct: 5, reraIndex: 3, reraCount: 20,
+      h1NedMean: 18, h2NedMean: 22, combinedFLPct: 25, estimatedArousalIndex: 8,
+    },
+    oximetry: null,
+  };
+}
+
+describe('SettingsTimeline', () => {
+  it('shows subtitle explaining amber rows when changes exist', () => {
+    const nights = [
+      makeNight('2025-01-15', { epap: 12 }),
+      makeNight('2025-01-14'),
+    ];
+    render(<SettingsTimeline nights={nights} therapyChangeDate={null} />);
+    expect(screen.getByText(/settings changed from the previous night/i)).toBeInTheDocument();
+  });
+
+  it('shows consistent-settings subtitle when no changes exist', () => {
+    const nights = [
+      makeNight('2025-01-15'),
+      makeNight('2025-01-14'),
+    ];
+    render(<SettingsTimeline nights={nights} therapyChangeDate={null} />);
+    expect(screen.getByText(/consistent across all nights/i)).toBeInTheDocument();
+  });
+
+  it('shows visible "Changed:" text on desktop rows with changes', () => {
+    const nights = [
+      makeNight('2025-01-15', { epap: 12, ipap: 16 }),
+      makeNight('2025-01-14'),
+    ];
+    render(<SettingsTimeline nights={nights} therapyChangeDate={null} />);
+    // Desktop table should have visible change text
+    const table = screen.getByRole('table');
+    const changedText = within(table).getByText(/Changed: EPAP, IPAP/);
+    expect(changedText).toBeInTheDocument();
+    expect(changedText).not.toHaveClass('sr-only');
+  });
+
+  it('shows "Therapy change reference" when therapyChangeDate has no changeMap entry', () => {
+    // Single night that is the therapyChangeDate — no prior night to compare
+    const nights = [makeNight('2025-01-14')];
+    render(<SettingsTimeline nights={nights} therapyChangeDate="2025-01-14" />);
+    const refs = screen.getAllByText(/Therapy change reference/);
+    expect(refs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('adds title attribute to AlertTriangle icon with change details', () => {
+    const nights = [
+      makeNight('2025-01-15', { trigger: 'High' }),
+      makeNight('2025-01-14'),
+    ];
+    render(<SettingsTimeline nights={nights} therapyChangeDate={null} />);
+    const icons = document.querySelectorAll('[data-testid="change-icon"]');
+    const icon = icons[0];
+    expect(icon).toBeTruthy();
+    expect(icon?.getAttribute('title')).toMatch(/Settings changed: Trigger/);
+  });
+
+  it('mobile card still shows "Changed:" text', () => {
+    const nights = [
+      makeNight('2025-01-15', { cycle: 'High' }),
+      makeNight('2025-01-14'),
+    ];
+    render(<SettingsTimeline nights={nights} therapyChangeDate={null} />);
+    // The mobile section has its own "Changed:" text
+    const mobileChangedTexts = screen.getAllByText(/Changed: Cycle/);
+    expect(mobileChangedTexts.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/components/dashboard/settings-timeline.tsx
+++ b/components/dashboard/settings-timeline.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useMemo, useState } from 'react';
+import React, { memo, useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { AlertTriangle, ChevronUp, ChevronDown } from 'lucide-react';
 import type { NightResult, MachineSettings } from '@/lib/types';
@@ -52,6 +52,16 @@ function settingsChanged(a: MachineSettings, b: MachineSettings): string[] {
   return changes;
 }
 
+function getChangeLabel(hasChanges: boolean, changes: string[]): string {
+  if (hasChanges) return `Changed: ${changes.join(', ')}`;
+  return 'Therapy change reference';
+}
+
+function getChangeTitle(hasChanges: boolean, changes: string[]): string {
+  if (hasChanges) return `Settings changed: ${changes.join(', ')}`;
+  return 'Therapy change reference date';
+}
+
 export const SettingsTimeline = memo(function SettingsTimeline({ nights, therapyChangeDate }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>('date');
   const [sortAsc, setSortAsc] = useState(false); // newest first by default
@@ -89,10 +99,19 @@ export const SettingsTimeline = memo(function SettingsTimeline({ nights, therapy
     return map;
   }, [nights]);
 
+  const hasAnyChanges = changeMap.size > 0 || nights.some((n) => n.dateStr === therapyChangeDate);
+
   return (
     <Card className="border-border/50">
       <CardHeader className="pb-3">
         <CardTitle className="text-sm font-medium">Machine Settings Timeline</CardTitle>
+        {nights.length > 1 && (
+          <p className="text-xs text-muted-foreground">
+            {hasAnyChanges
+              ? 'Amber rows indicate nights where your machine settings changed from the previous night.'
+              : 'Your machine settings were consistent across all nights.'}
+          </p>
+        )}
       </CardHeader>
       <CardContent>
         {/* Desktop table */}
@@ -139,10 +158,14 @@ export const SettingsTimeline = memo(function SettingsTimeline({ nights, therapy
                       <span className="flex items-center gap-1.5">
                         {n.dateStr}
                         {(hasChanges || isChange) && (
-                          <AlertTriangle className="h-3 w-3 text-amber-500" aria-hidden="true" />
+                          <span data-testid="change-icon" title={getChangeTitle(hasChanges, changes)}>
+                            <AlertTriangle className="h-3 w-3 text-amber-500" aria-hidden="true" />
+                          </span>
                         )}
                         {(hasChanges || isChange) && (
-                          <span className="sr-only">Settings changed</span>
+                          <span className="text-[10px] text-amber-400">
+                            {getChangeLabel(hasChanges, changes)}
+                          </span>
                         )}
                       </span>
                     </td>
@@ -198,10 +221,9 @@ export const SettingsTimeline = memo(function SettingsTimeline({ nights, therapy
                   <span className="flex items-center gap-1.5 font-mono text-xs font-medium tabular-nums">
                     {n.dateStr}
                     {(hasChanges || isChange) && (
-                      <AlertTriangle className="h-3 w-3 text-amber-500" aria-hidden="true" />
-                    )}
-                    {(hasChanges || isChange) && (
-                      <span className="sr-only">Settings changed</span>
+                      <span data-testid="change-icon" title={getChangeTitle(hasChanges, changes)}>
+                        <AlertTriangle className="h-3 w-3 text-amber-500" aria-hidden="true" />
+                      </span>
                     )}
                   </span>
                   <span className="text-[10px] font-medium text-muted-foreground">{s.papMode}</span>
@@ -240,10 +262,10 @@ export const SettingsTimeline = memo(function SettingsTimeline({ nights, therapy
                     </span>
                   </div>
                 </div>
-                {hasChanges && (
+                {(hasChanges || isChange) && (
                   <div className="mt-2 border-t border-amber-500/20 pt-1.5">
                     <span className="text-[10px] text-amber-400">
-                      Changed: {changes.join(', ')}
+                      {getChangeLabel(hasChanges, changes)}
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
## Summary

- Desktop rows in the Machine Settings Timeline now show visible "Changed: EPAP, IPAP" text (previously only visible on mobile)
- Added subtitle below the card title explaining what amber rows mean
- Warning icons now have tooltips with change details
- Handles therapy-change-only edge case with "Therapy change reference" label

## Test plan

- [x] 6 new component tests covering subtitle, desktop change text, therapy-change-only edge case, tooltip, and mobile regression
- [ ] Manual: load demo data, check Trends tab → Machine Settings Timeline renders subtitle and change labels on desktop
- [ ] Manual: verify mobile layout unchanged (already had "Changed:" text)
- [ ] Verify amber rows with warning icon now show human-readable explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)