### PR TITLE
test: waveform contribution integration tests

### DIFF
--- a/__tests__/waveform-api-route.test.ts
+++ b/__tests__/waveform-api-route.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ENGINE_VERSION } from '@/lib/engine-version';
+
+// ── Mocks (module-scope so vi.mock hoisting can access them) ──
+
+const mockUpload = vi.fn();
+const mockInsert = vi.fn();
+const mockRemove = vi.fn();
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseAdmin: vi.fn(() => ({
+    storage: {
+      from: () => ({
+        upload: mockUpload,
+        remove: mockRemove,
+      }),
+    },
+    from: () => ({
+      insert: mockInsert,
+    }),
+  })),
+}));
+
+vi.mock('@/lib/csrf', () => ({
+  validateOrigin: vi.fn(() => true),
+}));
+
+vi.mock('@/lib/rate-limit', () => {
+  class MockRateLimiter {
+    isLimited() { return false; }
+  }
+  return {
+    RateLimiter: MockRateLimiter,
+    getRateLimitKey: vi.fn(() => '127.0.0.1'),
+  };
+});
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeRequest(overrides: Partial<{
+  body: ArrayBuffer;
+  headers: Record<string, string>;
+}> = {}) {
+  const flowData = new Float32Array([1.0, 2.0, 3.0]);
+  const body = overrides.body ?? flowData.buffer;
+
+  const baseHeaders: Record<string, string> = {
+    'content-type': 'application/octet-stream',
+    'content-encoding': 'gzip',
+    'x-night-date': '2025-01-15',
+    'x-contribution-id': 'test-contribution-id',
+    'x-engine-version': ENGINE_VERSION,
+    'x-sampling-rate': '25',
+    'x-duration-seconds': '28800',
+    'x-sample-count': '720000',
+    'x-device-model': 'AirSense 10',
+    'x-pap-mode': 'APAP',
+    'x-analysis-results': JSON.stringify({ glasgow: { overall: 2.1 } }),
+    ...overrides.headers,
+  };
+
+  const headers = new Headers(baseHeaders);
+
+  return new Request('https://airwaylab.app/api/contribute-waveforms', {
+    method: 'POST',
+    headers,
+    body,
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('contribute-waveforms API route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpload.mockResolvedValue({ error: null });
+    mockInsert.mockResolvedValue({ error: null });
+    mockRemove.mockResolvedValue({ error: null });
+  });
+
+  it('accepts valid waveform upload and stores to Supabase', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    const request = makeRequest();
+    const response = await POST(request as never);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+
+    // Verify storage upload was called
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    const uploadArgs = mockUpload.mock.calls[0];
+    expect(uploadArgs[0]).toBe('test-contribution-id/2025-01-15.flow.gz');
+
+    // Verify DB insert was called with correct metadata
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const insertData = mockInsert.mock.calls[0][0];
+    expect(insertData.contribution_id).toBe('test-contribution-id');
+    expect(insertData.night_date).toBe('2025-01-15');
+    expect(insertData.engine_version).toBe(ENGINE_VERSION);
+    expect(insertData.sampling_rate).toBe(25);
+    expect(insertData.device_model).toBe('AirSense 10');
+    expect(insertData.pap_mode).toBe('APAP');
+    expect(insertData.storage_path).toBe('test-contribution-id/2025-01-15.flow.gz');
+  });
+
+  it('uses .bin extension when not compressed', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    const headers = new Headers({
+      'content-type': 'application/octet-stream',
+      'x-night-date': '2025-01-15',
+      'x-contribution-id': 'test-contribution-id',
+      'x-engine-version': ENGINE_VERSION,
+      'x-sampling-rate': '25',
+      'x-duration-seconds': '28800',
+      'x-sample-count': '720000',
+      'x-device-model': 'AirSense 10',
+      'x-pap-mode': 'APAP',
+      'x-analysis-results': JSON.stringify({ glasgow: { overall: 2.1 } }),
+      // No content-encoding header → not compressed
+    });
+
+    const request = new Request('https://airwaylab.app/api/contribute-waveforms', {
+      method: 'POST',
+      headers,
+      body: new Float32Array([1, 2, 3]).buffer,
+    });
+
+    await POST(request as never);
+
+    const uploadPath = mockUpload.mock.calls[0]?.[0];
+    expect(uploadPath).toBe('test-contribution-id/2025-01-15.flow.bin');
+  });
+
+  it('rejects request with missing required headers', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    const request = new Request('https://airwaylab.app/api/contribute-waveforms', {
+      method: 'POST',
+      headers: { 'content-type': 'application/octet-stream' },
+      body: new Uint8Array([1, 2, 3]),
+    });
+
+    const response = await POST(request as never);
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects request with invalid date format', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    const request = makeRequest({
+      headers: { 'x-night-date': '15-01-2025' },
+    });
+    const response = await POST(request as never);
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects empty body', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    const request = makeRequest({ body: new ArrayBuffer(0) });
+    const response = await POST(request as never);
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects oversized payload via content-length header', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    const request = makeRequest({
+      headers: { 'content-length': String(6 * 1024 * 1024) },
+    });
+    const response = await POST(request as never);
+    expect(response.status).toBe(413);
+  });
+
+  it('handles duplicate upload idempotently', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    mockUpload.mockResolvedValue({
+      error: { message: 'The resource already exists' },
+    });
+
+    const request = makeRequest();
+    const response = await POST(request as never);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.duplicate).toBe(true);
+
+    // Should NOT insert DB row for duplicate
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('cleans up storage on DB insert failure', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    mockInsert.mockResolvedValue({
+      error: { message: 'unique constraint violated' },
+    });
+
+    const request = makeRequest();
+    const response = await POST(request as never);
+
+    expect(response.status).toBe(500);
+
+    // Should have attempted to clean up the orphaned storage file
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+    expect(mockRemove.mock.calls[0][0]).toEqual(['test-contribution-id/2025-01-15.flow.gz']);
+  });
+
+  it('rejects invalid JSON in analysis results header', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    const request = makeRequest({
+      headers: { 'x-analysis-results': 'not-json' },
+    });
+    const response = await POST(request as never);
+    expect(response.status).toBe(400);
+  });
+});

