### PR TITLE
feat: add extended stats API for raw uploads and user metrics

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -22,7 +22,11 @@ export async function GET(request: Request) {
   if (!supabase) {
     // Return fallback zeros when Supabase isn't configured
     return NextResponse.json(
-      { totalUploads: 0, totalNights: 0, totalContributions: 0, totalContributedNights: 0 },
+      {
+        totalUploads: 0, totalNights: 0, totalContributions: 0, totalContributedNights: 0,
+        uniqueRawUploaders: 0, totalRawFiles: 0, totalWaveformContributions: 0,
+        uniqueWaveformContributors: 0, totalRegisteredUsers: 0,
+      },
       {
         headers: {
           'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
@@ -77,12 +81,35 @@ export async function GET(request: Request) {
       (sum, row) => sum + (row.night_count || 0), 0
     ) ?? 0;
 
+    // Fetch extended stats via RPC (raw uploads, waveform contributions, registered users)
+    let extendedStats = {
+      uniqueRawUploaders: 0,
+      totalRawFiles: 0,
+      totalWaveformContributions: 0,
+      uniqueWaveformContributors: 0,
+      totalRegisteredUsers: 0,
+    };
+
+    const { data: extData, error: extError } = await supabase.rpc('get_extended_stats');
+    if (extError) {
+      console.info('[stats] extended stats RPC skipped:', extError.message);
+    } else if (extData) {
+      extendedStats = {
+        uniqueRawUploaders: extData.unique_raw_uploaders ?? 0,
+        totalRawFiles: extData.total_raw_files ?? 0,
+        totalWaveformContributions: extData.total_waveform_contributions ?? 0,
+        uniqueWaveformContributors: extData.unique_waveform_contributors ?? 0,
+        totalRegisteredUsers: extData.total_registered_users ?? 0,
+      };
+    }
+
     return NextResponse.json(
       {
         totalUploads: totalUploads ?? 0,
         totalNights: totalNights,
         totalContributions: totalContributions ?? 0,
         totalContributedNights,
+        ...extendedStats,
       },
       {
         headers: {
@@ -92,7 +119,11 @@ export async function GET(request: Request) {
     );
   } catch {
     return NextResponse.json(
-      { totalUploads: 0, totalNights: 0, totalContributions: 0, totalContributedNights: 0 },
+      {
+        totalUploads: 0, totalNights: 0, totalContributions: 0, totalContributedNights: 0,
+        uniqueRawUploaders: 0, totalRawFiles: 0, totalWaveformContributions: 0,
+        uniqueWaveformContributors: 0, totalRegisteredUsers: 0,
+      },
       { status: 500 }
     );
   }

--- a/components/common/community-counter.tsx
+++ b/components/common/community-counter.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useEffect, useState, useRef, useCallback } from 'react';
-import { Moon, HeartHandshake } from 'lucide-react';
+import { Moon, HeartHandshake, Upload } from 'lucide-react';
 
-const CACHE_KEY = 'airwaylab_community-stats-v2';
+const CACHE_KEY = 'airwaylab_community-stats-v3';
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes (matches API cache)
 const REFRESH_INTERVAL = 60 * 1000; // 60 seconds auto-refresh
 
@@ -12,6 +12,11 @@ interface Stats {
   totalUploads: number;
   totalContributedNights: number;
   totalContributions: number;
+  uniqueRawUploaders: number;
+  totalRawFiles: number;
+  totalWaveformContributions: number;
+  uniqueWaveformContributors: number;
+  totalRegisteredUsers: number;
 }
 
 interface CachedStats extends Stats {
@@ -80,6 +85,11 @@ function useStats() {
               totalUploads: cached.totalUploads,
               totalContributedNights: cached.totalContributedNights,
               totalContributions: cached.totalContributions ?? 0,
+              uniqueRawUploaders: cached.uniqueRawUploaders ?? 0,
+              totalRawFiles: cached.totalRawFiles ?? 0,
+              totalWaveformContributions: cached.totalWaveformContributions ?? 0,
+              uniqueWaveformContributors: cached.uniqueWaveformContributors ?? 0,
+              totalRegisteredUsers: cached.totalRegisteredUsers ?? 0,
             });
             return;
           }
@@ -98,6 +108,11 @@ function useStats() {
         totalUploads: data.totalUploads ?? 0,
         totalContributedNights: data.totalContributedNights ?? 0,
         totalContributions: data.totalContributions ?? 0,
+        uniqueRawUploaders: data.uniqueRawUploaders ?? 0,
+        totalRawFiles: data.totalRawFiles ?? 0,
+        totalWaveformContributions: data.totalWaveformContributions ?? 0,
+        uniqueWaveformContributors: data.uniqueWaveformContributors ?? 0,
+        totalRegisteredUsers: data.totalRegisteredUsers ?? 0,
       };
       setStats(result);
       try {
@@ -135,12 +150,29 @@ export function CommunityCounter({
   variant = 'default',
 }: {
   className?: string;
-  variant?: 'default' | 'research';
+  variant?: 'default' | 'research' | 'raw-uploads';
 }) {
   const stats = useStats();
 
   // Don't show if no data
   if (!stats) return null;
+
+  if (variant === 'raw-uploads') {
+    // Hide if nobody has uploaded raw data yet
+    if (stats.uniqueRawUploaders === 0) return null;
+
+    return (
+      <div className={className}>
+        <Upload className="h-4 w-4 shrink-0" />
+        <span>
+          <strong className="font-semibold">
+            <AnimatedNumber value={stats.uniqueRawUploaders} />
+          </strong>{' '}
+          {stats.uniqueRawUploaders === 1 ? 'person' : 'people'} uploaded raw data
+        </span>
+      </div>
+    );
+  }
 
   if (variant === 'research') {
     // Hide if nobody has contributed yet

--- a/supabase/migrations/013_extended_stats_rpc.sql
+++ b/supabase/migrations/013_extended_stats_rpc.sql
@@ -1,0 +1,14 @@
+-- Extended stats RPC: returns all new aggregate counts in a single DB round-trip.
+-- Used by /api/stats to surface raw upload and registration metrics.
+-- SECURITY DEFINER bypasses RLS so the public API can read counts without auth.
+
+CREATE OR REPLACE FUNCTION public.get_extended_stats()
+RETURNS JSON LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT json_build_object(
+    'unique_raw_uploaders',          (SELECT COUNT(DISTINCT user_id) FROM public.user_files),
+    'total_raw_files',               (SELECT COUNT(*) FROM public.user_files),
+    'total_waveform_contributions',  (SELECT COUNT(*) FROM public.waveform_contributions),
+    'unique_waveform_contributors',  (SELECT COUNT(DISTINCT contribution_id) FROM public.waveform_contributions),
+    'total_registered_users',        (SELECT COUNT(*) FROM public.profiles)
+  );
+$$;


### PR DESCRIPTION
## Summary
- Add Supabase RPC function `get_extended_stats()` returning 5 new aggregate counts in a single DB round-trip
- Extend `/api/stats` response with `uniqueRawUploaders`, `totalRawFiles`, `totalWaveformContributions`, `uniqueWaveformContributors`, `totalRegisteredUsers`
- Extend `CommunityCounter` with `raw-uploads` variant and bump cache key to v3

## Test plan
- [ ] Deploy migration `013_extended_stats_rpc.sql` to Supabase
- [ ] `curl https://airwaylab.app/api/stats` — verify 5 new fields appear with zero values
- [ ] Verify `npx tsc --noEmit` and `npm run build` pass (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)