### PR TITLE
feat(dashboard): share prompts as centered modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Share prompts modal**: Share prompts now display as a centered modal overlay instead of inline cards at the bottom of the overview tab (`share-prompts-centered-modal`)
 - **Landing page reorder**: "How It Works" section now appears directly after the Trust Bar, before narrative sections (Mission, Vision), reducing scroll-to-conversion distance (`onboarding-audit-v2`)
 - **Overview tab hierarchy**: NextSteps CTA moved below the primary metrics grid and Glasgow breakdown — users see data before advice (`onboarding-audit-v2`)
 - **Dashboard density for new users**: SharePrompts and NightHeatmap hidden for first 5 sessions to reduce information overload (`onboarding-audit-v2`)

--- a/__tests__/share-prompts.test.tsx
+++ b/__tests__/share-prompts.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { NightResult } from '@/lib/types';
+
+// ── Mock sessionStorage ──────────────────────────────────────
+const sessionStore = new Map<string, string>();
+const sessionStorageMock: Storage = {
+  getItem: vi.fn((key: string) => sessionStore.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => { sessionStore.set(key, value); }),
+  removeItem: vi.fn((key: string) => { sessionStore.delete(key); }),
+  clear: vi.fn(() => { sessionStore.clear(); }),
+  get length() { return sessionStore.size; },
+  key: vi.fn((index: number) => Array.from(sessionStore.keys())[index] ?? null),
+};
+Object.defineProperty(globalThis, 'sessionStorage', { value: sessionStorageMock, writable: true });
+
+// ── Mock clipboard ───────────────────────────────────────────
+const writeTextMock = vi.fn(() => Promise.resolve());
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: writeTextMock },
+  writable: true,
+});
+
+// ── Mock auth ────────────────────────────────────────────────
+let mockTier = 'community';
+vi.mock('@/lib/auth/auth-context', () => ({
+  useAuth: () => ({ tier: mockTier }),
+}));
+
+// ── Mock feature gate ────────────────────────────────────────
+vi.mock('@/lib/auth/feature-gate', () => ({
+  canAccess: (feature: string, tier: string) => {
+    if (feature === 'pdf_report') return tier === 'supporter' || tier === 'champion';
+    return false;
+  },
+}));
+
+// ── Mock forum export ────────────────────────────────────────
+vi.mock('@/lib/forum-export', () => ({
+  exportForumSingleNight: vi.fn(() => 'mock forum text'),
+}));
+
+// ── Mock PDF report ──────────────────────────────────────────
+vi.mock('@/lib/pdf-report', () => ({
+  openPDFReport: vi.fn(),
+}));
+
+import { SharePrompts } from '@/components/dashboard/share-prompts';
+
+// ── Helpers ──────────────────────────────────────────────────
+function makeNight(dateStr: string): NightResult {
+  return {
+    date: new Date(dateStr),
+    dateStr,
+    durationHours: 7,
+    sessionCount: 1,
+    settings: {
+      deviceModel: 'AirSense 10',
+      papMode: 'CPAP',
+      epap: 10,
+      ipap: 10,
+      pressureSupport: 0,
+      riseTime: 1,
+      trigger: 'Med',
+      cycle: 'Med',
+      easyBreathe: 'On',
+    },
+    glasgow: {
+      overall: 3.5,
+      skew: 0.5, spike: 0.3, flatTop: 0.4, topHeavy: 0.2,
+      multiPeak: 0.3, noPause: 0.5, inspirRate: 0.4,
+      multiBreath: 0.6, variableAmp: 0.5,
+    },
+    wat: { flScore: 45, regularityScore: 1.2, periodicityIndex: 0.05 },
+    ned: {
+      breathCount: 500, nedMean: 25, nedMedian: 22, nedP95: 55,
+      nedClearFLPct: 30, nedBorderlinePct: 20, fiMean: 0.6,
+      fiFL85Pct: 15, tpeakMean: 0.35, mShapePct: 8,
+      reraIndex: 5, reraCount: 35, h1NedMean: 28, h2NedMean: 22,
+      combinedFLPct: 50, estimatedArousalIndex: 12,
+    },
+    oximetry: null,
+  } as unknown as NightResult;
+}
+
+describe('SharePrompts', () => {
+  const nights = [makeNight('2025-01-01')];
+  const selectedNight = nights[0];
+
+  beforeEach(() => {
+    sessionStore.clear();
+    vi.clearAllMocks();
+    mockTier = 'community';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Test 1: Modal renders centered with items-center justify-center
+  it('renders as a centered modal overlay with correct positioning classes', () => {
+    const { container } = render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+    );
+
+    const overlay = container.querySelector('[role="dialog"]');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveClass('fixed', 'inset-0', 'z-50', 'items-center', 'justify-center');
+  });
+
+  // Test 2: Clicking backdrop closes the modal
+  it('closes when backdrop is clicked', () => {
+    const { container } = render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+    );
+
+    const overlay = container.querySelector('[role="dialog"]');
+    expect(overlay).toBeInTheDocument();
+
+    fireEvent.click(overlay!);
+
+    // After clicking backdrop, the modal should no longer render
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+  });
+
+  // Test 3: Pressing Escape closes the modal
+  it('closes when Escape key is pressed', () => {
+    const { container } = render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+    );
+
+    expect(container.querySelector('[role="dialog"]')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+  });
+
+  // Test 4: Not rendered in demo mode
+  it('does not render when isDemo is true', () => {
+    const { container } = render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={true} />
+    );
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+  });
+
+  // Test 5: Not rendered when sessionStorage dismiss key is set
+  it('does not render when sessionStorage dismiss key is set', () => {
+    sessionStore.set('airwaylab_share_dismissed', '1');
+
+    const { container } = render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+    );
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+  });
+
+  // Test 6: Forum copy button copies text
+  it('copies forum text to clipboard when Copy for Forum Post is clicked', async () => {
+    render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+    );
+
+    const copyButton = screen.getByText('Copy for Forum Post');
+    fireEvent.click(copyButton);
+
+    expect(writeTextMock).toHaveBeenCalledWith('mock forum text');
+  });
+
+  // Test 7: PDF button gated by canAccess
+  it('shows PDF button for supporter tier', () => {
+    mockTier = 'supporter';
+
+    render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+    );
+
+    expect(screen.getByText('Download PDF Report')).toBeInTheDocument();
+  });
+
+  it('shows gated text for community tier', () => {
+    mockTier = 'community';
+
+    render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+    );
+
+    expect(screen.getByText('PDF reports are available on the Supporter plan.')).toBeInTheDocument();
+  });
+
+  // Test 8: Accessibility attributes
+  it('has aria-modal and role="dialog" on the overlay', () => {
+    const { container } = render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+    );
+
+    const overlay = container.querySelector('[role="dialog"]');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay).toHaveAttribute('aria-modal', 'true');
+    expect(overlay).toHaveAttribute('role', 'dialog');
+  });
+
+  // Test: X button closes the modal
+  it('closes when X button is clicked', () => {
+    const { container } = render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+    );
+
+    const closeButton = screen.getByLabelText('Dismiss share prompts');
+    fireEvent.click(closeButton);
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+  });
+});

