### PR TITLE
feat: improve chart zoom/pan discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to AirwayLab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — Chart UX Discoverability (2026-03-11)
+
+### Changed
+
+- **Zoom presets restyled as pill buttons**: Time range presets (5m/15m/30m/1h/2h) now render as distinct outline pill buttons instead of invisible ghost text, with the active preset highlighted (`chart-ux-discoverability`)
+- **Interaction hint near toolbar**: First-use hint explaining scroll-to-zoom and drag-to-pan appears below the toolbar (touch-aware), auto-dismisses after first interaction, dismissable via × button (`chart-ux-discoverability`)
+- **Minimap hover state**: Minimap bar now shows a visible hover state change for better affordance (`chart-ux-discoverability`)
+
+### Fixed
+
+- **Outdated waveform disclaimer**: Removed reference to non-existent "brush control" from waveform tab disclaimer text (`chart-ux-discoverability`)
+- **Buried interaction hints**: Removed 9px hint text previously hidden at the bottom of the page, replaced by the new near-toolbar hint (`chart-ux-discoverability`)
+
 ## [Unreleased] — E2E Testing with Real EDF Fixtures (2026-03-11)
 
 ### Added

--- a/components/charts/chart-interaction-hint.tsx
+++ b/components/charts/chart-interaction-hint.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { X } from 'lucide-react';
+import { useSyncedViewport } from '@/hooks/use-synced-viewport';
+
+const STORAGE_KEY = 'airwaylab_chart_hint_dismissed';
+
+function isDismissed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function persistDismiss(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, '1');
+  } catch {
+    // localStorage full or unavailable — hint will show again next session
+  }
+}
+
+export function ChartInteractionHint() {
+  const viewport = useSyncedViewport();
+  const [visible, setVisible] = useState(false);
+  const [isTouch, setIsTouch] = useState(false);
+
+  // Show hint only if not previously dismissed
+  useEffect(() => {
+    if (!isDismissed()) {
+      setVisible(true);
+    }
+    // Detect touch capability
+    setIsTouch('ontouchstart' in window || navigator.maxTouchPoints > 0);
+  }, []);
+
+  // Auto-dismiss when user zooms or pans (viewport changes from full view)
+  const dismiss = useCallback(() => {
+    setVisible(false);
+    persistDismiss();
+  }, []);
+
+  useEffect(() => {
+    if (visible && !viewport.isFullView) {
+      dismiss();
+    }
+  }, [visible, viewport.isFullView, dismiss]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-primary/20 bg-primary/[0.06] px-3 py-1.5 text-[11px] text-muted-foreground">
+      <span>
+        {isTouch
+          ? 'Pinch to zoom \u00b7 Swipe to pan \u00b7 Tap time presets above for quick ranges'
+          : 'Scroll to zoom \u00b7 Drag to pan \u00b7 Use time presets above for quick ranges'}
+      </span>
+      <button
+        onClick={dismiss}
+        className="ml-auto shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-foreground"
+        aria-label="Dismiss chart controls hint"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/components/charts/shared-chart-toolbar.tsx
+++ b/components/charts/shared-chart-toolbar.tsx
@@ -11,12 +11,26 @@ interface Props {
   disabled?: boolean;
 }
 
+function getActivePreset(visibleDuration: number): string | null {
+  // Find the preset whose duration is closest to the current visible duration
+  let best: { label: string; diff: number } | null = null;
+  for (const p of ZOOM_PRESETS) {
+    const diff = Math.abs(p.seconds - visibleDuration);
+    // Only match if within 20% of the preset duration
+    if (diff / p.seconds <= 0.2 && (!best || diff < best.diff)) {
+      best = { label: p.label, diff };
+    }
+  }
+  return best?.label ?? null;
+}
+
 export function SharedChartToolbar({ durationSeconds, disabled = false }: Props) {
   const viewport = useSyncedViewport();
 
   const visibleStart = viewport.clampedStart * viewport.bucketSeconds;
   const visibleEnd = viewport.clampedEnd * viewport.bucketSeconds;
   const visibleDuration = visibleEnd - visibleStart;
+  const activePreset = viewport.isFullView ? null : getActivePreset(visibleDuration);
 
   return (
     <div
@@ -26,18 +40,25 @@ export function SharedChartToolbar({ durationSeconds, disabled = false }: Props)
     >
       <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-border/50 bg-card/30 px-3 py-2">
         <div className="flex flex-wrap items-center gap-1.5">
-          {ZOOM_PRESETS.map((p) => (
-            <Button
-              key={p.label}
-              variant="ghost"
-              size="sm"
-              onClick={() => viewport.zoomToPreset(p.seconds)}
-              disabled={disabled || p.seconds > durationSeconds}
-              className="h-6 px-2 text-[10px] text-muted-foreground hover:text-foreground"
-            >
-              {p.label}
-            </Button>
-          ))}
+          {ZOOM_PRESETS.map((p) => {
+            const isActive = activePreset === p.label;
+            return (
+              <Button
+                key={p.label}
+                variant="outline"
+                size="sm"
+                onClick={() => viewport.zoomToPreset(p.seconds)}
+                disabled={disabled || p.seconds > durationSeconds}
+                className={
+                  isActive
+                    ? 'h-6 rounded-full border-primary/50 bg-primary/15 px-2.5 text-[10px] font-medium text-primary'
+                    : 'h-6 rounded-full border-border/60 px-2.5 text-[10px] font-medium text-muted-foreground hover:border-primary/40 hover:bg-primary/[0.06] hover:text-foreground'
+                }
+              >
+                {p.label}
+              </Button>
+            );
+          })}
           <div className="mx-1 h-4 w-px bg-border/50" />
           <Button
             variant="ghost"
@@ -106,7 +127,7 @@ export function SharedChartToolbar({ durationSeconds, disabled = false }: Props)
       {/* Minimap */}
       <div className="px-2">
         <div
-          className="relative h-2 w-full cursor-pointer rounded-full bg-border/30"
+          className="relative h-2 w-full cursor-pointer rounded-full bg-border/30 transition-colors hover:bg-border/50"
           onClick={(e) => {
             if (disabled) return;
             const rect = e.currentTarget.getBoundingClientRect();
@@ -118,7 +139,7 @@ export function SharedChartToolbar({ durationSeconds, disabled = false }: Props)
             viewport.setViewStart(newStart);
             viewport.setViewEnd(newStart + visibleCount);
           }}
-          aria-label="Click to jump to position"
+          aria-label="Minimap — click to jump to position"
         >
           <div
             className="absolute top-0 h-full rounded-full bg-primary/40 transition-all duration-100"

--- a/components/dashboard/graphs-tab.tsx
+++ b/components/dashboard/graphs-tab.tsx
@@ -11,6 +11,7 @@ import { SpO2Trace } from '@/components/charts/spo2-trace';
 import { TidalVolumeChart } from '@/components/charts/tidal-volume-chart';
 import { RespiratoryRateChart } from '@/components/charts/respiratory-rate-chart';
 import { SharedChartToolbar } from '@/components/charts/shared-chart-toolbar';
+import { ChartInteractionHint } from '@/components/charts/chart-interaction-hint';
 import { SyncedViewportProvider } from '@/hooks/use-synced-viewport';
 import { useWaveform } from '@/hooks/use-waveform';
 import { ErrorBoundary } from '@/components/common/error-boundary';
@@ -149,6 +150,9 @@ export function GraphsTab({
             {/* Shared toolbar + minimap */}
             <SharedChartToolbar durationSeconds={waveform.durationSeconds} />
 
+            {/* First-use interaction hint */}
+            <ChartInteractionHint />
+
             {/* Toggle buttons */}
             <div className="flex flex-wrap items-center gap-2">
               <Button
@@ -266,13 +270,7 @@ export function GraphsTab({
               <span>Sample rate: <strong className="text-foreground">{waveform.originalSampleRate.toFixed(0)} Hz</strong></span>
             </div>
 
-            {/* Hints + disclaimer */}
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="text-[9px] text-muted-foreground/40">
-                Scroll to zoom · Drag to pan · Pinch to zoom on touch · Arrow keys navigate · Esc resets
-              </div>
-            </div>
-
+            {/* Disclaimer */}
             <p className="text-[10px] leading-relaxed text-muted-foreground/50">
               Flow waveforms are downsampled for display. Tidal volume and respiratory rate are approximate.
               Event detection on this view is approximate — refer to the Flow Analysis tab for authoritative engine results.

--- a/components/dashboard/waveform-tab.tsx
+++ b/components/dashboard/waveform-tab.tsx
@@ -270,8 +270,7 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
       {/* Disclaimer */}
       <p className="text-[10px] leading-relaxed text-muted-foreground/50">
         Flow waveforms are downsampled for display. Event detection on this view is approximate —
-        refer to the Flow Analysis tab for authoritative engine results. Use the brush control
-        below the chart to zoom into specific time ranges.
+        refer to the Flow Analysis tab for authoritative engine results.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

- Zoom presets (5m/15m/30m/1h/2h) restyled from invisible ghost text to distinct outline pill buttons with active-state highlighting for the current zoom level
- Added dismissable first-use interaction hint near the toolbar ("Scroll to zoom · Drag to pan") — touch-aware, auto-dismisses after first zoom/pan, persists dismissal in localStorage
- Minimap now shows visible hover state for better affordance
- Fixed outdated "brush control" reference in waveform tab disclaimer
- Removed buried 9px hint text from bottom of page

## Files Changed
- `components/charts/shared-chart-toolbar.tsx` — Pill button styling, active preset, minimap hover
- `components/charts/chart-interaction-hint.tsx` — New dismissable hint component
- `components/dashboard/graphs-tab.tsx` — Added hint, removed old bottom hint
- `components/dashboard/waveform-tab.tsx` — Fixed outdated disclaimer text
- `CHANGELOG.md` — Updated

## Test plan
- [ ] Load Graphs tab → verify zoom presets display as visible pill buttons (not ghost text)
- [ ] Zoom to 15m → verify the 15m button highlights
- [ ] First load shows interaction hint below toolbar
- [ ] Scroll-zoom or drag-pan → hint auto-dismisses
- [ ] Reload page → hint stays dismissed
- [ ] Clear `airwaylab_chart_hint_dismissed` from localStorage → hint reappears
- [ ] On mobile/touch device → hint shows "Pinch to zoom" text
- [ ] Hover minimap bar → visible background change
- [ ] Waveform tab disclaimer no longer mentions "brush control"

🤖 Generated with [Claude Code](https://claude.com/claude-code)