### PR TITLE
fix: respect contribution consent — auto-contribute silently

### DIFF
--- a/__tests__/data-contribution.test.tsx
+++ b/__tests__/data-contribution.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { NightResult } from '@/lib/types';
+
+// ── Mock localStorage + sessionStorage ──────────────────────
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+  getItem: vi.fn((key: string) => storage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => { storage.set(key, value); }),
+  removeItem: vi.fn((key: string) => { storage.delete(key); }),
+  clear: vi.fn(() => { storage.clear(); }),
+  get length() { return storage.size; },
+  key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+const sessionStore = new Map<string, string>();
+const sessionStorageMock: Storage = {
+  getItem: vi.fn((key: string) => sessionStore.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => { sessionStore.set(key, value); }),
+  removeItem: vi.fn((key: string) => { sessionStore.delete(key); }),
+  clear: vi.fn(() => { sessionStore.clear(); }),
+  get length() { return sessionStore.size; },
+  key: vi.fn((index: number) => Array.from(sessionStore.keys())[index] ?? null),
+};
+Object.defineProperty(globalThis, 'sessionStorage', { value: sessionStorageMock, writable: true });
+
+// ── Mock fetch ──────────────────────────────────────────────
+const fetchMock = vi.fn();
+globalThis.fetch = fetchMock;
+
+// ── Mock analytics ──────────────────────────────────────────
+vi.mock('@/lib/analytics', () => ({
+  events: {
+    contributionOptedIn: vi.fn(),
+    contributionDismissed: vi.fn(),
+  },
+}));
+
+// ── Mock contribute module ──────────────────────────────────
+vi.mock('@/lib/contribute', () => ({
+  contributeNights: vi.fn(() => Promise.resolve({ ok: true, totalSent: 1, contributionId: 'test' })),
+  trackContributedDates: vi.fn(),
+}));
+
+import { DataContribution } from '@/components/dashboard/data-contribution';
+
+// ── Helpers ─────────────────────────────────────────────────
+function makeNight(dateStr: string): NightResult {
+  return {
+    date: new Date(dateStr),
+    dateStr,
+    durationHours: 7,
+    sessionCount: 1,
+    settings: {
+      deviceModel: 'AirSense 10',
+      papMode: 'CPAP',
+      epap: 10,
+      ipap: 10,
+      pressureSupport: 0,
+      riseTime: 1,
+      trigger: 'Med',
+      cycle: 'Med',
+      easyBreathe: 'On',
+    },
+    glasgow: {
+      overall: 3.5,
+      skew: 0.5, spike: 0.3, flatTop: 0.4, topHeavy: 0.2,
+      multiPeak: 0.3, noPause: 0.5, inspirRate: 0.4,
+      multiBreath: 0.6, variableAmp: 0.5,
+    },
+    wat: { flScore: 45, regularityScore: 1.2, periodicityIndex: 0.05 },
+    ned: {
+      breathCount: 500, nedMean: 25, nedMedian: 22, nedP95: 55,
+      nedClearFLPct: 30, nedBorderlinePct: 20, fiMean: 0.6,
+      fiFL85Pct: 15, tpeakMean: 0.35, mShapePct: 8,
+      reraIndex: 5, reraCount: 35, h1NedMean: 28, h2NedMean: 22,
+      combinedFLPct: 50, estimatedArousalIndex: 12,
+    },
+    oximetry: null,
+  } as unknown as NightResult;
+}
+
+describe('DataContribution', () => {
+  beforeEach(() => {
+    storage.clear();
+    sessionStore.clear();
+    vi.clearAllMocks();
+    // Stats endpoint — always return 0 to avoid social proof noise in tests
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ totalContributions: 0, totalContributedNights: 0 }),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Test 1: Opted-in user with new data sees auto-confirmation, not manual button
+  it('renders auto-confirmation when opted in and autoSubmitStatus is "success"', () => {
+    storage.set('airwaylab_contribute_optin', '1');
+    storage.set('airwaylab_contributed_dates', JSON.stringify(['2025-01-01']));
+
+    const nights = [makeNight('2025-01-01'), makeNight('2025-01-02')];
+
+    render(
+      <DataContribution
+        nights={nights}
+        autoSubmitStatus="success"
+        autoSubmitCount={1}
+      />
+    );
+
+    // Should show auto-contribution success message
+    expect(screen.getByText(/1 new night contributed automatically/)).toBeInTheDocument();
+    // Should NOT show the manual contribute button
+    expect(screen.queryByRole('button', { name: /contribute.*anonymously/i })).not.toBeInTheDocument();
+  });
+
+  // Test 2: First-time / opted-out users see the manual button
+  it('renders manual button when consent is absent', () => {
+    const nights = [makeNight('2025-01-01')];
+
+    render(<DataContribution nights={nights} />);
+
+    expect(screen.getByRole('button', { name: /contribute.*anonymously/i })).toBeInTheDocument();
+  });
+
+  it('renders manual button when consent is "0"', () => {
+    storage.set('airwaylab_contribute_optin', '0');
+    storage.set('airwaylab_contributed_dates', JSON.stringify(['2025-01-01']));
+
+    const nights = [makeNight('2025-01-01'), makeNight('2025-01-02')];
+
+    render(<DataContribution nights={nights} />);
+
+    expect(screen.getByRole('button', { name: /contribute.*anonymously/i })).toBeInTheDocument();
+  });
+
+  // Test 3: Nothing renders when opted in, no new data
+  it('renders nothing when opted in, no new data, and has contributed before', () => {
+    storage.set('airwaylab_contribute_optin', '1');
+    storage.set('airwaylab_contributed_dates', JSON.stringify(['2025-01-01']));
+
+    const nights = [makeNight('2025-01-01')];
+
+    const { container } = render(
+      <DataContribution nights={nights} autoSubmitStatus="idle" />
+    );
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  // Test 6: Auto-submit error falls back to manual button for opted-in users
+  it('falls back to manual button when auto-submit fails for opted-in users', () => {
+    storage.set('airwaylab_contribute_optin', '1');
+    storage.set('airwaylab_contributed_dates', JSON.stringify(['2025-01-01']));
+
+    const nights = [makeNight('2025-01-01'), makeNight('2025-01-02')];
+
+    render(
+      <DataContribution
+        nights={nights}
+        autoSubmitStatus="error"
+        autoSubmitCount={1}
+      />
+    );
+
+    // Should show error state with retry
+    expect(screen.getByText(/auto-contribution failed/i)).toBeInTheDocument();
+  });
+
+  // Test 7: Demo mode unchanged
+  it('renders demo teaser regardless of consent state', () => {
+    storage.set('airwaylab_contribute_optin', '1');
+    const nights = [makeNight('2025-01-01')];
+
+    render(<DataContribution nights={nights} isDemo />);
+
+    expect(screen.getByText(/help build the largest pap therapy dataset/i)).toBeInTheDocument();
+  });
+
+  // Test 8: Shows "Contributing..." while in flight
+  it('shows in-flight message when autoSubmitStatus is "sending"', () => {
+    storage.set('airwaylab_contribute_optin', '1');
+    storage.set('airwaylab_contributed_dates', JSON.stringify(['2025-01-01']));
+
+    const nights = [makeNight('2025-01-01'), makeNight('2025-01-02')];
+
+    render(
+      <DataContribution
+        nights={nights}
+        autoSubmitStatus="sending"
+        autoSubmitCount={1}
+      />
+    );
+
+    expect(screen.getByText(/contributing new data/i)).toBeInTheDocument();
+  });
+
+  // Test: N nights pluralization
+  it('pluralizes correctly for multiple new nights', () => {
+    storage.set('airwaylab_contribute_optin', '1');
+    storage.set('airwaylab_contributed_dates', JSON.stringify(['2025-01-01']));
+
+    const nights = [
+      makeNight('2025-01-01'),
+      makeNight('2025-01-02'),
+      makeNight('2025-01-03'),
+    ];
+
+    render(
+      <DataContribution
+        nights={nights}
+        autoSubmitStatus="success"
+        autoSubmitCount={2}
+      />
+    );
+
+    expect(screen.getByText(/2 new nights contributed automatically/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/persistent-contribution-consent.test.ts
+++ b/__tests__/persistent-contribution-consent.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock localStorage ────────────────────────────────────────────
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+  getItem: vi.fn((key: string) => storage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => { storage.set(key, value); }),
+  removeItem: vi.fn((key: string) => { storage.delete(key); }),
+  clear: vi.fn(() => { storage.clear(); }),
+  get length() { return storage.size; },
+  key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+import { trackContributedDates } from '@/lib/contribute';
+import { getConsentState } from '@/components/upload/contribution-consent-utils';
+import type { NightResult } from '@/lib/types';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeNight(dateStr: string): NightResult {
+  return {
+    date: new Date(dateStr),
+    dateStr,
+    durationHours: 7,
+    sessionCount: 1,
+    settings: {
+      deviceModel: 'AirSense 10',
+      papMode: 'CPAP',
+      epap: 10,
+      ipap: 10,
+      pressureSupport: 0,
+    },
+    glasgow: {
+      overall: 2.5,
+      skew: 0.3,
+      spike: 0.2,
+      flatTop: 0.1,
+      topHeavy: 0.1,
+      multiPeak: 0.1,
+      noPause: 0.2,
+      inspirRate: 0.3,
+      multiBreath: 0.1,
+      variableAmp: 0.2,
+    },
+    wat: { flScore: 30, regularityScore: 75, periodicityIndex: 5 },
+    ned: {
+      nedMean: 20,
+      combinedFLPct: 25,
+      reraIndex: 3,
+      h1NedMean: 18,
+      h2NedMean: 22,
+      flatnessIndex: 0.6,
+      mShapePct: 5,
+      estimatedArousalIndex: 8,
+    },
+    oximetry: null,
+  } as unknown as NightResult;
+}
+
+/** Filters nights to only those not in contributedDates — mirrors the analyze page logic. */
+function filterNewNights(nights: NightResult[]): NightResult[] {
+  const contributedDates: string[] = JSON.parse(
+    localStorage.getItem('airwaylab_contributed_dates') || '[]'
+  );
+  const contributedSet = new Set(contributedDates);
+  return nights.filter((n) => !contributedSet.has(n.dateStr));
+}
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('persistent-contribution-consent', () => {
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+  });
+
+  // Test 1: Opted-in users see auto-confirmation, not manual button
+  describe('DataContribution consent-aware rendering', () => {
+    it('opted-in + new data → auto-confirmation path (not manual button)', () => {
+      storage.set('airwaylab_contribute_optin', '1');
+      storage.set('airwaylab_contributed_dates', JSON.stringify(['2026-01-01']));
+
+      const nights = [makeNight('2026-01-01'), makeNight('2026-01-02')];
+      const isOptedIn = getConsentState();
+      const newNights = filterNewNights(nights);
+
+      expect(isOptedIn).toBe(true);
+      expect(newNights).toHaveLength(1);
+      // When opted in + has new data → component should render auto-confirm, not manual button
+    });
+
+    // Test 2: First-time / opted-out users see manual UI
+    it('no consent stored → manual contribution button', () => {
+      expect(getConsentState()).toBe(false);
+    });
+
+    it('consent explicitly "0" → manual contribution button', () => {
+      storage.set('airwaylab_contribute_optin', '0');
+      expect(getConsentState()).toBe(false);
+    });
+
+    // Test 3: No banner when opted in + no new data + has contributed before
+    it('opted-in, no new data, contributed before → renders nothing', () => {
+      storage.set('airwaylab_contribute_optin', '1');
+      storage.set('airwaylab_contributed_dates', JSON.stringify(['2026-01-01', '2026-01-02']));
+
+      const nights = [makeNight('2026-01-01'), makeNight('2026-01-02')];
+      const newNights = filterNewNights(nights);
+      const contributedDates: string[] = JSON.parse(
+        localStorage.getItem('airwaylab_contributed_dates') || '[]'
+      );
+
+      expect(newNights).toHaveLength(0);
+      expect(contributedDates.length).toBeGreaterThan(0);
+      // Component should return null
+    });
+  });
+
+  // Test 4: Auto-submit filters nights to new only
+  describe('auto-submit filters to new nights only', () => {
+    it('filters out 58 contributed nights, sends only the 1 new night', () => {
+      const allDates = Array.from({ length: 59 }, (_, i) => {
+        const d = new Date(2026, 0, 1 + i);
+        return d.toISOString().slice(0, 10);
+      });
+      storage.set(
+        'airwaylab_contributed_dates',
+        JSON.stringify(allDates.slice(0, 58))
+      );
+
+      const allNights = allDates.map(makeNight);
+      const newNights = filterNewNights(allNights);
+
+      expect(newNights).toHaveLength(1);
+      expect(newNights[0].dateStr).toBe(allDates[58]);
+    });
+
+    it('sends all nights when none were previously contributed', () => {
+      const nights = [makeNight('2026-01-01'), makeNight('2026-01-02')];
+      const newNights = filterNewNights(nights);
+      expect(newNights).toHaveLength(2);
+    });
+  });
+
+  // Test 5: trackContributedDates is cumulative
+  describe('trackContributedDates cumulative update', () => {
+    it('updates count to 59 after adding 1 new night to 58 existing', () => {
+      const existingDates = Array.from({ length: 58 }, (_, i) => {
+        const d = new Date(2026, 0, 1 + i);
+        return d.toISOString().slice(0, 10);
+      });
+      storage.set('airwaylab_contributed_dates', JSON.stringify(existingDates));
+
+      const newNight = makeNight('2026-02-28');
+      trackContributedDates([newNight]);
+
+      const updated: string[] = JSON.parse(
+        localStorage.getItem('airwaylab_contributed_dates') || '[]'
+      );
+      expect(updated).toHaveLength(59);
+      expect(updated).toContain('2026-02-28');
+      expect(localStorage.getItem('airwaylab_contributed_nights')).toBe('59');
+    });
+  });
+
+  // Test 6: Error fallback — even opted-in users see manual button on failure
+  describe('auto-submit error fallback', () => {
+    it('error status means banner should show manual retry even for opted-in users', () => {
+      storage.set('airwaylab_contribute_optin', '1');
+      type AutoSubmitStatus = 'idle' | 'sending' | 'success' | 'error';
+      const status: AutoSubmitStatus = 'error';
+
+      // On error, the banner should fall back to manual contribution
+      // regardless of opt-in state
+      expect(status).toBe('error');
+      expect(getConsentState()).toBe(true);
+    });
+  });
+
+  // Test 7: Demo mode unchanged — teaser renders regardless of consent
+  describe('demo mode unchanged', () => {
+    it('renders teaser in demo mode regardless of consent state', () => {
+      storage.set('airwaylab_contribute_optin', '1');
+      const isDemo = true;
+      // In demo mode, the component should always show the teaser banner
+      // isDemo=true takes precedence over consent state
+      expect(isDemo).toBe(true);
+      expect(getConsentState()).toBe(true);
+    });
+  });
+
+  // Test 8: Loading state coordination
+  describe('auto-submit status coordination', () => {
+    it('status transitions: idle → sending → success', () => {
+      type AutoSubmitStatus = 'idle' | 'sending' | 'success' | 'error';
+      let status: AutoSubmitStatus = 'idle';
+
+      status = 'sending';
+      expect(status).toBe('sending');
+      // Banner should show "Contributing new data..."
+
+      status = 'success';
+      expect(status).toBe('success');
+      // Banner should show "N new nights contributed automatically — thank you"
+    });
+
+    it('status transitions: idle → sending → error', () => {
+      type AutoSubmitStatus = 'idle' | 'sending' | 'success' | 'error';
+      let status: AutoSubmitStatus = 'idle';
+
+      status = 'sending';
+      status = 'error';
+      expect(status).toBe('error');
+      // Banner should fall back to manual button with retry
+    });
+  });
+});

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -10,7 +10,7 @@ import { ErrorDataSubmission } from '@/components/upload/error-data-submission';
 import { StorageConsent } from '@/components/upload/storage-consent';
 import { StorageProgressBanner } from '@/components/upload/storage-progress-banner';
 import { uploadOrchestrator } from '@/lib/storage/upload-orchestrator';
-import { DataContribution } from '@/components/dashboard/data-contribution';
+import { DataContribution, type AutoSubmitStatus } from '@/components/dashboard/data-contribution';
 import { NightSelector } from '@/components/common/night-selector';
 import { ExportButtons } from '@/components/dashboard/export-buttons';
 import { EmailOptIn } from '@/components/common/email-opt-in';
@@ -91,6 +91,8 @@ function AnalyzePageInner() {
   const [oximetryJustAdded, setOximetryJustAdded] = useState(false);
   const hadOximetryRef = useRef(false);
   const [showContributeNudge, setShowContributeNudge] = useState(false);
+  const [autoSubmitStatus, setAutoSubmitStatus] = useState<AutoSubmitStatus>('idle');
+  const [autoSubmitCount, setAutoSubmitCount] = useState(0);
   const pendingNightsRef = useRef<NightResult[]>([]);
   const [showDemoStar, setShowDemoStar] = useState(false);
   const demoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -190,17 +192,16 @@ function AnalyzePageInner() {
           localStorage.getItem('airwaylab_contributed_dates') || '[]'
         );
         const contributedSet = new Set(contributedDates);
-        const hasNewData = newState.nights.some((n) => !contributedSet.has(n.dateStr));
+        const newNights = newState.nights.filter((n) => !contributedSet.has(n.dateStr));
 
-        if (contributeOptInRef.current && hasNewData) {
-          submitContribution(newState.nights);
+        if (contributeOptInRef.current && newNights.length > 0) {
+          setAutoSubmitCount(newNights.length);
+          submitContribution(newNights);
         } else if (!contributeOptInRef.current && contributedDates.length === 0) {
           // Only show nudge if user has never contributed before
           pendingNightsRef.current = newState.nights;
           setShowContributeNudge(true);
         }
-        // If user already opted in and no new data, or already contributed,
-        // the DataContribution banner handles re-contribution offers
 
         // Cloud storage: auto-upload raw files if consented
         if (storageConsentRef.current && sdFilesRef.current.length > 0) {
@@ -261,9 +262,15 @@ function AnalyzePageInner() {
   );
 
   const submitContribution = useCallback((nightsToSubmit: NightResult[]) => {
+    setAutoSubmitStatus('sending');
     contributeNights(nightsToSubmit)
-      .then(() => trackContributedDates(nightsToSubmit))
-      .catch(() => { /* non-critical */ });
+      .then(() => {
+        trackContributedDates(nightsToSubmit);
+        setAutoSubmitStatus('success');
+      })
+      .catch(() => {
+        setAutoSubmitStatus('error');
+      });
   }, []);
 
   const handleNudgeContribute = useCallback(() => {
@@ -554,7 +561,12 @@ function AnalyzePageInner() {
           <StorageProgressBanner />
 
           {/* Data Contribution — prominent placement at top of dashboard */}
-          <DataContribution nights={nights} isDemo={isDemo} />
+          <DataContribution
+            nights={nights}
+            isDemo={isDemo}
+            autoSubmitStatus={autoSubmitStatus}
+            autoSubmitCount={autoSubmitCount}
+          />
 
           {/* Controls Bar */}
           <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-4">

--- a/components/dashboard/data-contribution.tsx
+++ b/components/dashboard/data-contribution.tsx
@@ -1,26 +1,40 @@
 'use client';
 
 import { useState, useCallback, useEffect } from 'react';
-import { Users, Loader2, X, Shield, Heart } from 'lucide-react';
+import { Users, Loader2, X, Shield, Heart, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { events } from '@/lib/analytics';
 import { contributeNights, trackContributedDates } from '@/lib/contribute';
+import { getConsentState } from '@/components/upload/contribution-consent-utils';
 import type { NightResult } from '@/lib/types';
 
 const DISMISS_KEY = 'airwaylab_contribute_dismissed';
 
+export type AutoSubmitStatus = 'idle' | 'sending' | 'success' | 'error';
+
 interface Props {
   nights: NightResult[];
   isDemo?: boolean;
+  /** Status of auto-contribution triggered by analyze/page.tsx for opted-in users */
+  autoSubmitStatus?: AutoSubmitStatus;
+  /** Number of new nights sent by auto-submit (for display) */
+  autoSubmitCount?: number;
 }
 
 /**
  * Opt-in anonymous data contribution banner.
  * Shown after analysis completes. Dismissible, remembers choice.
- * Tracks how many nights were previously contributed so users
- * can contribute again when they upload new data.
+ *
+ * For opted-in users (airwaylab_contribute_optin === '1'), the banner
+ * shows auto-contribution status instead of a manual submit button.
+ * The manual UI is only shown for users who haven't opted in.
  */
-export function DataContribution({ nights, isDemo = false }: Props) {
+export function DataContribution({
+  nights,
+  isDemo = false,
+  autoSubmitStatus = 'idle',
+  autoSubmitCount = 0,
+}: Props) {
   const [dismissed, setDismissed] = useState(() => {
     if (typeof window === 'undefined') return false;
     try {
@@ -28,6 +42,12 @@ export function DataContribution({ nights, isDemo = false }: Props) {
     } catch {
       return false;
     }
+  });
+
+  // Check persistent consent state
+  const [isOptedIn] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return getConsentState();
   });
 
   // Track which nights were previously contributed (date-based dedup)
@@ -80,7 +100,10 @@ export function DataContribution({ nights, isDemo = false }: Props) {
   const hasNewData = nights.some((n) => !contributedSet.has(n.dateStr));
 
   // Don't show if dismissed this session, or if no new data to contribute (for real uploads)
-  if (dismissed || (!isDemo && !hasNewData && contributedNightCount > 0)) return null;
+  if (dismissed || (!isDemo && !hasNewData && contributedNightCount > 0)) {
+    // Exception: opted-in users still see the auto-contribution status if in-flight or just succeeded
+    if (!isOptedIn || autoSubmitStatus === 'idle') return null;
+  }
 
   // Demo mode — show teaser encouraging real upload
   if (isDemo) {
@@ -106,7 +129,75 @@ export function DataContribution({ nights, isDemo = false }: Props) {
     );
   }
 
-  // Success state
+  // ── Opted-in path: show auto-contribution status ──────────
+  if (isOptedIn) {
+    // Auto-submit in flight
+    if (autoSubmitStatus === 'sending') {
+      return (
+        <div aria-live="polite" className="rounded-lg border border-primary/10 bg-primary/[0.02] px-4 py-3 animate-fade-in-up">
+          <div className="flex items-center gap-2.5">
+            <Loader2 className="h-4 w-4 animate-spin text-primary/60" />
+            <p className="text-sm text-muted-foreground">
+              Contributing new data...
+            </p>
+          </div>
+        </div>
+      );
+    }
+
+    // Auto-submit succeeded
+    if (autoSubmitStatus === 'success') {
+      return (
+        <div aria-live="polite" className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-4 py-3 animate-fade-in-up">
+          <div className="flex items-center gap-2.5">
+            <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+            <p className="text-sm text-muted-foreground">
+              {autoSubmitCount === 1
+                ? '1 new night contributed automatically'
+                : `${autoSubmitCount} new nights contributed automatically`}
+              {' '}&mdash; thank you
+            </p>
+          </div>
+        </div>
+      );
+    }
+
+    // Auto-submit failed — fall back to manual retry
+    if (autoSubmitStatus === 'error') {
+      return (
+        <div aria-live="polite" className="rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3 animate-fade-in-up">
+          <div className="flex items-center gap-2.5">
+            <Heart className="h-4 w-4 text-red-400" />
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-sm text-muted-foreground">
+                Auto-contribution failed.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-6 text-xs"
+                onClick={handleContribute}
+                disabled={status === 'sending'}
+              >
+                {status === 'sending' ? (
+                  <><Loader2 className="h-3 w-3 animate-spin mr-1" /> Retrying...</>
+                ) : (
+                  'Tap to retry'
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Auto-submit idle + no new data → don't show anything
+    return null;
+  }
+
+  // ── Not opted-in path: manual contribution UI ─────────────
+
+  // Success state (from manual contribution)
   if (status === 'success') {
     return (
       <div aria-live="polite" className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-4 py-3 animate-fade-in-up">


### PR DESCRIPTION
## Summary

- **DataContribution banner now checks `airwaylab_contribute_optin`** — opted-in users see quiet auto-contribution status (sending/success/error) instead of the manual "Contribute your new data" banner
- **Auto-submit sends only new nights** — filters through `contributedDates` before calling `contributeNights()`, preventing duplicate rows in `data_contributions`
- **Error fallback** — if auto-contribution fails, opted-in users see a manual retry button

## Test plan

- [ ] Upload SD card as returning contributor with consent stored (`airwaylab_contribute_optin = '1'`) → should see "Contributing new data..." then "N new nights contributed automatically — thank you"
- [ ] Upload SD card without consent stored → should see standard manual "Contribute N nights anonymously" button (unchanged)
- [ ] Upload same SD card twice with consent → second upload shows no banner (no new data)
- [ ] Demo mode → shows teaser banner regardless of consent state
- [ ] Verify network tab: only new nights are sent to `/api/contribute-data`, not the full dataset
- [ ] All 307 tests pass, TypeScript clean, production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)