### PR TITLE
fix: tighten dashboard spacing so metrics appear above the fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to AirwayLab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — Dashboard Density (2026-03-11)
+
+### Changed
+
+- **Tighter dashboard spacing**: Reduced vertical gaps between sections (`gap-6` → `gap-4`, header margin reduced) so key metrics appear above the fold on typical laptop viewports (`dashboard-density-above-fold`)
+- **Device Settings collapsed by default**: Converted from always-visible card to a collapsible `<details>` element, saving ~120px of vertical space on load. All fields still accessible with one click (`dashboard-density-above-fold`)
+
 ## [Unreleased] — Chart UX Discoverability (2026-03-11)
 
 ### Changed

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -392,7 +392,7 @@ function AnalyzePageInner() {
       )}
 
       {/* Header */}
-      <div className="mb-6 sm:mb-8">
+      <div className="mb-4 sm:mb-6">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
@@ -540,7 +540,7 @@ function AnalyzePageInner() {
       {/* Results Dashboard */}
       {isComplete && nights.length > 0 && currentNight && (
         <ThresholdsProvider>
-        <div className="flex flex-col gap-6 animate-fade-in-up">
+        <div className="flex flex-col gap-4 animate-fade-in-up">
           {/* Demo Banner */}
           {isDemo && (
             <div className="flex flex-col gap-3 rounded-xl border border-primary/20 bg-primary/5 px-4 py-3">
@@ -698,7 +698,7 @@ function AnalyzePageInner() {
               </TabsTrigger>
             </TabsList>
 
-            <TabsContent value="overview" className="mt-6">
+            <TabsContent value="overview" className="mt-4">
               <ErrorBoundary context="Overview">
                 <OverviewTab
                   nights={nights}

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -138,7 +138,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
   );
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-4">
       {/* Night Summary Hero — single glanceable takeaway */}
       <NightSummaryHero night={n} />
 
@@ -154,16 +154,17 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         </div>
       )}
 
-      {/* Device Settings & Session Info */}
-      <Card className="border-border/50">
-        <CardHeader className="pb-2">
-          <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-            <Settings2 className="h-4 w-4" />
-            Device Settings
-            <span className="ml-auto text-xs font-normal tabular-nums">{fmtHrs(n.durationHours)} · {n.sessionCount} session{n.sessionCount !== 1 ? 's' : ''}</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
+      {/* Device Settings & Session Info (collapsed by default) */}
+      <details className="group rounded-xl border border-border/50 bg-card/30">
+        <summary className="flex cursor-pointer items-center gap-2 px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground [&::-webkit-details-marker]:hidden">
+          <ChevronRight className="h-4 w-4 transition-transform group-open:rotate-90" />
+          <Settings2 className="h-4 w-4" />
+          Device Settings
+          <span className="ml-auto text-xs font-normal tabular-nums">
+            {fmtHrs(n.durationHours)} · {n.sessionCount} session{n.sessionCount !== 1 ? 's' : ''}
+          </span>
+        </summary>
+        <div className="border-t border-border/30 px-4 pb-4 pt-3">
           <div className="grid grid-cols-2 gap-x-6 gap-y-2 sm:grid-cols-4">
             {n.settings.deviceModel && (
               <div className="col-span-2 sm:col-span-4">
@@ -204,8 +205,8 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
               <p className="text-xs font-medium">{n.settings.easyBreathe ? 'On' : 'Off'}</p>
             </div>
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </details>
 
       {/* Key Metrics Grid */}
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4 stagger-children">


### PR DESCRIPTION
## Summary

- Reduced vertical gaps throughout the results dashboard (`gap-6` → `gap-4`, header margin `mb-6 sm:mb-8` → `mb-4 sm:mb-6`, tab content `mt-6` → `mt-4`)
- Collapsed Device Settings into a `<details>` element by default, matching the existing Glasgow Component Breakdown pattern — saves ~120px on load
- All information is preserved — Device Settings expands with one click

Net effect: ~170px less vertical space before the 4 key metric cards, putting them above the fold on typical 1440×900 viewports.

## Test plan

- [ ] Load dashboard at 1440×900 — verify Glasgow, FL Score, NED Mean, RERA Index cards are visible without scrolling
- [ ] Click "Device Settings" → verify all fields (Device, Mode, EPAP, IPAP, PS, Rise Time, Trigger, Cycle, EasyBreathe) expand correctly
- [ ] Verify collapsed state shows Settings2 icon, "Device Settings" label, and duration + session count
- [ ] Check mobile viewport (375px) — no horizontal overflow, all content accessible
- [ ] Verify Night Summary Hero still renders above metrics
- [ ] `npx tsc --noEmit` ✓ | `npm run lint` ✓ | `npm test` ✓ (454/454) | `npm run build` ✓

**Spec:** `specs/dashboard-density-above-fold.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)