### PR TITLE
feat(onboarding): landing page reorder, dashboard hierarchy, mobile UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to AirwayLab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — Onboarding Audit v2 (2026-03-11)
+
+### Changed
+
+- **Landing page reorder**: "How It Works" section now appears directly after the Trust Bar, before narrative sections (Mission, Vision), reducing scroll-to-conversion distance (`onboarding-audit-v2`)
+- **Overview tab hierarchy**: NextSteps CTA moved below the primary metrics grid and Glasgow breakdown — users see data before advice (`onboarding-audit-v2`)
+- **Dashboard density for new users**: SharePrompts and NightHeatmap hidden for first 5 sessions to reduce information overload (`onboarding-audit-v2`)
+- **Demo banner context**: Demo mode now explains the sample clinical scenario (BiPAP ST user, settings change on Jan 14) to help users interpret the data (`onboarding-audit-v2`)
+- **Upload screen simplified**: Removed StorageConsent and ContributionOptIn from upload idle screen; StorageConsent moved to post-analysis dashboard (`onboarding-audit-v2`)
+
+### Added
+
+- **Mobile upload warning**: `/analyze` page now shows a mobile-only banner suggesting the demo when SD card upload isn't practical (`onboarding-audit-v2`)
+- **Community links in NextSteps**: "Share your results" step now includes clickable links to r/SleepApnea and ApneaBoard (`onboarding-audit-v2`)
+
+### Fixed
+
+- **Demo exit preserves data**: Exiting demo mode no longer clears previously persisted real analysis data (`onboarding-audit-v2`)
+- **Restored contribution nudge dialog**: Re-added accidentally deleted `contribution-nudge-dialog.tsx` component
+
 ## [Unreleased] — Share Link MVP & Providers Page (2026-03-11)
 
 ### Added

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -4,7 +4,6 @@ import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { useSearchParams } from 'next/navigation';
 import { FileUpload } from '@/components/upload/file-upload';
 import { ProgressDisplay } from '@/components/upload/progress-display';
-import { ContributionOptIn } from '@/components/upload/contribution-opt-in';
 import { ContributionNudgeDialog } from '@/components/upload/contribution-nudge-dialog';
 import { ErrorDataSubmission } from '@/components/upload/error-data-submission';
 import { StorageConsent } from '@/components/upload/storage-consent';
@@ -308,12 +307,22 @@ function AnalyzePageInner() {
         }
       } catch { /* noop */ }
     }
+
+    const wasDemo = isDemo;
     setIsDemo(false);
     orchestrator.reset();
     setSelectedNight(0);
-    setPersistedData(null);
-    clearPersistedResults();
-    clearManifest();
+
+    if (wasDemo) {
+      // Exiting demo: restore previously persisted data if it exists
+      const saved = loadPersistedResults();
+      setPersistedData(saved);
+    } else {
+      // Resetting real analysis: clear persisted data
+      setPersistedData(null);
+      clearPersistedResults();
+      clearManifest();
+    }
   }, [isDemo]);
 
   const { status, progress, error, warning } = state;
