### PR TITLE
fix: cap event overlay ReferenceAreas to prevent browser OOM crash

### DIFF
--- a/components/charts/flow-waveform.tsx
+++ b/components/charts/flow-waveform.tsx
@@ -82,14 +82,22 @@ export const FlowWaveform = memo(function FlowWaveform({
     [allData, viewport.clampedStart, viewport.clampedEnd]
   );
 
-  // Filter events to visible range
-  const visibleEvents = useMemo(() => {
-    if (!showEvents || data.length === 0) return [];
+  // Filter events to visible range, capped to prevent SVG OOM
+  const MAX_VISIBLE_EVENTS = 100;
+  const { visibleEvents, eventsCapped } = useMemo(() => {
+    if (!showEvents || data.length === 0) return { visibleEvents: [] as typeof waveform.events, eventsCapped: false };
     const startT = data[0].t;
     const endT = data[data.length - 1].t;
-    return waveform.events.filter(
+    const filtered = waveform.events.filter(
       (e) => e.endSec >= startT && e.startSec <= endT
     );
+    if (filtered.length <= MAX_VISIBLE_EVENTS) {
+      return { visibleEvents: filtered, eventsCapped: false };
+    }
+    // Evenly sample to keep spatial distribution
+    const step = filtered.length / MAX_VISIBLE_EVENTS;
+    const sampled = Array.from({ length: MAX_VISIBLE_EVENTS }, (_, i) => filtered[Math.round(i * step)]);
+    return { visibleEvents: sampled, eventsCapped: true };
   }, [waveform.events, showEvents, data]);
 
   const tickFormatter = useCallback((value: number) => formatElapsedTimeShort(value), []);
@@ -112,6 +120,9 @@ export const FlowWaveform = memo(function FlowWaveform({
               <span className="inline-block h-2 w-3 rounded-sm bg-chart-1/25" />
               M
             </span>
+            {eventsCapped && (
+              <span className="text-amber-500/80">Zoom in to see all events</span>
+            )}
           </div>
         )}
       </div>

--- a/components/charts/spo2-trace.tsx
+++ b/components/charts/spo2-trace.tsx
@@ -91,12 +91,19 @@ export const SpO2Trace = memo(function SpO2Trace({
     [points, localStart, localEnd]
   );
 
-  // Filter ODI events to visible range
-  const visibleODI3 = useMemo(() => {
-    if (!showODIEvents || data.length === 0) return [];
+  // Filter ODI events to visible range, capped to prevent SVG OOM
+  const MAX_VISIBLE_ODI = 100;
+  const { visibleODI3, odiCapped } = useMemo(() => {
+    if (!showODIEvents || data.length === 0) return { visibleODI3: [] as number[], odiCapped: false };
     const startT = data[0].t;
     const endT = data[data.length - 1].t;
-    return trace.odi3Events.filter((t) => t >= startT && t <= endT);
+    const filtered = trace.odi3Events.filter((t) => t >= startT && t <= endT);
+    if (filtered.length <= MAX_VISIBLE_ODI) {
+      return { visibleODI3: filtered, odiCapped: false };
+    }
+    const step = filtered.length / MAX_VISIBLE_ODI;
+    const sampled = Array.from({ length: MAX_VISIBLE_ODI }, (_, i) => filtered[Math.round(i * step)]);
+    return { visibleODI3: sampled, odiCapped: true };
   }, [trace.odi3Events, showODIEvents, data]);
 
   // Determine SpO2 Y-axis domain
@@ -226,6 +233,9 @@ export const SpO2Trace = memo(function SpO2Trace({
           <span className="inline-block h-2 w-3 rounded-sm" style={{ backgroundColor: 'hsl(0 84% 60% / 0.2)' }} />
           ODI-3
         </span>
+        {odiCapped && (
+          <span className="text-amber-500/80">Zoom in to see all events</span>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- The previous downsample fix (#68) capped chart **data points** at 1500 but left **event overlays** (Recharts `ReferenceArea` SVG elements) uncapped
- Nights with high event counts (500+ RERA/FL/M-shape events, 300+ ODI-3 desaturations) rendered hundreds of SVG elements that crashed the browser tab
- Caps both `FlowWaveform` and `SpO2Trace` visible events to 100 evenly-sampled ReferenceAreas, with a "Zoom in to see all events" hint when capped

## Test plan
- [ ] Upload SD card with high-AHI night (50+ events/hr) → Graphs tab should load without crash
- [ ] Verify event markers still render correctly on zoomed-in views
- [ ] Verify "Zoom in to see all events" hint appears on full-night view with many events
- [ ] Verify no regression on nights with few events (< 100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)