### PR TITLE
feat: auto-fix Sentry errors via Claude Code PR pipeline

### DIFF
--- a/.github/prompts/fix-sentry-error.md
+++ b/.github/prompts/fix-sentry-error.md
@@ -1,0 +1,103 @@
+You are an automated bug fixer for AirwayLab (airwaylab.app), a Next.js 14 sleep/airway analysis tool.
+
+## Your task
+
+A production error was detected by Sentry and filed as a GitHub issue. Read the issue body for the error message, stack trace, affected URL, and browser/OS context. Your job is to:
+
+1. Identify the affected file(s) from the stack trace
+2. Read and understand the relevant code and its surrounding context
+3. Determine the root cause
+4. Implement a minimal, focused fix
+5. Verify the fix compiles and builds
+
+## Project context
+
+- **Stack:** Next.js 14 (App Router), TypeScript strict, Tailwind CSS, Supabase, Vercel
+- **No `src/` directory.** Top-level: `app/`, `components/`, `lib/`, `workers/`, `hooks/`
+- **Dark-only theme.** shadcn/ui with @base-ui/react primitives.
+- **Privacy-first.** Core analysis runs in-browser via Web Workers. Server features are opt-in.
+
+## Constraints
+
+### Protected modules — NEVER modify
+
+These contain clinically validated algorithms. Do not change any logic in:
+
+- `lib/parsers/` — data parsing engine
+- `lib/analyzers/` — analysis engine
+- `workers/` — web workers
+
+If the error originates in a protected module, **do not attempt a fix**. Instead:
+1. Comment on the issue with your root cause analysis
+2. Apply the `needs-human` label
+3. Stop — do not open a PR
+
+### Code standards
+
+- TypeScript strict — no `any`, no `@ts-ignore`
+- Follow existing patterns in the codebase (read CLAUDE.md for details)
+- Keep changes minimal — fix the bug, don't refactor surrounding code
+- No new dependencies
+- No `console.log` — use `console.error` with structured context if needed
+- Zod for any external data validation
+- Error messages must be user-friendly, never raw error strings
+
+### Verification
+
+Before committing, you MUST run both of these and they MUST pass:
+
+```bash
+npx tsc --noEmit
+npm run build
+```
+
+If either fails after your fix, iterate up to 3 times. If you still can't get a clean build, comment on the issue with your analysis and apply the `needs-human` label instead of opening a broken PR.
+
+### Branch and PR
+
+- Create branch: `fix/sentry-{issue-number}`
+- Commit message: `fix: [Sentry #{issue-number}] {brief description}`
+- PR title: same as commit message
+- PR body format:
+
+```markdown
+## Sentry Error Fix
+
+Automatically generated fix for the linked Sentry error.
+
+## What went wrong
+
+[Describe the root cause]
+
+## What this changes
+
+[Describe the fix — which files, what was changed, why]
+
+## Verification
+
+- [x] `npx tsc --noEmit` passes
+- [x] `npm run build` passes
+
+Fixes #{issue-number}
+```
+
+- Add label `auto-fix` to the PR
+
+### If you cannot fix the error
+
+Do NOT open a PR with a partial or uncertain fix. Instead:
+
+1. Comment on the issue:
+
+```
+I analysed this error but couldn't produce a clean fix automatically.
+
+**Root cause hypothesis:** [your analysis]
+**Affected files:** [list of files involved]
+**Suggested investigation:** [steps a human developer should take]
+
+Labelling as `needs-human` for manual review.
+```
+
+2. Apply the `needs-human` label
+3. Stop