@@ -419,6 +428,21 @@ function AnalyzePageInner() {
       {/* Upload State */}
       {status === 'idle' && !isDemo && (
         <div className="mx-auto max-w-lg">
+          {/* Mobile upload warning */}
+          <div className="mb-4 flex items-start gap-2.5 rounded-lg border border-amber-500/20 bg-amber-500/5 px-4 py-3 sm:hidden">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+            <div className="text-xs text-muted-foreground">
+              <p>SD card upload works best on a desktop computer.</p>
+              <button
+                type="button"
+                onClick={loadDemo}
+                className="mt-1 font-medium text-primary hover:underline"
+              >
+                Try the demo to see what AirwayLab can do &rarr;
+              </button>
+            </div>
+          </div>
+
           <FileUpload onFilesSelected={handleFiles} />
 
           {/* Demo CTA — shown immediately after upload for discoverability */}
@@ -440,16 +464,6 @@ function AnalyzePageInner() {
             <p className="text-[11px] text-muted-foreground/50">
               See what AirwayLab looks like with 5 nights of example data
             </p>
-          </div>
-
-          {/* Cloud storage consent — shown for eligible users */}
-          <div className="mt-4">
-            <StorageConsent onChange={(v) => { storageConsentRef.current = v; }} />
-          </div>
-
-          {/* Data contribution opt-in — shown during upload for higher conversion */}
-          <div className="mt-4">
-            <ContributionOptIn onChange={(v) => { contributeOptInRef.current = v; }} />
           </div>
         </div>
       )}
@@ -506,14 +520,21 @@ function AnalyzePageInner() {
         <div className="flex flex-col gap-6 animate-fade-in-up">
           {/* Demo Banner */}
           {isDemo && (
-            <div className="flex flex-col gap-3 rounded-xl border border-primary/20 bg-primary/5 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">Demo mode</span>{' '}
-                — viewing sample data. Upload your own SD card to analyze your therapy.
+            <div className="flex flex-col gap-3 rounded-xl border border-primary/20 bg-primary/5 px-4 py-3">
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm text-muted-foreground">
+                  <span className="font-medium text-foreground">Demo mode</span>{' '}
+                  — viewing sample data. Upload your own SD card to analyze your therapy.
+                </p>
+                <Button variant="outline" size="sm" onClick={handleReset} className="gap-1.5 self-start sm:self-auto">
+                  <Upload className="h-3 w-3" /> Upload Your Data
+                </Button>
+              </div>
+              {/* Sample data context — update if lib/sample-data.ts changes */}
+              <p className="text-xs text-muted-foreground/70">
+                Sample scenario: BiPAP ST user with moderate flow limitation across 5 nights.
+                Settings were adjusted (EPAP 8&rarr;10, IPAP 14&rarr;16) on Jan 14 &mdash; compare nights before and after to see the effect.
               </p>
-              <Button variant="outline" size="sm" onClick={handleReset} className="gap-1.5 self-start sm:self-auto">
-                <Upload className="h-3 w-3" /> Upload Your Data
-              </Button>
             </div>
           )}
 
@@ -599,6 +620,11 @@ function AnalyzePageInner() {
               </Button>
             </div>
           </div>
+
+          {/* Cloud storage consent — shown post-analysis for non-demo users */}
+          {!isDemo && (
+            <StorageConsent onChange={(v) => { storageConsentRef.current = v; }} />
+          )}
 
           {/* Tabbed Views */}
           <Tabs defaultValue="overview" onValueChange={(tab) => events.tabViewed(tab)}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -301,6 +301,117 @@ export default function Home() {
         </div>
       </section>
 
+      {/* ─── How It Works ─── */}
+      <section className="border-y border-border/50 bg-card/20 py-12 sm:py-16">
+        <div className="container mx-auto px-4 sm:px-6">
+          <div className="mb-8 sm:mb-12">
+            <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
+              How It Works
+            </h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              From SD card to actionable insights in seconds
+            </p>
+          </div>
+          <div className="mx-auto grid max-w-4xl gap-0 sm:grid-cols-3">
+            {steps.map((s, i) => (
+              <div key={s.num} className="relative flex gap-4 pb-8 sm:flex-col sm:items-center sm:pb-0 sm:text-center">
+                {/* Connector line */}
+                {i < steps.length - 1 && (
+                  <>
+                    <div className="absolute left-5 top-12 hidden h-[1px] w-[calc(100%-40px)] bg-border/50 sm:block" style={{ left: 'calc(50% + 24px)' }} />
+                    <div className="absolute left-5 top-12 h-[calc(100%-48px)] w-[1px] bg-border/50 sm:hidden" />
+                  </>
+                )}
+                <div className="relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-primary/30 bg-card font-mono text-xs font-bold text-primary sm:mb-4 sm:h-12 sm:w-12 sm:text-sm">
+                  {s.num}
+                </div>
+                <div>
+                  <h3 className="mb-1 text-sm font-semibold">{s.title}</h3>
+                  <p className="text-xs leading-relaxed text-muted-foreground">{s.desc}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* What You'll Need */}
+          <div className="mx-auto mt-10 max-w-4xl rounded-xl border border-border/50 bg-card/50 p-5 sm:mt-14 sm:p-6">
+            <h3 className="mb-3 text-sm font-semibold">What You&apos;ll Need</h3>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="flex items-start gap-3">
+                <HardDrive className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                <div>
+                  <p className="text-xs font-medium">ResMed SD Card</p>
+                  <p className="text-[11px] text-muted-foreground">
+                    AirSense 10/11 or AirCurve 10 with DATALOG folder. Select the entire SD card or just the DATALOG directory.
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3">
+                <Stethoscope className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Pulse Oximetry CSV <span className="text-[10px]">(optional)</span>
+                  </p>
+                  <p className="text-[11px] text-muted-foreground">
+                    Viatom/Checkme O2 Max CSV for SpO₂, heart rate surges, and coupled cardio-respiratory analysis.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <p className="mt-4 text-center text-xs text-muted-foreground">
+              Use alongside{' '}
+              <a
+                href="https://www.sleepfiles.com/OSCAR/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline decoration-muted-foreground/50 underline-offset-2 transition-colors hover:text-foreground"
+              >
+                OSCAR
+              </a>{' '}
+              for automated scoring and a different lens on your therapy data.
+            </p>
+          </div>
+
+          {/* For Providers */}
+          <div className="mx-auto mt-6 max-w-4xl rounded-xl border border-primary/20 bg-primary/5 p-5 sm:p-6">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-primary/10 p-2">
+                <Stethoscope className="h-4 w-4 text-primary" />
+              </div>
+              <div>
+                <h3 className="text-sm font-semibold">Sleep consultant or clinician?</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Your patients share a link, you see the full analysis. No software installs, no file transfers.
+                </p>
+              </div>
+            </div>
+            <Link
+              href="/providers"
+              className="mt-3 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+            >
+              See how AirwayLab fits your workflow <ArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
+
+          {/* Not on PAP yet? */}
+          <div className="mx-auto mt-6 max-w-4xl rounded-xl border border-border/50 bg-card/30 p-5 sm:p-6">
+            <h3 className="text-sm font-semibold">Not on PAP therapy yet?</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              AirwayLab requires PAP flow data from a ResMed SD card.
+              If you suspect sleep-disordered breathing but aren&apos;t yet diagnosed,
+              talk to your doctor about a sleep study. Our blog has resources
+              to help you understand what to ask for.
+            </p>
+            <Link
+              href="/blog"
+              className="mt-2 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+            >
+              Read the blog <ArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
+        </div>
+      </section>
+
       {/* ─── Mission ─── */}
       <section className="container mx-auto px-4 py-14 sm:px-6 sm:py-20">
         <div className="mb-8 sm:mb-12">
@@ -581,117 +692,6 @@ export default function Home() {
               Try the interactive demo
             </Button>
           </Link>
-        </div>
-      </section>
-
-      {/* ─── How It Works ─── */}
-      <section className="border-y border-border/50 bg-card/20 py-12 sm:py-16">
-        <div className="container mx-auto px-4 sm:px-6">
-          <div className="mb-8 sm:mb-12">
-            <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
-              How It Works
-            </h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              From SD card to actionable insights in seconds
-            </p>
-          </div>
-          <div className="mx-auto grid max-w-4xl gap-0 sm:grid-cols-3">
-            {steps.map((s, i) => (
-              <div key={s.num} className="relative flex gap-4 pb-8 sm:flex-col sm:items-center sm:pb-0 sm:text-center">
-                {/* Connector line */}
-                {i < steps.length - 1 && (
-                  <>
-                    <div className="absolute left-5 top-12 hidden h-[1px] w-[calc(100%-40px)] bg-border/50 sm:block" style={{ left: 'calc(50% + 24px)' }} />
-                    <div className="absolute left-5 top-12 h-[calc(100%-48px)] w-[1px] bg-border/50 sm:hidden" />
-                  </>
-                )}
-                <div className="relative z-10 flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-primary/30 bg-card font-mono text-xs font-bold text-primary sm:mb-4 sm:h-12 sm:w-12 sm:text-sm">
-                  {s.num}
-                </div>
-                <div>
-                  <h3 className="mb-1 text-sm font-semibold">{s.title}</h3>
-                  <p className="text-xs leading-relaxed text-muted-foreground">{s.desc}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {/* What You'll Need */}
-          <div className="mx-auto mt-10 max-w-4xl rounded-xl border border-border/50 bg-card/50 p-5 sm:mt-14 sm:p-6">
-            <h3 className="mb-3 text-sm font-semibold">What You&apos;ll Need</h3>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="flex items-start gap-3">
-                <HardDrive className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                <div>
-                  <p className="text-xs font-medium">ResMed SD Card</p>
-                  <p className="text-[11px] text-muted-foreground">
-                    AirSense 10/11 or AirCurve 10 with DATALOG folder. Select the entire SD card or just the DATALOG directory.
-                  </p>
-                </div>
-              </div>
-              <div className="flex items-start gap-3">
-                <Stethoscope className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground">
-                    Pulse Oximetry CSV <span className="text-[10px]">(optional)</span>
-                  </p>
-                  <p className="text-[11px] text-muted-foreground">
-                    Viatom/Checkme O2 Max CSV for SpO₂, heart rate surges, and coupled cardio-respiratory analysis.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <p className="mt-4 text-center text-xs text-muted-foreground">
-              Use alongside{' '}
-              <a
-                href="https://www.sleepfiles.com/OSCAR/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline decoration-muted-foreground/50 underline-offset-2 transition-colors hover:text-foreground"
-              >
-                OSCAR
-              </a>{' '}
-              for automated scoring and a different lens on your therapy data.
-            </p>
-          </div>
-
-          {/* For Providers */}
-          <div className="mx-auto mt-6 max-w-4xl rounded-xl border border-primary/20 bg-primary/5 p-5 sm:p-6">
-            <div className="flex items-center gap-3">
-              <div className="rounded-lg bg-primary/10 p-2">
-                <Stethoscope className="h-4 w-4 text-primary" />
-              </div>
-              <div>
-                <h3 className="text-sm font-semibold">Sleep consultant or clinician?</h3>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Your patients share a link, you see the full analysis. No software installs, no file transfers.
-                </p>
-              </div>
-            </div>
-            <Link
-              href="/providers"
-              className="mt-3 inline-flex items-center gap-1 text-xs text-primary hover:underline"
-            >
-              See how AirwayLab fits your workflow <ArrowRight className="h-3 w-3" />
-            </Link>
-          </div>
-
-          {/* Not on PAP yet? */}
-          <div className="mx-auto mt-6 max-w-4xl rounded-xl border border-border/50 bg-card/30 p-5 sm:p-6">
-            <h3 className="text-sm font-semibold">Not on PAP therapy yet?</h3>
-            <p className="mt-1 text-xs text-muted-foreground">
-              AirwayLab requires PAP flow data from a ResMed SD card.
-              If you suspect sleep-disordered breathing but aren&apos;t yet diagnosed,
-              talk to your doctor about a sleep study. Our blog has resources
-              to help you understand what to ask for.
-            </p>
-            <Link
-              href="/blog"
-              className="mt-2 inline-flex items-center gap-1 text-xs text-primary hover:underline"
-            >
-              Read the blog <ArrowRight className="h-3 w-3" />
-            </Link>
-          </div>
         </div>
       </section>
 

--- a/components/dashboard/next-steps.tsx
+++ b/components/dashboard/next-steps.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import Link from 'next/link';
 import { Lightbulb, ArrowRight } from 'lucide-react';
 import type { NightResult } from '@/lib/types';
@@ -16,6 +17,7 @@ interface Props {
 
 interface Step {
   text: string;
+  richText?: ReactNode;
   link?: { href: string; label: string };
   onClick?: () => void;
   actionLabel?: string;
@@ -64,6 +66,29 @@ export function NextSteps({ selectedNight, hasOximetry, nightCount, onUploadOxim
 
   steps.push({
     text: 'Share your results on r/SleepApnea or ApneaBoard for community feedback.',
+    richText: (
+      <>
+        Share your results on{' '}
+        <a
+          href="https://reddit.com/r/SleepApnea"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-primary hover:underline"
+        >
+          r/SleepApnea
+        </a>
+        {' '}or{' '}
+        <a
+          href="https://www.apneaboard.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-primary hover:underline"
+        >
+          ApneaBoard
+        </a>
+        {' '}for community feedback.
+      </>
+    ),
   });
 
   const shown = steps.slice(0, 3);
@@ -81,7 +106,7 @@ export function NextSteps({ selectedNight, hasOximetry, nightCount, onUploadOxim
               {i + 1}
             </span>
             <span>
-              {step.text}
+              {step.richText ?? step.text}
               {step.link && (
                 <Link
                   href={step.link.href}

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -234,15 +234,6 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         </div>
       )}
 
-      {/* Next Steps CTA */}
-      <NextSteps
-        selectedNight={n}
-        hasOximetry={!!n.oximetry}
-        nightCount={nights.length}
-        onUploadOximetry={onUploadOximetry}
-        onReUpload={onReUpload}
-      />
-
       {/* Device Settings & Session Info */}
       <Card className="border-border/50">
         <CardHeader className="pb-2">
@@ -403,6 +394,15 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         </div>
       </details>
 
+      {/* Next Steps CTA */}
+      <NextSteps
+        selectedNight={n}
+        hasOximetry={!!n.oximetry}
+        nightCount={nights.length}
+        onUploadOximetry={onUploadOximetry}
+        onReUpload={onReUpload}
+      />
+
       {/* Secondary Metrics */}
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4 stagger-children">
         <MetricCard
@@ -551,11 +551,13 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         );
       })()}
 
-      {/* Share Prompts (real data only) */}
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={isDemo} />
+      {/* Share Prompts (real data only, hidden for new users to reduce density) */}
+      {!isNewUser && (
+        <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={isDemo} />
+      )}
 
-      {/* Heatmap */}
-      {nights.length > 1 && (
+      {/* Heatmap (hidden for new users to reduce density) */}
+      {nights.length > 1 && !isNewUser && (
         <NightHeatmap nights={nights} therapyChangeDate={therapyChangeDate} />
       )}
 


### PR DESCRIPTION
## Summary

- **Landing page reorder**: "How It Works" section moved above narrative sections (Mission, Vision) to reduce scroll-to-conversion distance — targeting the 50% bounce rate
- **Dashboard hierarchy**: NextSteps CTA moved below metrics grid so users see data before advice; SharePrompts and NightHeatmap hidden for first 5 sessions
- **Mobile UX**: Warning banner on `/analyze` suggesting demo mode when SD card upload isn't practical
- **Upload simplified**: Consent dialogs removed from upload screen, StorageConsent moved to post-analysis
- **Demo improvements**: Clinical scenario context in demo banner; exiting demo no longer destroys persisted real data
- **Community links**: NextSteps now includes clickable links to r/SleepApnea and ApneaBoard

## Files Changed
- `app/page.tsx` — Landing page section reorder
- `app/analyze/page.tsx` — Mobile banner, consent move, demo banner + exit fix
- `components/dashboard/overview-tab.tsx` — NextSteps position, new-user density
- `components/dashboard/next-steps.tsx` — Community links via `richText` field
- `CHANGELOG.md` — Updated

## Test plan
- [ ] Landing page: verify "How It Works" appears before "Why We Built This"
- [ ] Overview tab: verify NextSteps appears after Glasgow breakdown, before secondary metrics
- [ ] Mobile: verify warning banner on `/analyze` (resize browser < 640px)
- [ ] Demo: verify context banner mentions "BiPAP ST" and settings change
- [ ] Demo exit: load demo → exit → verify persisted data is not cleared
- [ ] New user: clear `airwaylab_session_count` → verify SharePrompts and Heatmap are hidden
- [ ] Community links: verify r/SleepApnea and ApneaBoard links open in new tab
- [ ] Upload screen: verify no StorageConsent or ContributionOptIn visible

Spec: `specs/onboarding-audit-v2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)