### PR TITLE
fix(dashboard): prevent share modal from auto-opening on page load

### DIFF
--- a/__tests__/share-prompts.test.tsx
+++ b/__tests__/share-prompts.test.tsx
@@ -4,18 +4,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { NightResult } from '@/lib/types';
 
-// ── Mock sessionStorage ──────────────────────────────────────
-const sessionStore = new Map<string, string>();
-const sessionStorageMock: Storage = {
-  getItem: vi.fn((key: string) => sessionStore.get(key) ?? null),
-  setItem: vi.fn((key: string, value: string) => { sessionStore.set(key, value); }),
-  removeItem: vi.fn((key: string) => { sessionStore.delete(key); }),
-  clear: vi.fn(() => { sessionStore.clear(); }),
-  get length() { return sessionStore.size; },
-  key: vi.fn((index: number) => Array.from(sessionStore.keys())[index] ?? null),
-};
-Object.defineProperty(globalThis, 'sessionStorage', { value: sessionStorageMock, writable: true });
-
 // ── Mock clipboard ───────────────────────────────────────────
 const writeTextMock = vi.fn(() => Promise.resolve());
 Object.defineProperty(navigator, 'clipboard', {
@@ -88,21 +76,22 @@ function makeNight(dateStr: string): NightResult {
 describe('SharePrompts', () => {
   const nights = [makeNight('2025-01-01')];
   const selectedNight = nights[0];
+  let onClose: () => void;
 
   beforeEach(() => {
-    sessionStore.clear();
     vi.clearAllMocks();
     mockTier = 'community';
+    onClose = vi.fn() as unknown as () => void;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  // Test 1: Modal renders centered with items-center justify-center
-  it('renders as a centered modal overlay with correct positioning classes', () => {
+  // Test 1: Modal renders when open=true
+  it('renders as a centered modal overlay when open', () => {
     const { container } = render(
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+      <SharePrompts nights={nights} selectedNight={selectedNight} open={true} onClose={onClose} />
     );
 
     const overlay = container.querySelector('[role="dialog"]');
@@ -110,58 +99,54 @@ describe('SharePrompts', () => {
     expect(overlay).toHaveClass('fixed', 'inset-0', 'z-50', 'items-center', 'justify-center');
   });
 
-  // Test 2: Clicking backdrop closes the modal
-  it('closes when backdrop is clicked', () => {
+  // Test 2: Does not render when open=false
+  it('does not render when open is false', () => {
     const { container } = render(
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+      <SharePrompts nights={nights} selectedNight={selectedNight} open={false} onClose={onClose} />
+    );
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+  });
+
+  // Test 3: Clicking backdrop calls onClose
+  it('calls onClose when backdrop is clicked', () => {
+    const { container } = render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} open={true} onClose={onClose} />
     );
 
     const overlay = container.querySelector('[role="dialog"]');
-    expect(overlay).toBeInTheDocument();
-
     fireEvent.click(overlay!);
 
-    // After clicking backdrop, the modal should no longer render
-    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  // Test 3: Pressing Escape closes the modal
-  it('closes when Escape key is pressed', () => {
-    const { container } = render(
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+  // Test 4: Pressing Escape calls onClose
+  it('calls onClose when Escape key is pressed', () => {
+    render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} open={true} onClose={onClose} />
     );
-
-    expect(container.querySelector('[role="dialog"]')).toBeInTheDocument();
 
     fireEvent.keyDown(document, { key: 'Escape' });
 
-    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  // Test 4: Not rendered in demo mode
-  it('does not render when isDemo is true', () => {
-    const { container } = render(
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={true} />
+  // Test 5: X button calls onClose
+  it('calls onClose when X button is clicked', () => {
+    render(
+      <SharePrompts nights={nights} selectedNight={selectedNight} open={true} onClose={onClose} />
     );
 
-    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
-  });
+    const closeButton = screen.getByLabelText('Dismiss share prompts');
+    fireEvent.click(closeButton);
 
-  // Test 5: Not rendered when sessionStorage dismiss key is set
-  it('does not render when sessionStorage dismiss key is set', () => {
-    sessionStore.set('airwaylab_share_dismissed', '1');
-
-    const { container } = render(
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
-    );
-
-    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   // Test 6: Forum copy button copies text
   it('copies forum text to clipboard when Copy for Forum Post is clicked', async () => {
     render(
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+      <SharePrompts nights={nights} selectedNight={selectedNight} open={true} onClose={onClose} />
     );
 
     const copyButton = screen.getByText('Copy for Forum Post');
@@ -175,7 +160,7 @@ describe('SharePrompts', () => {
     mockTier = 'supporter';
 
     render(
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+      <SharePrompts nights={nights} selectedNight={selectedNight} open={true} onClose={onClose} />
     );
 
     expect(screen.getByText('Download PDF Report')).toBeInTheDocument();
@@ -185,7 +170,7 @@ describe('SharePrompts', () => {
     mockTier = 'community';
 
     render(
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+      <SharePrompts nights={nights} selectedNight={selectedNight} open={true} onClose={onClose} />
     );
 
     expect(screen.getByText('PDF reports are available on the Supporter plan.')).toBeInTheDocument();
@@ -194,24 +179,12 @@ describe('SharePrompts', () => {
   // Test 8: Accessibility attributes
   it('has aria-modal and role="dialog" on the overlay', () => {
     const { container } = render(
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
+      <SharePrompts nights={nights} selectedNight={selectedNight} open={true} onClose={onClose} />
     );
 
     const overlay = container.querySelector('[role="dialog"]');
     expect(overlay).toBeInTheDocument();
     expect(overlay).toHaveAttribute('aria-modal', 'true');
     expect(overlay).toHaveAttribute('role', 'dialog');
-  });
-
-  // Test: X button closes the modal
-  it('closes when X button is clicked', () => {
-    const { container } = render(
-      <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={false} />
-    );
-
-    const closeButton = screen.getByLabelText('Dismiss share prompts');
-    fireEvent.click(closeButton);
-
-    expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
   });
 });

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -12,7 +12,7 @@ import { DEMO_AI_INSIGHTS } from '@/lib/demo-ai-insights';
 import { AIInsightsCTA } from '@/components/dashboard/ai-insights-cta';
 import { NightSummaryHero } from '@/components/dashboard/night-summary-hero';
 import { InsightsPanel } from '@/components/dashboard/insights-panel';
-import { HeartPulse, TrendingDown, TrendingUp, ChevronRight, Upload, Info, Settings2 } from 'lucide-react';
+import { HeartPulse, TrendingDown, TrendingUp, ChevronRight, Upload, Info, Settings2, Share2 } from 'lucide-react';
 import { UpgradePrompt } from '@/components/auth/upgrade-prompt';
 import { useAuth } from '@/lib/auth/auth-context';
 import { canAccess, incrementAIUsage } from '@/lib/auth/feature-gate';
@@ -61,6 +61,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
 
   const { user, tier, isPaid } = useAuth();
 
+  const [shareOpen, setShareOpen] = useState(false);
   const [aiInsights, setAiInsights] = useState<Insight[] | null>(null);
   const [serverRemainingCredits, setAiRemainingCredits] = useState<number | undefined>(undefined);
   const [aiLoading, setAiLoading] = useState(false);
@@ -473,9 +474,23 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         );
       })()}
 
-      {/* Share Prompts (real data only, hidden for new users to reduce density) */}
-      {!isNewUser && (
-        <SharePrompts nights={nights} selectedNight={selectedNight} isDemo={isDemo} />
+      {/* Share button + modal (real data only, hidden for new users to reduce density) */}
+      {!isNewUser && !isDemo && (
+        <>
+          <button
+            onClick={() => setShareOpen(true)}
+            className="flex w-full items-center gap-2 rounded-lg border border-border/50 bg-card/50 px-4 py-3 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+          >
+            <Share2 className="h-4 w-4" />
+            Share your analysis
+          </button>
+          <SharePrompts
+            nights={nights}
+            selectedNight={selectedNight}
+            open={shareOpen}
+            onClose={() => setShareOpen(false)}
+          />
+        </>
       )}
 
       {/* Heatmap (hidden for new users to reduce density) */}

--- a/components/dashboard/share-prompts.tsx
+++ b/components/dashboard/share-prompts.tsx
@@ -10,12 +10,11 @@ import { canAccess } from '@/lib/auth/feature-gate';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 import type { NightResult } from '@/lib/types';
 
-const DISMISS_KEY = 'airwaylab_share_dismissed';
-
 interface Props {
   nights: NightResult[];
   selectedNight: NightResult;
-  isDemo: boolean;
+  open: boolean;
+  onClose: () => void;
 }
 
 /**
@@ -23,30 +22,14 @@ interface Props {
  * 1. Community sharing (copy for Reddit / ApneaBoard)
  * 2. Clinician sharing (PDF report)
  *
- * Only shown for real data (not demo). Dismissable via sessionStorage.
+ * Controlled modal — parent manages open/close state.
  */
-export function SharePrompts({ nights, selectedNight, isDemo }: Props) {
+export function SharePrompts({ nights, selectedNight, open, onClose }: Props) {
   const { tier } = useAuth();
   const pdfAllowed = canAccess('pdf_report', tier);
-  const [dismissed, setDismissed] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    try {
-      return sessionStorage.getItem(DISMISS_KEY) === '1';
-    } catch {
-      return false;
-    }
-  });
   const [copied, setCopied] = useState<string | null>(null);
 
-  const open = !isDemo && !dismissed;
   const focusTrapRef = useFocusTrap(open);
-
-  const handleDismiss = useCallback(() => {
-    setDismissed(true);
-    try {
-      sessionStorage.setItem(DISMISS_KEY, '1');
-    } catch { /* noop */ }
-  }, []);
 
   // Close on Escape key
   useEffect(() => {
@@ -54,13 +37,13 @@ export function SharePrompts({ nights, selectedNight, isDemo }: Props) {
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        handleDismiss();
+        onClose();
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [open, handleDismiss]);
+  }, [open, onClose]);
 
   const handleCopyForum = useCallback(async () => {
     const text = exportForumSingleNight(selectedNight);
@@ -80,7 +63,7 @@ export function SharePrompts({ nights, selectedNight, isDemo }: Props) {
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
-      onClick={handleDismiss}
+      onClick={onClose}
       role="dialog"
       aria-modal="true"
       aria-label="Share your analysis"
@@ -91,7 +74,7 @@ export function SharePrompts({ nights, selectedNight, isDemo }: Props) {
         onClick={(e) => e.stopPropagation()}
       >
         <button
-          onClick={handleDismiss}
+          onClick={onClose}
           className="absolute right-3 top-3 rounded p-1 text-muted-foreground transition-colors hover:text-foreground"
           aria-label="Dismiss share prompts"
         >


### PR DESCRIPTION
## Summary
- The share modal (from #59) auto-opened whenever analysis results were displayed, immediately blocking the dashboard on navigate or session restore
- Converted `SharePrompts` from a self-opening modal to a controlled component with `open`/`onClose` props
- Added a subtle "Share your analysis" button in the overview tab that opens the modal on click

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] All 364 tests pass
- [ ] Navigate to /analyze with persisted results — modal should NOT auto-open
- [ ] Click "Share your analysis" button — modal opens
- [ ] Close via X, backdrop, or Escape — modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)