--- a/.github/workflows/auto-fix-error.yml
+++ b/.github/workflows/auto-fix-error.yml
@@ -1,0 +1,80 @@
+name: Auto-fix Sentry Error
+
+on:
+  issues:
+    types: [opened, labeled]
+
+concurrency:
+  group: auto-fix
+  cancel-in-progress: false
+
+jobs:
+  auto-fix:
+    # Only run for sentry-labelled issues, not opened by this workflow
+    if: |
+      contains(github.event.issue.labels.*.name, 'sentry') &&
+      github.event.issue.user.login != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for existing fix branch
+        id: check-branch
+        run: |
+          BRANCH="fix/sentry-${{ github.event.issue.number }}"
+          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if fix already in progress
+        if: steps.check-branch.outputs.exists == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'A fix branch already exists for this issue (`fix/sentry-${{ github.event.issue.number }}`). Skipping auto-fix.'
+            });
+
+      - name: Check daily run count
+        if: steps.check-branch.outputs.exists == 'false'
+        id: rate-limit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'auto-fix-error.yml',
+              created: `>=${new Date(Date.now() - 86400000).toISOString().split('T')[0]}`,
+              status: 'completed',
+            });
+            const count = runs.data.total_count;
+            core.setOutput('exceeded', count >= 5 ? 'true' : 'false');
+            if (count >= 5) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: 'Daily auto-fix limit reached (5/day). This issue will need manual review.'
+              });
+            }
+
+      - name: Run Claude Code
+        if: |
+          steps.check-branch.outputs.exists == 'false' &&
+          steps.rate-limit.outputs.exceeded == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-sonnet-4-6
+          prompt_file: .github/prompts/fix-sentry-error.md
+          issue_number: ${{ github.event.issue.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Demo exit preserves data**: Exiting demo mode no longer clears previously persisted real analysis data (`onboarding-audit-v2`)
 - **Restored contribution nudge dialog**: Re-added accidentally deleted `contribution-nudge-dialog.tsx` component
 
+## [Unreleased] — Auto-fix Sentry Errors (2026-03-11)
+
+### Added
+
+- **Auto-fix Sentry errors**: GitHub Actions workflow that triggers on Sentry-labelled issues, runs Claude Code (Sonnet) to analyse and fix the error, and opens a PR for review. Includes branch deduplication, daily rate limit (5/day), and protected module guards. (`auto-fix-sentry-errors`)
+
 ## [Unreleased] — Share Link MVP & Providers Page (2026-03-11)
 
 ### Added


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow (`.github/workflows/auto-fix-error.yml`) that triggers on Sentry-labelled GitHub issues
- Add Claude Code prompt template (`.github/prompts/fix-sentry-error.md`) with project constraints and fix instructions
- Pipeline: Sentry alert → GitHub issue → workflow → Claude Code (Sonnet) → fix branch + PR for human review

## Guardrails

- **Branch dedup:** Skips if `fix/sentry-{N}` branch already exists
- **Rate limit:** Max 5 auto-fix runs per day
- **Protected modules:** Claude Code is instructed to never modify `lib/parsers/`, `lib/analyzers/`, `workers/`
- **Bot-loop prevention:** Ignores issues opened by `github-actions[bot]`
- **Verification:** Claude Code must pass `tsc --noEmit` + `npm run build` before opening a PR
- **Fallback:** If it can't fix the error, it comments with analysis and applies `needs-human` label

## Files Changed

- `.github/workflows/auto-fix-error.yml` — new workflow
- `.github/prompts/fix-sentry-error.md` — new prompt template
- `CHANGELOG.md` — added entry

## Setup required after merge

1. **Sentry alert rules** (airwaylab.sentry.io → Alerts):
   - Rule 1: "A new issue is created" → create GitHub issue with `sentry` label
   - Rule 2: "Issue reappears after 24h inactivity" → create GitHub issue with `sentry` label
2. **GitHub Actions secret**: Add `ANTHROPIC_API_KEY` to repo secrets
3. **GitHub labels**: Create `sentry`, `needs-human`, `auto-fix` labels

## Test plan

- [ ] Verify workflow YAML is valid (CI will check syntax)
- [ ] After merge + setup: create a test issue with `sentry` label and confirm workflow triggers
- [ ] Verify rate limit logic by checking `actions/github-script` step output
- [ ] Verify branch dedup by creating a second issue for the same branch name

🤖 Generated with [Claude Code](https://claude.com/claude-code)