### PR TITLE
fix: graphs tab crash from memory exhaustion on large SD cards

### DIFF
--- a/components/dashboard/graphs-tab.tsx
+++ b/components/dashboard/graphs-tab.tsx
@@ -13,6 +13,7 @@ import { RespiratoryRateChart } from '@/components/charts/respiratory-rate-chart
 import { SharedChartToolbar } from '@/components/charts/shared-chart-toolbar';
 import { SyncedViewportProvider } from '@/hooks/use-synced-viewport';
 import { useWaveform } from '@/hooks/use-waveform';
+import { ErrorBoundary } from '@/components/common/error-boundary';
 import { formatElapsedTimeShort } from '@/lib/waveform-utils';
 import type { NightResult } from '@/lib/types';
 import {
@@ -171,18 +172,22 @@ export function GraphsTab({
               </Button>
             </div>
 
-            {/* Stacked charts */}
+            {/* Stacked charts — each wrapped in its own ErrorBoundary */}
             <div className="flex flex-col gap-4 rounded-lg border border-border/50 bg-card/20 p-3">
               {/* Flow Waveform */}
-              <FlowWaveform
-                waveform={waveform}
-                showPressure={showFlowPressure}
-                showEvents={showEvents}
-              />
+              <ErrorBoundary context="Flow Waveform">
+                <FlowWaveform
+                  waveform={waveform}
+                  showPressure={showFlowPressure}
+                  showEvents={showEvents}
+                />
+              </ErrorBoundary>
 
               {/* Tidal Volume */}
               {hasTidalVolume ? (
-                <TidalVolumeChart tidalVolume={waveform.tidalVolume!} />
+                <ErrorBoundary context="Tidal Volume">
+                  <TidalVolumeChart tidalVolume={waveform.tidalVolume!} />
+                </ErrorBoundary>
               ) : (
                 <div className="flex items-center justify-center py-4 text-xs text-muted-foreground/60">
                   Requires flow data — upload your SD card.
@@ -191,7 +196,9 @@ export function GraphsTab({
 
               {/* Respiratory Rate */}
               {hasRespRate ? (
-                <RespiratoryRateChart respiratoryRate={waveform.respiratoryRate!} />
+                <ErrorBoundary context="Respiratory Rate">
+                  <RespiratoryRateChart respiratoryRate={waveform.respiratoryRate!} />
+                </ErrorBoundary>
               ) : (
                 <div className="flex items-center justify-center py-4 text-xs text-muted-foreground/60">
                   Requires flow data — upload your SD card.
@@ -200,10 +207,12 @@ export function GraphsTab({
 
               {/* Pressure */}
               {hasPressure ? (
-                <DevicePressureChart
-                  pressure={waveform.pressure}
-                  settings={selectedNight.settings}
-                />
+                <ErrorBoundary context="Pressure">
+                  <DevicePressureChart
+                    pressure={waveform.pressure}
+                    settings={selectedNight.settings}
+                  />
+                </ErrorBoundary>
               ) : (
                 <div className="flex items-center justify-center py-4 text-xs text-muted-foreground/60">
                   No pressure data in this recording.
@@ -212,7 +221,9 @@ export function GraphsTab({
 
               {/* Leak */}
               {hasLeak ? (
-                <DeviceLeakChart leak={waveform.leak} />
+                <ErrorBoundary context="Leak">
+                  <DeviceLeakChart leak={waveform.leak} />
+                </ErrorBoundary>
               ) : (
                 <div className="flex items-center justify-center py-4 text-xs text-muted-foreground/60">
                   No leak data in this recording.
@@ -221,7 +232,9 @@ export function GraphsTab({
 
               {/* SpO2 — always visible */}
               {oxTrace ? (
-                <SpO2Trace trace={oxTrace} />
+                <ErrorBoundary context="SpO₂ Trace">
+                  <SpO2Trace trace={oxTrace} />
+                </ErrorBoundary>
               ) : (
                 <div className="flex flex-col items-center justify-center gap-2 py-6">
                   <HeartPulse className="h-5 w-5 text-muted-foreground/40" />
@@ -243,10 +256,10 @@ export function GraphsTab({
 
             {/* Stats bar */}
             <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border/50 bg-card/50 px-4 py-3 text-xs text-muted-foreground sm:gap-5">
-              <span>Duration: <strong className="text-foreground">{formatElapsedTimeShort(waveform.durationSeconds)}</strong></span>
-              <span>Breaths: <strong className="text-foreground">{waveform.stats.breathCount.toLocaleString()}</strong></span>
-              <span>Flow range: <strong className="text-foreground">{waveform.stats.flowMin.toFixed(0)} – {waveform.stats.flowMax.toFixed(0)} L/min</strong></span>
-              {waveform.stats.pressureMin !== null && waveform.stats.pressureMax !== null && (
+              <span>Duration: <strong className="text-foreground">{formatElapsedTimeShort(waveform.durationSeconds ?? 0)}</strong></span>
+              <span>Breaths: <strong className="text-foreground">{(waveform.stats?.breathCount ?? 0).toLocaleString()}</strong></span>
+              <span>Flow range: <strong className="text-foreground">{(waveform.stats?.flowMin ?? 0).toFixed(0)} – {(waveform.stats?.flowMax ?? 0).toFixed(0)} L/min</strong></span>
+              {waveform.stats?.pressureMin != null && waveform.stats?.pressureMax != null && (
                 <span>Pressure: <strong className="text-foreground">{waveform.stats.pressureMin.toFixed(1)} – {waveform.stats.pressureMax.toFixed(1)} cmH₂O</strong></span>
               )}
               <span>Events: <strong className="text-foreground">{waveform.events.length}</strong></span>

--- a/lib/waveform-orchestrator.ts
+++ b/lib/waveform-orchestrator.ts
@@ -79,8 +79,21 @@ class WaveformOrchestrator {
         return null;
       }
 
-      // Read only BRP files into ArrayBuffers
-      const fileBuffers = await readFiles(brpFiles);
+      // Further filter to only BRP files matching the target date's DATALOG folder.
+      // A night like "2026-03-10" has files in DATALOG/20260310/.
+      // This avoids reading ALL BRP files into memory (60+ files for large SD cards).
+      const dateCompact = targetDate.replace(/-/g, ''); // "20260310"
+      const dateFiltered = brpFiles.filter((f) => {
+        const path =
+          (f as unknown as { webkitRelativePath?: string }).webkitRelativePath || f.name;
+        return path.includes(`DATALOG/${dateCompact}/`) || path.includes(`/${dateCompact}_`);
+      });
+
+      // Fall back to all BRP files if no path-based match (non-standard folder structure)
+      const filesToRead = dateFiltered.length > 0 ? dateFiltered : brpFiles;
+
+      // Read only matching BRP files into ArrayBuffers
+      const fileBuffers = await readFiles(filesToRead);
 
       // Run worker
       const waveform = await this.runWorker(fileBuffers, targetDate);


### PR DESCRIPTION
## Summary

- **Root cause**: Waveform extraction read ALL ~60+ BRP files into ArrayBuffers to display a single night. For 2 months of data at 10-20MB/file, that's 600MB-1.2GB — enough to crash the browser tab with an OOM kill (no error boundary can catch this).
- **Fix**: Filter BRP files by `DATALOG/YYYYMMDD/` folder date BEFORE reading, so only 1-3 files for the target night are loaded. Falls back to all BRP files for non-standard folder structures.
- **Per-chart ErrorBoundary**: Each chart (flow, tidal volume, respiratory rate, pressure, leak, SpO2) now has its own error boundary. A Recharts crash in one chart shows a scoped error card instead of taking down the entire graphs tab.
- **Defensive stats access**: Optional chaining on `waveform.stats` properties in the stats bar.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes  
- [x] All 414 tests pass
- [ ] Upload large SD card (60+ days) → graphs tab should load without crashing
- [ ] Verify waveform renders correctly for selected night
- [ ] If a chart fails, only that chart shows error — rest of page works

🤖 Generated with [Claude Code](https://claude.com/claude-code)