### PR TITLE
fix: waveform stuck, consent not persisting, unhandled crash

### DIFF
--- a/components/dashboard/data-contribution.tsx
+++ b/components/dashboard/data-contribution.tsx
@@ -5,7 +5,7 @@ import { Users, Loader2, X, Shield, Heart, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { events } from '@/lib/analytics';
 import { contributeNights, trackContributedDates } from '@/lib/contribute';
-import { getConsentState } from '@/components/upload/contribution-consent-utils';
+import { getConsentState, setConsentState } from '@/components/upload/contribution-consent-utils';
 import type { NightResult } from '@/lib/types';
 
 const DISMISS_KEY = 'airwaylab_contribute_dismissed';
@@ -90,6 +90,8 @@ export function DataContribution({
       setStatus('success');
       events.contributionOptedIn();
       trackContributedDates(nights);
+      // Persist opt-in so the user isn't prompted again on future visits
+      setConsentState(true);
     } catch {
       setStatus('error');
     }

--- a/components/dashboard/waveform-tab.tsx
+++ b/components/dashboard/waveform-tab.tsx
@@ -55,11 +55,9 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
 
     if (sdFiles.length > 0) {
       // Local files available — extract from them
-      if (waveformOrchestrator.hasCached(dateStr)) {
-        waveformOrchestrator.extract(sdFiles, dateStr);
-      } else {
-        waveformOrchestrator.extract(sdFiles, dateStr);
-      }
+      waveformOrchestrator.extract(sdFiles, dateStr).catch((err) => {
+        console.error('[waveform-tab] extraction failed:', err);
+      });
       return;
     }
 
@@ -72,8 +70,10 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
       loadCloudFiles(dateStr)
         .then((cloudFiles) => {
           if (cloudFiles.length > 0) {
-            waveformOrchestrator.extract(cloudFiles, dateStr);
+            return waveformOrchestrator.extract(cloudFiles, dateStr);
           }
+        })
+        .then(() => {
           setCloudAttempted(true);
         })
         .catch((err) => {
@@ -87,7 +87,9 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
 
   const handleRetry = useCallback(() => {
     if (sdFiles.length > 0) {
-      waveformOrchestrator.extract(sdFiles, selectedNight.dateStr);
+      waveformOrchestrator.extract(sdFiles, selectedNight.dateStr).catch((err) => {
+        console.error('[waveform-tab] retry failed:', err);
+      });
     } else if (user) {
       // Retry cloud load
       cloudAttemptedDates.current.delete(selectedNight.dateStr);
@@ -96,10 +98,10 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
       loadCloudFiles(selectedNight.dateStr)
         .then((cloudFiles) => {
           if (cloudFiles.length > 0) {
-            waveformOrchestrator.extract(cloudFiles, selectedNight.dateStr);
+            return waveformOrchestrator.extract(cloudFiles, selectedNight.dateStr);
           }
-          setCloudAttempted(true);
         })
+        .then(() => setCloudAttempted(true))
         .catch(() => setCloudAttempted(true))
         .finally(() => setCloudLoading(false));
     }

--- a/hooks/use-waveform.ts
+++ b/hooks/use-waveform.ts
@@ -49,7 +49,9 @@ export function useWaveform(
 
     if (sdFiles.length > 0) {
       // Local files available — extract from them
-      waveformOrchestrator.extract(sdFiles, dateStr);
+      waveformOrchestrator.extract(sdFiles, dateStr).catch((err) => {
+        console.error('[use-waveform] extraction failed:', err);
+      });
       return;
     }
 
@@ -62,8 +64,10 @@ export function useWaveform(
       loadCloudFiles(dateStr)
         .then((cloudFiles) => {
           if (cloudFiles.length > 0) {
-            waveformOrchestrator.extract(cloudFiles, dateStr);
+            return waveformOrchestrator.extract(cloudFiles, dateStr);
           }
+        })
+        .then(() => {
           setCloudAttempted(true);
         })
         .catch((err: unknown) => {
@@ -77,7 +81,9 @@ export function useWaveform(
 
   const retry = useCallback(() => {
     if (sdFiles.length > 0) {
-      waveformOrchestrator.extract(sdFiles, selectedNight.dateStr);
+      waveformOrchestrator.extract(sdFiles, selectedNight.dateStr).catch((err) => {
+        console.error('[use-waveform] retry failed:', err);
+      });
     } else if (user) {
       // Retry cloud load
       cloudAttemptedDates.current.delete(selectedNight.dateStr);
@@ -86,10 +92,10 @@ export function useWaveform(
       loadCloudFiles(selectedNight.dateStr)
         .then((cloudFiles) => {
           if (cloudFiles.length > 0) {
-            waveformOrchestrator.extract(cloudFiles, selectedNight.dateStr);
+            return waveformOrchestrator.extract(cloudFiles, selectedNight.dateStr);
           }
-          setCloudAttempted(true);
         })
+        .then(() => setCloudAttempted(true))
         .catch(() => setCloudAttempted(true))
         .finally(() => setCloudLoading(false));
     }

--- a/lib/waveform-orchestrator.ts
+++ b/lib/waveform-orchestrator.ts
@@ -14,7 +14,7 @@ export interface WaveformState {
   error: string | null;
 }
 
-const WORKER_TIMEOUT_MS = 30_000; // 30 seconds
+const WORKER_TIMEOUT_MS = 60_000; // 60 seconds (increased from 30 for large SD cards)
 const BUCKET_SECONDS = 2; // 2-second buckets for overview
 
 class WaveformOrchestrator {
@@ -66,8 +66,21 @@ class WaveformOrchestrator {
     this.setState({ status: 'loading', waveform: null, error: null });
 
     try {
-      // Read files into ArrayBuffers
-      const fileBuffers = await readFiles(files);
+      // Pre-filter to BRP files only — avoids reading non-flow files into memory
+      const brpFiles = files.filter((f) => {
+        const path =
+          (f as unknown as { webkitRelativePath?: string }).webkitRelativePath || f.name;
+        const name = (path.split('/').pop() || '').toLowerCase();
+        return (name.endsWith('brp.edf') || name.endsWith('_brp.edf')) && f.size > 50 * 1024;
+      });
+
+      if (brpFiles.length === 0) {
+        this.setState({ status: 'error', waveform: null, error: 'No flow data files found' });
+        return null;
+      }
+
+      // Read only BRP files into ArrayBuffers
+      const fileBuffers = await readFiles(brpFiles);
 
       // Run worker
       const waveform = await this.runWorker(fileBuffers, targetDate);
@@ -116,9 +129,15 @@ class WaveformOrchestrator {
         clearTimeout(timeout);
       };
 
-      this.worker = new Worker(
-        new URL('./waveform-worker.ts', import.meta.url)
-      );
+      try {
+        this.worker = new Worker(
+          new URL('./waveform-worker.ts', import.meta.url)
+        );
+      } catch (err) {
+        settle();
+        reject(new Error(err instanceof Error ? err.message : 'Failed to create waveform worker'));
+        return;
+      }
 
       this.worker.onmessage = (e: MessageEvent<WaveformWorkerResponse>) => {
         const msg = e.data;


### PR DESCRIPTION
## Summary

- **Waveform extraction stuck**: Pre-filter SD card files to BRP-only before reading into memory — avoids reading hundreds of non-flow files into ArrayBuffers. Increased worker timeout from 30s to 60s. Added try-catch around Worker construction.
- **Contribution consent not persisting**: When user manually contributes via the dashboard banner button, the `airwaylab_contribute_optin` flag is now persisted. Previously only dates were tracked, so users were re-prompted on every visit with new data.
- **Page crash**: All fire-and-forget `waveformOrchestrator.extract()` calls now have `.catch()` handlers. Cloud extraction promises are properly chained so errors propagate to existing catch handlers instead of causing unhandled rejections.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] All 414 tests pass
- [ ] Upload large SD card (60+ days) → waveform tab should load or show error, not hang
- [ ] Manually contribute via banner → reload with new data → should auto-submit, not re-prompt
- [ ] Waveform extraction failure → should show error state with retry button, not crash page

🤖 Generated with [Claude Code](https://claude.com/claude-code)