--- a/components/dashboard/share-prompts.tsx
+++ b/components/dashboard/share-prompts.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { MessageSquare, FileText, Check, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { exportForumSingleNight } from '@/lib/forum-export';
 import { openPDFReport } from '@/lib/pdf-report';
 import { useAuth } from '@/lib/auth/auth-context';
 import { canAccess } from '@/lib/auth/feature-gate';
+import { useFocusTrap } from '@/hooks/use-focus-trap';
 import type { NightResult } from '@/lib/types';
 
 const DISMISS_KEY = 'airwaylab_share_dismissed';
@@ -18,7 +19,7 @@ interface Props {
 }
 
 /**
- * Post-analysis share prompts:
+ * Post-analysis share prompts displayed as a centered modal overlay.
  * 1. Community sharing (copy for Reddit / ApneaBoard)
  * 2. Clinician sharing (PDF report)
  *
@@ -37,12 +38,29 @@ export function SharePrompts({ nights, selectedNight, isDemo }: Props) {
   });
   const [copied, setCopied] = useState<string | null>(null);
 
+  const open = !isDemo && !dismissed;
+  const focusTrapRef = useFocusTrap(open);
+
   const handleDismiss = useCallback(() => {
     setDismissed(true);
     try {
       sessionStorage.setItem(DISMISS_KEY, '1');
     } catch { /* noop */ }
   }, []);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        handleDismiss();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, handleDismiss]);
 
   const handleCopyForum = useCallback(async () => {
     const text = exportForumSingleNight(selectedNight);
@@ -57,80 +75,96 @@ export function SharePrompts({ nights, selectedNight, isDemo }: Props) {
     openPDFReport(nights);
   }, [nights]);
 
-  // Only show for real data
-  if (isDemo || dismissed) return null;
+  if (!open) return null;
 
   return (
-    <div className="flex flex-col gap-3">
-      {/* Community share */}
-      <div className="relative rounded-lg border border-border/50 bg-card/50 px-4 py-3">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={handleDismiss}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Share your analysis"
+    >
+      <div
+        ref={focusTrapRef}
+        className="relative mx-4 w-full max-w-md rounded-xl border border-border bg-background p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
         <button
           onClick={handleDismiss}
-          className="absolute right-2 top-2 rounded p-0.5 text-muted-foreground/40 transition-colors hover:text-muted-foreground"
+          className="absolute right-3 top-3 rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
           aria-label="Dismiss share prompts"
         >
-          <X className="h-3 w-3" />
+          <X className="h-4 w-4" />
         </button>
-        <div className="flex items-start gap-3 pr-6">
-          <MessageSquare className="mt-0.5 h-4 w-4 shrink-0 text-primary/60" />
-          <div className="flex flex-col gap-2">
-            <div>
-              <p className="text-sm font-medium">Share with the community</p>
-              <p className="text-xs text-muted-foreground">
-                Posting your results on ApneaBoard, Reddit, CPAPtalk, or your favourite sleep community helps others understand their data too.
-              </p>
-            </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 gap-1.5 text-xs"
-                onClick={handleCopyForum}
-              >
-                {copied === 'forum' ? (
-                  <>
-                    <Check className="h-3 w-3 text-emerald-500" /> Copied!
-                  </>
-                ) : (
-                  'Copy for Forum Post'
-                )}
-              </Button>
-            </div>
-            <p className="text-[10px] text-muted-foreground/50">
-              Results are anonymised — only metrics are shared, never raw data.
-            </p>
-          </div>
-        </div>
-      </div>
 
-      {/* Doctor share */}
-      <div className="rounded-lg border border-border/50 bg-card/50 px-4 py-3">
-        <div className="flex items-start gap-3">
-          <FileText className="mt-0.5 h-4 w-4 shrink-0 text-primary/60" />
-          <div className="flex flex-col gap-2">
-            <div>
-              <p className="text-sm font-medium">Share with your clinician</p>
-              <p className="text-xs text-muted-foreground">
-                Taking these results to your sleep doctor? Export a PDF report they can review.
-              </p>
+        <h2 className="mb-5 text-lg font-semibold">Share Your Analysis</h2>
+
+        <div className="flex flex-col gap-4">
+          {/* Community share */}
+          <div className="rounded-lg border border-border/50 bg-card/50 px-4 py-3">
+            <div className="flex items-start gap-3">
+              <MessageSquare className="mt-0.5 h-4 w-4 shrink-0 text-primary/60" />
+              <div className="flex flex-col gap-2">
+                <div>
+                  <p className="text-sm font-medium">Share with the community</p>
+                  <p className="text-xs text-muted-foreground">
+                    Posting your results on ApneaBoard, Reddit, CPAPtalk, or your favourite sleep community helps others understand their data too.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 gap-1.5 text-xs"
+                    onClick={handleCopyForum}
+                  >
+                    {copied === 'forum' ? (
+                      <>
+                        <Check className="h-3 w-3 text-emerald-500" /> Copied!
+                      </>
+                    ) : (
+                      'Copy for Forum Post'
+                    )}
+                  </Button>
+                </div>
+                <p className="text-[10px] text-muted-foreground/50">
+                  Results are anonymised — only metrics are shared, never raw data.
+                </p>
+              </div>
             </div>
-            {pdfAllowed ? (
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 w-fit gap-1.5 text-xs"
-                onClick={handlePDF}
-              >
-                <FileText className="h-3 w-3" /> Download PDF Report
-              </Button>
-            ) : (
-              <p className="text-xs text-muted-foreground/70">
-                PDF reports are available on the Supporter plan.
-              </p>
-            )}
-            <p className="text-[10px] text-muted-foreground/50">
-              The report includes key metrics, traffic-light indicators, and a medical disclaimer.
-            </p>
+          </div>
+
+          {/* Doctor share */}
+          <div className="rounded-lg border border-border/50 bg-card/50 px-4 py-3">
+            <div className="flex items-start gap-3">
+              <FileText className="mt-0.5 h-4 w-4 shrink-0 text-primary/60" />
+              <div className="flex flex-col gap-2">
+                <div>
+                  <p className="text-sm font-medium">Share with your clinician</p>
+                  <p className="text-xs text-muted-foreground">
+                    Taking these results to your sleep doctor? Export a PDF report they can review.
+                  </p>
+                </div>
+                {pdfAllowed ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 w-fit gap-1.5 text-xs"
+                    onClick={handlePDF}
+                  >
+                    <FileText className="h-3 w-3" /> Download PDF Report
+                  </Button>
+                ) : (
+                  <p className="text-xs text-muted-foreground/70">
+                    PDF reports are available on the Supporter plan.
+                  </p>
+                )}
+                <p className="text-[10px] text-muted-foreground/50">
+                  The report includes key metrics, traffic-light indicators, and a medical disclaimer.
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Converts share prompts from inline cards at the bottom of the overview tab to a centered modal overlay
- Adds backdrop dismiss, Escape key close, focus trap (`useFocusTrap`), and ARIA dialog attributes (`role="dialog"`, `aria-modal="true"`)
- Consistent with existing modal pattern used by `ShareConsentModal`

## Files Changed
- `components/dashboard/share-prompts.tsx` — converted from inline flex-col cards to fixed centered modal overlay
- `__tests__/share-prompts.test.tsx` — 10 new tests covering modal positioning, dismiss behaviors, accessibility, and feature gating
- `CHANGELOG.md` — added entry under Unreleased

## Test Plan
- [x] 10 tests pass (modal positioning, backdrop close, Escape close, X button close, demo guard, session dismiss, forum copy, PDF gating community/supporter, ARIA attributes)
- [ ] Manual: verify modal appears centered on desktop and mobile
- [ ] Manual: verify dismiss persists for the session

## Build Verification
- TypeScript: ✓ (pre-existing errors from deleted contribution-nudge-dialog only)
- Lint: ✓ No warnings or errors
- Tests: ✓ 344 passed (10 new)
- Build: pre-existing failure from deleted contribution-nudge-dialog import (not related to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)