--- a/__tests__/waveform-contribution-integration.test.ts
+++ b/__tests__/waveform-contribution-integration.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { ENGINE_VERSION } from '@/lib/engine-version';
+
+// ── localStorage mock ────────────────────────────────────────
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+  getItem: vi.fn((key: string) => storage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => { storage.set(key, value); }),
+  removeItem: vi.fn((key: string) => { storage.delete(key); }),
+  clear: vi.fn(() => { storage.clear(); }),
+  get length() { return storage.size; },
+  key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+// ── Sentry mock ──────────────────────────────────────────────
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+// ── EDF parser mock ──────────────────────────────────────────
+// Returns a minimal EDFFile with synthetic flow data
+vi.mock('@/lib/parsers/edf-parser', () => ({
+  parseEDF: vi.fn((buffer: ArrayBuffer, filePath: string) => {
+    // Extract date from filename: DATALOG/YYYYMMDD/YYYYMMDD_HHMMSS_BRP.edf
+    const match = filePath.match(/(\d{8})_(\d{6})_BRP/);
+    const dateStr = match?.[1] ?? '20250115';
+    const timeStr = match?.[2] ?? '220000';
+    const y = parseInt(dateStr.slice(0, 4));
+    const m = parseInt(dateStr.slice(4, 6)) - 1;
+    const d = parseInt(dateStr.slice(6, 8));
+    const h = parseInt(timeStr.slice(0, 2));
+    const min = parseInt(timeStr.slice(2, 4));
+
+    // 100 samples of synthetic sine wave flow data
+    const flowData = new Float32Array(100);
+    for (let i = 0; i < 100; i++) {
+      flowData[i] = Math.sin((2 * Math.PI * i) / 25);
+    }
+
+    return {
+      header: {
+        version: '0',
+        patientId: '',
+        recordingId: '',
+        startDate: `${d}.${m + 1}.${y % 100}`,
+        startTime: `${h}.${min}.0`,
+        headerBytes: 256,
+        reserved: '',
+        numDataRecords: 4,
+        recordDuration: 1,
+        numSignals: 1,
+      },
+      signals: [{
+        label: 'Flow',
+        transducer: '',
+        physicalDimension: 'L/min',
+        physicalMin: -100,
+        physicalMax: 100,
+        digitalMin: -32768,
+        digitalMax: 32767,
+        prefiltering: '',
+        numSamples: 25,
+        reserved: '',
+      }],
+      recordingDate: new Date(y, m, d, h, min),
+      flowData,
+      pressureData: null,
+      samplingRate: 25,
+      durationSeconds: 4,
+      filePath,
+    };
+  }),
+}));
+
+import {
+  getContributedWaveformDates,
+  trackContributedWaveformDate,
+  clearContributedWaveformDates,
+  setContributedWaveformEngine,
+} from '@/components/upload/contribution-consent-utils';
+import type { NightResult } from '@/lib/types';
+
+// ── Test helpers ─────────────────────────────────────────────
+
+/** Create a minimal NightResult for testing. */
+function makeNight(dateStr: string): NightResult {
+  return {
+    date: new Date(dateStr),
+    dateStr,
+    durationHours: 7.5,
+    sessionCount: 1,
+    settings: {
+      deviceModel: 'AirSense 10',
+      epap: 10,
+      ipap: 16,
+      pressureSupport: 6,
+      papMode: 'APAP',
+      riseTime: 3,
+      trigger: 'Medium',
+      cycle: 'Medium',
+      easyBreathe: false,
+    },
+    glasgow: {
+      overall: 2.1,
+      skew: 0.3, spike: 0.15, flatTop: 0.35, topHeavy: 0.22,
+      multiPeak: 0.2, noPause: 0.1, inspirRate: 0.25,
+      multiBreath: 0.15, variableAmp: 0.3,
+    },
+    wat: { flScore: 32, regularityScore: 68, periodicityIndex: 18 },
+    ned: {
+      breathCount: 4120, nedMean: 19.5, nedMedian: 17.2, nedP95: 38.5,
+      nedClearFLPct: 3.2, nedBorderlinePct: 8.5, fiMean: 0.72,
+      fiFL85Pct: 12.5, tpeakMean: 0.38, mShapePct: 4.8,
+      reraIndex: 6.4, reraCount: 48, h1NedMean: 17.8, h2NedMean: 21.2,
+      combinedFLPct: 22, estimatedArousalIndex: 8.2,
+    },
+    oximetry: null,
+    oximetryTrace: null,
+  };
+}
+
+/** Create a mock SD card File with a BRP path inside a DATALOG folder. */
+function makeBRPFile(dateStr: string): File {
+  const dateNum = dateStr.replace(/-/g, '');
+  const path = `CPAP_DATA/DATALOG/${dateNum}/${dateNum}_220000_BRP.edf`;
+  const name = `${dateNum}_220000_BRP.edf`;
+  // Create a file with enough bytes to pass the 50KB BRP filter
+  const data = new Uint8Array(60 * 1024);
+  const file = new File([data], name, { type: 'application/octet-stream' });
+  Object.defineProperty(file, 'webkitRelativePath', { value: path, writable: false });
+  return file;
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('contributeWaveformsBackground — integration', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+    fetchSpy = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uploads waveform data for new nights', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    const nights = [makeNight('2025-01-15')];
+    const files = [makeBRPFile('2025-01-15')];
+
+    await contributeWaveformsBackground(nights, files, 'test-contribution-id');
+
+    // Should have made one fetch call to the API
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe('/api/contribute-waveforms');
+
+    const callArgs = fetchSpy.mock.calls[0][1];
+    expect(callArgs.method).toBe('POST');
+    expect(callArgs.headers['X-Night-Date']).toBe('2025-01-15');
+    expect(callArgs.headers['X-Contribution-Id']).toBe('test-contribution-id');
+    expect(callArgs.headers['X-Engine-Version']).toBe(ENGINE_VERSION);
+    expect(callArgs.headers['X-Sampling-Rate']).toBe('25');
+    expect(callArgs.headers['X-Device-Model']).toBe('AirSense 10');
+    expect(callArgs.headers['X-Pap-Mode']).toBe('APAP');
+    expect(callArgs.headers['Content-Type']).toBe('application/octet-stream');
+
+    // Should have binary body
+    expect(callArgs.body).toBeInstanceOf(ArrayBuffer);
+    expect(callArgs.body.byteLength).toBeGreaterThan(0);
+  });
+
+  it('tracks contributed dates after successful upload', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    const nights = [makeNight('2025-01-15'), makeNight('2025-01-16')];
+    const files = [makeBRPFile('2025-01-15'), makeBRPFile('2025-01-16')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    const tracked = getContributedWaveformDates();
+    expect(tracked.has('2025-01-15')).toBe(true);
+    expect(tracked.has('2025-01-16')).toBe(true);
+  });
+
+  it('skips already-contributed nights (incremental upload)', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    // Pre-mark one night as contributed
+    trackContributedWaveformDate('2025-01-15');
+
+    const nights = [makeNight('2025-01-15'), makeNight('2025-01-16')];
+    const files = [makeBRPFile('2025-01-15'), makeBRPFile('2025-01-16')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    // Should only upload the new night (2025-01-16)
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][1].headers['X-Night-Date']).toBe('2025-01-16');
+  });
+
+  it('skips all nights when everything is already contributed', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    trackContributedWaveformDate('2025-01-15');
+    trackContributedWaveformDate('2025-01-16');
+
+    const nights = [makeNight('2025-01-15'), makeNight('2025-01-16')];
+    const files = [makeBRPFile('2025-01-15'), makeBRPFile('2025-01-16')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears contributed dates and re-uploads when engine version changes', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    // Simulate a previous contribution with an older engine
+    trackContributedWaveformDate('2025-01-15');
+    setContributedWaveformEngine('0.5.0-old');
+
+    const nights = [makeNight('2025-01-15')];
+    const files = [makeBRPFile('2025-01-15')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    // Dates should have been cleared and re-uploaded
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][1].headers['X-Night-Date']).toBe('2025-01-15');
+  });
+
+  it('does not clear dates when engine version matches', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    trackContributedWaveformDate('2025-01-15');
+    setContributedWaveformEngine(ENGINE_VERSION);
+
+    const nights = [makeNight('2025-01-15'), makeNight('2025-01-16')];
+    const files = [makeBRPFile('2025-01-15'), makeBRPFile('2025-01-16')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    // Only the new night should be uploaded
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][1].headers['X-Night-Date']).toBe('2025-01-16');
+  });
+
+  it('records engine version after successful contribution', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+    const { getContributedWaveformEngine } = await import('@/components/upload/contribution-consent-utils');
+
+    const nights = [makeNight('2025-01-15')];
+    const files = [makeBRPFile('2025-01-15')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    expect(getContributedWaveformEngine()).toBe(ENGINE_VERSION);
+  });
+
+  it('does not throw on fetch failure (fire-and-forget)', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    fetchSpy.mockResolvedValue({ ok: false, status: 500 });
+
+    const nights = [makeNight('2025-01-15')];
+    const files = [makeBRPFile('2025-01-15')];
+
+    // Should not throw
+    await expect(
+      contributeWaveformsBackground(nights, files, 'test-id')
+    ).resolves.toBeUndefined();
+
+    // Should NOT track the date since upload failed
+    const tracked = getContributedWaveformDates();
+    expect(tracked.has('2025-01-15')).toBe(false);
+  });
+
+  it('does not throw on network error (fire-and-forget)', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    fetchSpy.mockRejectedValue(new Error('Network error'));
+
+    const nights = [makeNight('2025-01-15')];
+    const files = [makeBRPFile('2025-01-15')];
+
+    await expect(
+      contributeWaveformsBackground(nights, files, 'test-id')
+    ).resolves.toBeUndefined();
+  });
+
+  it('sends anonymised analysis results in headers', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    const nights = [makeNight('2025-01-15')];
+    const files = [makeBRPFile('2025-01-15')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    const resultsHeader = fetchSpy.mock.calls[0][1].headers['X-Analysis-Results'];
+    const parsed = JSON.parse(resultsHeader);
+
+    // Should contain anonymised scores
+    expect(parsed.glasgow.overall).toBe(2.1);
+    expect(parsed.wat.flScore).toBe(32);
+    expect(parsed.ned.nedMean).toBe(19.5);
+    expect(parsed.oximetry).toBeNull();
+
+    // Should NOT contain raw data or personal info
+    expect(parsed.date).toBeUndefined();
+    expect(parsed.dateStr).toBeUndefined();
+    expect(parsed.settings).toBeUndefined();
+  });
+
+  it('uploads multiple nights sequentially', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    const nights = [
+      makeNight('2025-01-15'),
+      makeNight('2025-01-16'),
+      makeNight('2025-01-17'),
+    ];
+    const files = [
+      makeBRPFile('2025-01-15'),
+      makeBRPFile('2025-01-16'),
+      makeBRPFile('2025-01-17'),
+    ];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const uploadedDates = fetchSpy.mock.calls.map(
+      (c: unknown[]) => (c[1] as { headers: Record<string, string> }).headers['X-Night-Date']
+    );
+    expect(uploadedDates).toContain('2025-01-15');
+    expect(uploadedDates).toContain('2025-01-16');
+    expect(uploadedDates).toContain('2025-01-17');
+  });
+
+  it('does nothing when no SD files provided', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    const nights = [makeNight('2025-01-15')];
+
+    await contributeWaveformsBackground(nights, [], 'test-id');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no nights provided', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    const files = [makeBRPFile('2025-01-15')];
+
+    await contributeWaveformsBackground([], files, 'test-id');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('continues uploading remaining nights when one fails', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    // First call fails, second succeeds
+    fetchSpy
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true });
+
+    const nights = [makeNight('2025-01-15'), makeNight('2025-01-16')];
+    const files = [makeBRPFile('2025-01-15'), makeBRPFile('2025-01-16')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    // Only the successful night should be tracked
+    const tracked = getContributedWaveformDates();
+    expect(tracked.has('2025-01-15')).toBe(false);
+    expect(tracked.has('2025-01-16')).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Adds 14 client-side integration tests for `contributeWaveformsBackground` covering: upload flow, incremental dedup, engine version invalidation, fire-and-forget error handling, anonymised data verification, multi-night sequential upload
- Adds 9 API route tests for `POST /api/contribute-waveforms` covering: valid upload + Supabase storage, .bin/.gz extension logic, header validation, payload size limits, duplicate idempotency, DB failure cleanup, invalid JSON rejection

## Test plan
- [x] All 23 new tests pass
- [x] Full suite: 412 tests pass across 32 files
- [x] TypeScript clean (`npx tsc --noEmit`)
- [x] Build clean (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)