### PR TITLE
feat: device-agnostic upload copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to AirwayLab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — Generic Upload Copy (2026-03-11)
+
+### Changed
+
+- **Device-agnostic upload flow**: Removed ResMed-specific language from upload heading, instructions, validation messages, and meta descriptions. ResMed is now only mentioned in a compatibility note below the upload steps. (`generic-upload-copy`)
+- **Other-device encouragement**: Added CTA inviting non-ResMed users to upload their data and enable sharing so we can analyse the structure and add support (`generic-upload-copy`)
+
 ## [Unreleased] — Waveform Data Contribution (2026-03-11)
 
 ### Added

--- a/__tests__/upload-validation.test.ts
+++ b/__tests__/upload-validation.test.ts
@@ -98,6 +98,24 @@ describe('validateSDFiles', () => {
     expect(result.warnings.some((w) => w.includes('DATALOG folder'))).toBe(true);
   });
 
+  it('does not mention "ResMed" in no-EDF error message', () => {
+    const files = [mockFile('readme.txt'), mockFile('data.csv')];
+    const result = validateSDFiles(files);
+    expect(result.errors[0]).not.toContain('ResMed');
+  });
+
+  it('does not mention "ResMed" in folder structure warning', () => {
+    const files = [
+      mockFile('BRP.edf'),
+      mockFile('FLW.edf'),
+      mockFile('STR.edf'),
+    ];
+    const result = validateSDFiles(files);
+    const folderWarning = result.warnings.find((w) => w.includes('DATALOG'));
+    expect(folderWarning).toBeDefined();
+    expect(folderWarning).not.toContain('ResMed');
+  });
+
   it('handles case-insensitive EDF extension', () => {
     const files = [
       mockFile('BRP_20250110.EDF', 5000, 'SD/DATALOG/20250110/BRP_20250110.EDF'),

--- a/app/analyze/layout.tsx
+++ b/app/analyze/layout.tsx
@@ -3,11 +3,11 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Analyze — AirwayLab',
   description:
-    'Upload your ResMed SD card data for flow limitation analysis, Glasgow Index scoring, and oximetry insights.',
+    'Upload your PAP SD card data for flow limitation analysis, Glasgow Index scoring, and oximetry insights.',
   openGraph: {
     title: 'Analyze — AirwayLab',
     description:
-      'Upload ResMed PAP SD card data for research-grade flow limitation analysis. 100% client-side processing.',
+      'Upload PAP SD card data for research-grade flow limitation analysis. 100% client-side processing.',
   },
 };
 

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -401,7 +401,7 @@ function AnalyzePageInner() {
             <p className="mt-1 text-xs text-muted-foreground sm:text-sm">
               {isDemo
                 ? 'Exploring sample data — upload your own SD card to see your results'
-                : 'Upload your ResMed SD card folder to begin analysis'}
+                : 'Upload your SD card folder to begin analysis'}
             </p>
           </div>
           <div className="flex items-center gap-3">
@@ -525,7 +525,7 @@ function AnalyzePageInner() {
                 <p className="text-sm text-red-400">{error}</p>
               </div>
               <p className="pl-[26px] text-xs text-muted-foreground">
-                Make sure you selected the DATALOG folder from your ResMed SD card. Need help?{' '}
+                Make sure you selected the DATALOG folder from your SD card. Need help?{' '}
                 <a href="/about#getting-started" className="text-primary hover:underline">See the guide</a>.
               </p>
             </div>

--- a/components/upload/file-upload.tsx
+++ b/components/upload/file-upload.tsx
@@ -98,7 +98,7 @@ export function FileUpload({ onFilesSelected, disabled }: FileUploadProps) {
       <div
         role="button"
         tabIndex={0}
-        aria-label={sdFiles.length > 0 ? `${sdFiles.length} SD card files selected. Click to change selection.` : 'Upload ResMed SD card root folder. Click or drag and drop.'}
+        aria-label={sdFiles.length > 0 ? `${sdFiles.length} SD card files selected. Click to change selection.` : 'Upload PAP SD card root folder. Click or drag and drop.'}
         className={`group relative cursor-pointer rounded-xl border-2 border-dashed transition-all ${
           dragOver
             ? 'border-primary bg-primary/5'
@@ -135,7 +135,7 @@ export function FileUpload({ onFilesSelected, disabled }: FileUploadProps) {
                 ? sdValidation
                   ? `${sdValidation.edfCount} EDF files found`
                   : `${sdFiles.length} files selected`
-                : 'Upload ResMed SD Card'}
+                : 'Upload SD Card'}
             </p>
             <p className="mt-0.5 text-xs text-muted-foreground">
               {sdFiles.length > 0
@@ -163,7 +163,7 @@ export function FileUpload({ onFilesSelected, disabled }: FileUploadProps) {
           {sdFiles.length === 0 && (
             <div className="mt-2 flex flex-col gap-1.5 text-left">
               {[
-                'Remove the SD card from your ResMed machine',
+                'Remove the SD card from your PAP machine',
                 'Insert it into your computer (use an adapter if needed)',
                 'Click here and select the SD card root folder',
               ].map((step, i) => (
@@ -176,6 +176,14 @@ export function FileUpload({ onFilesSelected, disabled }: FileUploadProps) {
                   </span>
                 </div>
               ))}
+              <div className="mt-2 space-y-0.5">
+                <p className="text-[10px] text-muted-foreground/70">
+                  Currently supports ResMed AirSense 10/11 and AirCurve 10.
+                </p>
+                <p className="text-[10px] text-muted-foreground/70">
+                  Using another device? Upload your data and enable data sharing so we can analyse the structure and add support.
+                </p>
+              </div>
             </div>
           )}
         </div>

--- a/lib/upload-validation.ts
+++ b/lib/upload-validation.ts
@@ -13,7 +13,7 @@ export interface ValidationResult {
 /**
  * Validate selected SD card files before analysis.
  * Checks for presence of EDF files, expected folder structure,
- * and common mistakes (wrong folder, non-ResMed data).
+ * and common mistakes (wrong folder, unsupported data).
  */
 export function validateSDFiles(files: File[]): ValidationResult {
   const warnings: string[] = [];
@@ -50,14 +50,14 @@ export function validateSDFiles(files: File[]): ValidationResult {
   // Check for common mistakes
   if (edfFiles.length === 0) {
     errors.push(
-      'No EDF files found. Make sure you selected the DATALOG folder from your ResMed SD card.'
+      'No EDF files found. Make sure you selected the root folder or DATALOG folder from your PAP machine\'s SD card.'
     );
     return { valid: false, edfCount: 0, warnings, errors };
   }
 
   if (!hasDatalog && edfFiles.length < 5) {
     warnings.push(
-      'Folder structure doesn\'t look like a ResMed SD card. Expected a DATALOG folder with dated subfolders.'
+      'Folder structure doesn\'t match a recognised PAP SD card layout. Expected a DATALOG folder with dated subfolders.'
     );
   }
 


### PR DESCRIPTION
## Summary
- Removed "ResMed" from upload heading, step instructions, validation errors/warnings, page subtitle, error help text, and meta descriptions
- Added compatibility note: "Currently supports ResMed AirSense 10/11 and AirCurve 10"
- Added CTA for non-ResMed users: "Using another device? Upload your data and enable data sharing so we can analyse the structure and add support."

## Files Changed
- `components/upload/file-upload.tsx` — heading, aria-label, step 1, compatibility note + other-device CTA
- `lib/upload-validation.ts` — no-EDF error + folder structure warning copy
- `app/analyze/page.tsx` — subtitle + error state help text
- `app/analyze/layout.tsx` — meta description + OG description
- `__tests__/upload-validation.test.ts` — 2 new tests confirming "ResMed" absent from validation messages
- `CHANGELOG.md` — added entry

## Review Results
- TypeScript: ✓
- Lint: ✓
- Tests: ✓ (414 passed, 0 failed)
- Build: ✓

## Test plan
- [ ] Upload a ResMed SD card — works as before
- [ ] Verify upload area says "Upload SD Card" (not "Upload ResMed SD Card")
- [ ] Verify compatibility note + other-device CTA visible below steps
- [ ] Upload non-EDF files — error message says "PAP machine's SD card" not "ResMed"
- [ ] Check `/analyze` meta tags in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)