### PR TITLE
feat: add machine event parsing and per-type event toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to AirwayLab will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — Granular Event Toggles (2026-03-11)
+
+### Added
+
+- **Machine event parsing**: New EVE.edf parser extracts machine-recorded events (Obstructive Apnea, Central Apnea, Hypopnea, Unclassified Apnea) from ResMed EVE files using EDF+ TAL format — matching OSCAR's event types (`granular-event-toggles`)
+- **Per-type event toggles**: All event types (machine + algorithm-detected) now have individual toggle buttons on Graphs and Waveform tabs — grouped by source (Machine: OA/CA/H/UA, AirwayLab: RERA/FL/M) with event counts and color-coded dots (`granular-event-toggles`)
+- **SpO₂ trace toggles**: ODI-3 events and Heart Rate can be individually toggled on/off in the Graphs tab and Oximetry tab (`granular-event-toggles`)
+
+### Changed
+
+- **Waveform orchestrator**: Now loads EVE.edf files alongside BRP.edf files, date-filtered to avoid reading unnecessary files into memory (`granular-event-toggles`)
+- **Event overlays**: FlowWaveform chart now filters events by type using a `visibleEventTypes` set instead of a binary show/hide toggle (`granular-event-toggles`)
+
 ## [Unreleased] — Dashboard Density (2026-03-11)
 
 ### Changed

--- a/__tests__/eve-parser.test.ts
+++ b/__tests__/eve-parser.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parseEVE, type MachineEvent } from '@/lib/parsers/eve-parser';
+import { filterEVEFiles } from '@/lib/parsers/night-grouper';
+
+const FIXTURES_DIR = join(__dirname, 'fixtures/sd-card/DATALOG');
+
+function readFixture(relativePath: string): ArrayBuffer {
+  const buf = readFileSync(join(FIXTURES_DIR, relativePath));
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+}
+
+describe('EVE Parser', () => {
+  describe('parseEVE — Obstructive Apnea fixture', () => {
+    it('extracts Obstructive Apnea events with correct onset and duration', () => {
+      const buffer = readFixture('20260111/20260111_210642_EVE.edf');
+      const events = parseEVE(buffer);
+
+      expect(events.length).toBe(4);
+
+      for (const event of events) {
+        expect(event.type).toBe('obstructive-apnea');
+        expect(event.rawLabel).toBe('Obstructive Apnea');
+        expect(event.onsetSec).toBeGreaterThan(0);
+        expect(event.durationSec).toBeGreaterThan(0);
+      }
+    });
+
+    it('returns events sorted by onset', () => {
+      const buffer = readFixture('20260111/20260111_210642_EVE.edf');
+      const events = parseEVE(buffer);
+
+      for (let i = 1; i < events.length; i++) {
+        expect(events[i].onsetSec).toBeGreaterThanOrEqual(events[i - 1].onsetSec);
+      }
+    });
+
+    it('has expected onset values from hexdump analysis', () => {
+      const buffer = readFixture('20260111/20260111_210642_EVE.edf');
+      const events = parseEVE(buffer);
+
+      // From hexdump: +11954, +22791, +26424, +29628
+      expect(events[0].onsetSec).toBe(11954);
+      expect(events[1].onsetSec).toBe(22791);
+      expect(events[2].onsetSec).toBe(26424);
+      expect(events[3].onsetSec).toBe(29628);
+    });
+
+    it('has expected duration values', () => {
+      const buffer = readFixture('20260111/20260111_210642_EVE.edf');
+      const events = parseEVE(buffer);
+
+      // From hexdump: 10, 13, 11, 14
+      expect(events[0].durationSec).toBe(10);
+      expect(events[1].durationSec).toBe(13);
+      expect(events[2].durationSec).toBe(11);
+      expect(events[3].durationSec).toBe(14);
+    });
+  });
+
+  describe('parseEVE — Unclassified Apnea fixture', () => {
+    it('normalises generic "Apnea" label to unclassified-apnea', () => {
+      const buffer = readFixture('20260309/20260310_000154_EVE.edf');
+      const events = parseEVE(buffer);
+
+      expect(events.length).toBeGreaterThan(0);
+
+      for (const event of events) {
+        expect(event.type).toBe('unclassified-apnea');
+        expect(event.rawLabel).toBe('Apnea');
+      }
+    });
+
+    it('has expected onset values from hexdump analysis', () => {
+      const buffer = readFixture('20260309/20260310_000154_EVE.edf');
+      const events = parseEVE(buffer);
+
+      // From hexdump: first events at +3960, +7831, +10183, +11860, ...
+      expect(events[0].onsetSec).toBe(3960);
+      expect(events[1].onsetSec).toBe(7831);
+      expect(events[2].onsetSec).toBe(10183);
+    });
+  });
+
+  describe('parseEVE — Recording starts annotation', () => {
+    it('skips "Recording starts" annotation', () => {
+      // Both fixtures have a "Recording starts" annotation — it should be excluded
+      const buffer = readFixture('20260111/20260111_210642_EVE.edf');
+      const events = parseEVE(buffer);
+
+      for (const event of events) {
+        expect(event.rawLabel).not.toBe('Recording starts');
+      }
+    });
+  });
+
+  describe('parseEVE — error resilience', () => {
+    it('returns empty array for truncated buffer', () => {
+      const events = parseEVE(new ArrayBuffer(10));
+      expect(events).toEqual([]);
+    });
+
+    it('returns empty array for empty buffer', () => {
+      const events = parseEVE(new ArrayBuffer(0));
+      expect(events).toEqual([]);
+    });
+
+    it('returns empty array for buffer with valid header but no annotations signal', () => {
+      // Create a minimal EDF header with no EDF Annotations signal
+      const buf = new ArrayBuffer(768);
+      const view = new Uint8Array(buf);
+      const encoder = new TextEncoder();
+      // version
+      view.set(encoder.encode('0       '), 0);
+      // numSignals = 1
+      view.set(encoder.encode('1   '), 252);
+      // signal label = "SomeOther"
+      view.set(encoder.encode('SomeOther       '), 256);
+      // headerBytes
+      view.set(encoder.encode('512     '), 184);
+      // numDataRecords
+      view.set(encoder.encode('0       '), 236);
+      // recordDuration
+      view.set(encoder.encode('0.00    '), 244);
+
+      const events = parseEVE(buf);
+      expect(events).toEqual([]);
+    });
+  });
+
+  describe('parseEVE — unknown labels', () => {
+    it('skips events with unrecognised annotation labels', () => {
+      // All fixtures should only return recognised event types
+      const buffer = readFixture('20260309/20260310_000154_EVE.edf');
+      const events = parseEVE(buffer);
+
+      const validTypes = ['obstructive-apnea', 'central-apnea', 'hypopnea', 'unclassified-apnea'];
+      for (const event of events) {
+        expect(validTypes).toContain(event.type);
+      }
+    });
+  });
+});
+
+describe('filterEVEFiles', () => {
+  it('matches _EVE.edf files', () => {
+    const files = [
+      { name: '20260111_210642_EVE.edf', path: 'DATALOG/20260111/20260111_210642_EVE.edf', size: 1000 },
+      { name: '20260111_210642_BRP.edf', path: 'DATALOG/20260111/20260111_210642_BRP.edf', size: 500000 },
+      { name: 'STR.edf', path: 'STR.edf', size: 10000 },
+    ];
+
+    const result = filterEVEFiles(files);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('20260111_210642_EVE.edf');
+  });
+
+  it('matches case-insensitively', () => {
+    const files = [
+      { name: '20260111_210642_eve.edf', path: 'test/20260111_210642_eve.edf', size: 500 },
+      { name: '20260111_210642_EVE.EDF', path: 'test/20260111_210642_EVE.EDF', size: 500 },
+    ];
+
+    const result = filterEVEFiles(files);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array when no EVE files', () => {
+    const files = [
+      { name: 'BRP.edf', path: 'test/BRP.edf', size: 500000 },
+      { name: 'STR.edf', path: 'test/STR.edf', size: 10000 },
+    ];
+
+    const result = filterEVEFiles(files);
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not match partial EVE in filename', () => {
+    const files = [
+      { name: 'EVELYN.edf', path: 'test/EVELYN.edf', size: 500 },
+      { name: 'PREVENT_EVE.edf', path: 'test/PREVENT_EVE.edf', size: 500 },
+    ];
+
+    // PREVENT_EVE.edf ends with EVE.edf so it should match
+    // EVELYN.edf does not end with EVE.edf
+    const result = filterEVEFiles(files);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('PREVENT_EVE.edf');
+  });
+});

--- a/components/charts/flow-waveform.tsx
+++ b/components/charts/flow-waveform.tsx
@@ -12,23 +12,56 @@ import {
   ReferenceArea,
   ReferenceLine,
 } from 'recharts';
-import type { WaveformData } from '@/lib/waveform-types';
+import type { WaveformData, WaveformEvent } from '@/lib/waveform-types';
 import { formatElapsedTimeShort, formatElapsedTime } from '@/lib/waveform-utils';
 import { CHART_COLORS, GRID_STROKE, AXIS_TICK_FILL, AXIS_LINE_STROKE, withAlpha } from '@/lib/chart-theme';
 import { useSyncedViewport } from '@/hooks/use-synced-viewport';
 import { downsampleForChart } from '@/lib/chart-downsample';
 
+export type EventType = WaveformEvent['type'];
+
 interface Props {
   waveform: WaveformData;
   showPressure?: boolean;
-  showEvents?: boolean;
+  /** Set of visible event types. If undefined, all events are shown. Empty set = no events. */
+  visibleEventTypes?: Set<EventType>;
 }
 
 const EVENT_COLORS: Record<string, { fill: string; stroke: string }> = {
+  // Algorithm-detected
   'rera': { fill: withAlpha(CHART_COLORS[4], 0.15), stroke: withAlpha(CHART_COLORS[4], 0.4) },
   'flow-limitation': { fill: withAlpha(CHART_COLORS[2], 0.12), stroke: withAlpha(CHART_COLORS[2], 0.35) },
   'm-shape': { fill: withAlpha(CHART_COLORS[0], 0.12), stroke: withAlpha(CHART_COLORS[0], 0.35) },
+  // Machine-recorded
+  'obstructive-apnea': { fill: 'hsl(0 70% 50% / 0.18)', stroke: 'hsl(0 70% 50% / 0.45)' },
+  'central-apnea': { fill: 'hsl(180 60% 45% / 0.18)', stroke: 'hsl(180 60% 45% / 0.45)' },
+  'hypopnea': { fill: 'hsl(220 70% 55% / 0.15)', stroke: 'hsl(220 70% 55% / 0.40)' },
+  'unclassified-apnea': { fill: 'hsl(45 80% 50% / 0.15)', stroke: 'hsl(45 80% 50% / 0.40)' },
 };
+
+const EVENT_SHORT_LABELS: Record<string, string> = {
+  'rera': 'R',
+  'flow-limitation': 'FL',
+  'm-shape': 'M',
+  'obstructive-apnea': 'OA',
+  'central-apnea': 'CA',
+  'hypopnea': 'H',
+  'unclassified-apnea': 'UA',
+};
+
+/** Legend items grouped by source */
+const MACHINE_LEGEND: { type: EventType; label: string; colorClass: string }[] = [
+  { type: 'obstructive-apnea', label: 'OA', colorClass: 'hsl(0 70% 50% / 0.35)' },
+  { type: 'central-apnea', label: 'CA', colorClass: 'hsl(180 60% 45% / 0.35)' },
+  { type: 'hypopnea', label: 'H', colorClass: 'hsl(220 70% 55% / 0.35)' },
+  { type: 'unclassified-apnea', label: 'UA', colorClass: 'hsl(45 80% 50% / 0.35)' },
+];
+
+const ALGORITHM_LEGEND: { type: EventType; label: string; tailwindClass: string }[] = [
+  { type: 'rera', label: 'RERA', tailwindClass: 'bg-chart-5/30' },
+  { type: 'flow-limitation', label: 'FL', tailwindClass: 'bg-chart-3/25' },
+  { type: 'm-shape', label: 'M', tailwindClass: 'bg-chart-1/25' },
+];
 
 function FlowTooltipContent({ active, payload, label }: {
   active?: boolean;
@@ -54,9 +87,13 @@ function FlowTooltipContent({ active, payload, label }: {
 export const FlowWaveform = memo(function FlowWaveform({
   waveform,
   showPressure = false,
-  showEvents = true,
+  visibleEventTypes,
 }: Props) {
   const viewport = useSyncedViewport();
+
+  // Determine which types are active
+  const activeTypes: Set<EventType> | null = visibleEventTypes ?? null;
+  const anyEventsVisible = activeTypes === null || activeTypes.size > 0;
 
   // Full data array
   const allData = useMemo(() => {
@@ -82,14 +119,14 @@ export const FlowWaveform = memo(function FlowWaveform({
     [allData, viewport.clampedStart, viewport.clampedEnd]
   );
 
-  // Filter events to visible range, capped to prevent SVG OOM
+  // Filter events to visible range + active types, capped to prevent SVG OOM
   const MAX_VISIBLE_EVENTS = 100;
   const { visibleEvents, eventsCapped } = useMemo(() => {
-    if (!showEvents || data.length === 0) return { visibleEvents: [] as typeof waveform.events, eventsCapped: false };
+    if (!anyEventsVisible || data.length === 0) return { visibleEvents: [] as typeof waveform.events, eventsCapped: false };
     const startT = data[0].t;
     const endT = data[data.length - 1].t;
     const filtered = waveform.events.filter(
-      (e) => e.endSec >= startT && e.startSec <= endT
+      (e) => e.endSec >= startT && e.startSec <= endT && (activeTypes === null || activeTypes.has(e.type))
     );
     if (filtered.length <= MAX_VISIBLE_EVENTS) {
       return { visibleEvents: filtered, eventsCapped: false };
@@ -98,28 +135,48 @@ export const FlowWaveform = memo(function FlowWaveform({
     const step = filtered.length / MAX_VISIBLE_EVENTS;
     const sampled = Array.from({ length: MAX_VISIBLE_EVENTS }, (_, i) => filtered[Math.round(i * step)]);
     return { visibleEvents: sampled, eventsCapped: true };
-  }, [waveform.events, showEvents, data]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [waveform.events, anyEventsVisible, activeTypes, data]);
+
+  // Determine which event types exist in the data (for legend display)
+  const presentTypes = useMemo(() => {
+    const types = new Set<EventType>();
+    for (const e of waveform.events) types.add(e.type);
+    return types;
+  }, [waveform.events]);
 
   const tickFormatter = useCallback((value: number) => formatElapsedTimeShort(value), []);
+
+  // Build legend items from types that exist in data and are visible
+  const machineItems = MACHINE_LEGEND.filter((item) =>
+    presentTypes.has(item.type) && (activeTypes === null || activeTypes.has(item.type))
+  );
+  const algorithmItems = ALGORITHM_LEGEND.filter((item) =>
+    presentTypes.has(item.type) && (activeTypes === null || activeTypes.has(item.type))
+  );
+  const hasVisibleLegend = machineItems.length > 0 || algorithmItems.length > 0;
 
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between px-1">
         <h3 className="text-xs font-medium text-muted-foreground">Flow Waveform</h3>
-        {showEvents && (
+        {hasVisibleLegend && (
           <div className="flex flex-wrap gap-2 text-[10px] text-muted-foreground">
-            <span className="flex items-center gap-1">
-              <span className="inline-block h-2 w-3 rounded-sm bg-chart-5/30" />
-              RERA
-            </span>
-            <span className="flex items-center gap-1">
-              <span className="inline-block h-2 w-3 rounded-sm bg-chart-3/25" />
-              FL
-            </span>
-            <span className="flex items-center gap-1">
-              <span className="inline-block h-2 w-3 rounded-sm bg-chart-1/25" />
-              M
-            </span>
+            {machineItems.map((item) => (
+              <span key={item.type} className="flex items-center gap-1">
+                <span
+                  className="inline-block h-2 w-3 rounded-sm"
+                  style={{ backgroundColor: item.colorClass }}
+                />
+                {item.label}
+              </span>
+            ))}
+            {algorithmItems.map((item) => (
+              <span key={item.type} className="flex items-center gap-1">
+                <span className={`inline-block h-2 w-3 rounded-sm ${item.tailwindClass}`} />
+                {item.label}
+              </span>
+            ))}
             {eventsCapped && (
               <span className="text-amber-500/80">Zoom in to see all events</span>
             )}
@@ -201,7 +258,7 @@ export const FlowWaveform = memo(function FlowWaveform({
             {/* Event overlays */}
             {visibleEvents.map((event, i) => {
               const colors = EVENT_COLORS[event.type] ?? EVENT_COLORS['flow-limitation'];
-              const labelText = event.type === 'rera' ? 'R' : event.type === 'm-shape' ? 'M' : 'FL';
+              const labelText = EVENT_SHORT_LABELS[event.type] ?? event.type;
               return (
                 <ReferenceArea
                   key={`${event.type}-${i}`}

--- a/components/dashboard/graphs-tab.tsx
+++ b/components/dashboard/graphs-tab.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { TrendChart } from '@/components/charts/trend-chart';
-import { FlowWaveform } from '@/components/charts/flow-waveform';
+import { FlowWaveform, type EventType } from '@/components/charts/flow-waveform';
 import { DevicePressureChart } from '@/components/charts/device-pressure-chart';
 import { DeviceLeakChart } from '@/components/charts/device-leak-chart';
 import { SpO2Trace } from '@/components/charts/spo2-trace';
@@ -37,6 +37,24 @@ interface Props {
   onUploadOximetry?: () => void;
 }
 
+const MACHINE_EVENT_DEFS: { type: EventType; label: string; color: string }[] = [
+  { type: 'obstructive-apnea', label: 'OA', color: 'hsl(0 70% 50%)' },
+  { type: 'central-apnea', label: 'CA', color: 'hsl(180 60% 45%)' },
+  { type: 'hypopnea', label: 'H', color: 'hsl(220 70% 55%)' },
+  { type: 'unclassified-apnea', label: 'UA', color: 'hsl(45 80% 50%)' },
+];
+
+const ALGORITHM_EVENT_DEFS: { type: EventType; label: string; color: string }[] = [
+  { type: 'rera', label: 'RERA', color: 'hsl(262 83% 58%)' },
+  { type: 'flow-limitation', label: 'FL', color: 'hsl(38 92% 50%)' },
+  { type: 'm-shape', label: 'M', color: 'hsl(0 84% 60%)' },
+];
+
+const ALL_EVENT_TYPES: EventType[] = [
+  ...MACHINE_EVENT_DEFS.map((d) => d.type),
+  ...ALGORITHM_EVENT_DEFS.map((d) => d.type),
+];
+
 export function GraphsTab({
   selectedNight,
   nights,
@@ -48,7 +66,9 @@ export function GraphsTab({
 }: Props) {
   const { state, cloudLoading, cloudAttempted, retry } = useWaveform(selectedNight, isDemo, sdFiles);
   const [showFlowPressure, setShowFlowPressure] = useState(false);
-  const [showEvents, setShowEvents] = useState(true);
+  const [visibleTypes, setVisibleTypes] = useState<Set<EventType>>(() => new Set(ALL_EVENT_TYPES));
+  const [showODIEvents, setShowODIEvents] = useState(true);
+  const [showHR, setShowHR] = useState(true);
 
   const waveform = state.waveform;
   const hasPressure = waveform ? waveform.pressure.length > 0 : false;
@@ -59,6 +79,29 @@ export function GraphsTab({
   const isFromCloud = sdFiles.length === 0 && !isDemo && cloudAttempted;
 
   const oxTrace = selectedNight.oximetryTrace ?? null;
+
+  // Per-type event counts
+  const eventCounts = useMemo(() => {
+    if (!waveform) return new Map<EventType, number>();
+    const counts = new Map<EventType, number>();
+    for (const t of ALL_EVENT_TYPES) counts.set(t, 0);
+    for (const e of waveform.events) {
+      counts.set(e.type, (counts.get(e.type) ?? 0) + 1);
+    }
+    return counts;
+  }, [waveform]);
+
+  const toggleEventType = useCallback((type: EventType) => {
+    setVisibleTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  }, []);
 
   // Compute data length for synced viewport (flow data is the reference)
   const dataLength = waveform?.flow.length ?? 0;
@@ -153,8 +196,9 @@ export function GraphsTab({
             {/* First-use interaction hint */}
             <ChartInteractionHint />
 
-            {/* Toggle buttons */}
-            <div className="flex flex-wrap items-center gap-2">
+            {/* Toggle buttons — grouped by source */}
+            <div className="flex flex-wrap items-center gap-1.5">
+              {/* Pressure toggle */}
               <Button
                 variant={showFlowPressure ? 'secondary' : 'outline'}
                 size="sm"
@@ -165,15 +209,108 @@ export function GraphsTab({
                 {showFlowPressure ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
                 Pressure Overlay
               </Button>
-              <Button
-                variant={showEvents ? 'secondary' : 'outline'}
-                size="sm"
-                onClick={() => setShowEvents(!showEvents)}
-                className="gap-1.5 text-xs"
-              >
-                {showEvents ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
-                Events ({waveform.events.length})
-              </Button>
+
+              <div className="mx-1 h-4 w-px bg-border/50" />
+
+              {/* Machine event toggles */}
+              <span className="hidden text-[9px] font-medium uppercase tracking-wider text-muted-foreground/50 sm:inline">Machine</span>
+              {MACHINE_EVENT_DEFS.map((def) => {
+                const count = eventCounts.get(def.type) ?? 0;
+                const isOn = visibleTypes.has(def.type);
+                return (
+                  <button
+                    key={def.type}
+                    onClick={() => toggleEventType(def.type)}
+                    disabled={count === 0}
+                    aria-pressed={isOn}
+                    aria-label={`${def.label}: ${isOn ? 'visible' : 'hidden'} (${count})`}
+                    className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                      count === 0
+                        ? 'cursor-not-allowed border-transparent bg-transparent text-muted-foreground/30'
+                        : isOn
+                          ? 'border-border bg-card text-foreground'
+                          : 'border-transparent bg-transparent text-muted-foreground/50 line-through'
+                    }`}
+                  >
+                    <div
+                      className="h-2 w-2 rounded-full"
+                      style={{ backgroundColor: isOn && count > 0 ? def.color : 'hsl(215 20% 30%)' }}
+                    />
+                    {def.label} ({count})
+                  </button>
+                );
+              })}
+
+              <div className="mx-1 h-4 w-px bg-border/50" />
+
+              {/* Algorithm event toggles */}
+              <span className="hidden text-[9px] font-medium uppercase tracking-wider text-muted-foreground/50 sm:inline">AirwayLab</span>
+              {ALGORITHM_EVENT_DEFS.map((def) => {
+                const count = eventCounts.get(def.type) ?? 0;
+                const isOn = visibleTypes.has(def.type);
+                return (
+                  <button
+                    key={def.type}
+                    onClick={() => toggleEventType(def.type)}
+                    disabled={count === 0}
+                    aria-pressed={isOn}
+                    aria-label={`${def.label}: ${isOn ? 'visible' : 'hidden'} (${count})`}
+                    className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                      count === 0
+                        ? 'cursor-not-allowed border-transparent bg-transparent text-muted-foreground/30'
+                        : isOn
+                          ? 'border-border bg-card text-foreground'
+                          : 'border-transparent bg-transparent text-muted-foreground/50 line-through'
+                    }`}
+                  >
+                    <div
+                      className="h-2 w-2 rounded-full"
+                      style={{ backgroundColor: isOn && count > 0 ? def.color : 'hsl(215 20% 30%)' }}
+                    />
+                    {def.label} ({count})
+                  </button>
+                );
+              })}
+
+              {/* SpO2 toggles — only when trace available */}
+              {oxTrace && (
+                <>
+                  <div className="mx-1 h-4 w-px bg-border/50" />
+                  <span className="hidden text-[9px] font-medium uppercase tracking-wider text-muted-foreground/50 sm:inline">SpO₂</span>
+                  <button
+                    onClick={() => setShowODIEvents(!showODIEvents)}
+                    aria-pressed={showODIEvents}
+                    aria-label={`ODI-3: ${showODIEvents ? 'visible' : 'hidden'}`}
+                    className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                      showODIEvents
+                        ? 'border-border bg-card text-foreground'
+                        : 'border-transparent bg-transparent text-muted-foreground/50 line-through'
+                    }`}
+                  >
+                    <div
+                      className="h-2 w-2 rounded-full"
+                      style={{ backgroundColor: showODIEvents ? 'hsl(0 84% 60%)' : 'hsl(215 20% 30%)' }}
+                    />
+                    ODI-3 ({oxTrace.odi3Events.length})
+                  </button>
+                  <button
+                    onClick={() => setShowHR(!showHR)}
+                    aria-pressed={showHR}
+                    aria-label={`Heart Rate: ${showHR ? 'visible' : 'hidden'}`}
+                    className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                      showHR
+                        ? 'border-border bg-card text-foreground'
+                        : 'border-transparent bg-transparent text-muted-foreground/50 line-through'
+                    }`}
+                  >
+                    <div
+                      className="h-2 w-2 rounded-full"
+                      style={{ backgroundColor: showHR ? 'hsl(0 84% 60%)' : 'hsl(215 20% 30%)' }}
+                    />
+                    Heart Rate
+                  </button>
+                </>
+              )}
             </div>
 
             {/* Stacked charts — each wrapped in its own ErrorBoundary */}
@@ -183,7 +320,7 @@ export function GraphsTab({
                 <FlowWaveform
                   waveform={waveform}
                   showPressure={showFlowPressure}
-                  showEvents={showEvents}
+                  visibleEventTypes={visibleTypes}
                 />
               </ErrorBoundary>
 
@@ -237,7 +374,7 @@ export function GraphsTab({
               {/* SpO2 — always visible */}
               {oxTrace ? (
                 <ErrorBoundary context="SpO₂ Trace">
-                  <SpO2Trace trace={oxTrace} />
+                  <SpO2Trace trace={oxTrace} showHR={showHR} showODIEvents={showODIEvents} />
                 </ErrorBoundary>
               ) : (
                 <div className="flex flex-col items-center justify-center gap-2 py-6">

--- a/components/dashboard/oximetry-tab.tsx
+++ b/components/dashboard/oximetry-tab.tsx
@@ -23,6 +23,8 @@ export function OximetryTab({ selectedNight, previousNight, nights = [], onUploa
   const THRESHOLDS = useThresholds();
   const ox = selectedNight.oximetry;
   const pOx = previousNight?.oximetry;
+  const [showODIEvents, setShowODIEvents] = useState(true);
+  const [showHR, setShowHR] = useState(true);
 
   const [detailMetric, setDetailMetric] = useState<{
     label: string;
@@ -83,11 +85,44 @@ export function OximetryTab({ selectedNight, previousNight, nights = [], onUploa
     <div className="flex flex-col gap-6">
       {/* SpO2 / HR Trace Chart */}
       {trace && (
-        <SpO2Trace
-          trace={trace}
-          showHR={true}
-          showODIEvents={true}
-        />
+        <>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-[9px] font-medium uppercase tracking-wider text-muted-foreground/50">SpO₂</span>
+            <button
+              onClick={() => setShowODIEvents(!showODIEvents)}
+              aria-pressed={showODIEvents}
+              aria-label={`ODI-3 events: ${showODIEvents ? 'visible' : 'hidden'}`}
+              className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                showODIEvents
+                  ? 'border-border bg-card text-foreground'
+                  : 'border-transparent bg-transparent text-muted-foreground/50 line-through'
+              }`}
+            >
+              <div
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: showODIEvents ? 'hsl(0 84% 60%)' : 'hsl(215 20% 30%)' }}
+              />
+              ODI-3
+            </button>
+            <button
+              onClick={() => setShowHR(!showHR)}
+              aria-pressed={showHR}
+              aria-label={`Heart Rate: ${showHR ? 'visible' : 'hidden'}`}
+              className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                showHR
+                  ? 'border-border bg-card text-foreground'
+                  : 'border-transparent bg-transparent text-muted-foreground/50 line-through'
+              }`}
+            >
+              <div
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: showHR ? 'hsl(0 84% 60%)' : 'hsl(215 20% 30%)' }}
+              />
+              Heart Rate
+            </button>
+          </div>
+          <SpO2Trace trace={trace} showHR={showHR} showODIEvents={showODIEvents} />
+        </>
       )}
 
       {/* SpO2 Metrics */}

--- a/components/dashboard/waveform-tab.tsx
+++ b/components/dashboard/waveform-tab.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { FlowWaveform } from '@/components/charts/flow-waveform';
+import { FlowWaveform, type EventType } from '@/components/charts/flow-waveform';
 import { waveformOrchestrator, type WaveformState } from '@/lib/waveform-orchestrator';
 import { generateSyntheticWaveform, formatElapsedTimeShort } from '@/lib/waveform-utils';
 import { loadCloudFiles } from '@/lib/storage/cloud-file-loader';
@@ -18,11 +18,29 @@ interface Props {
   onReUpload?: () => void;
 }
 
+const MACHINE_EVENT_DEFS: { type: EventType; label: string; color: string }[] = [
+  { type: 'obstructive-apnea', label: 'OA', color: 'hsl(0 70% 50%)' },
+  { type: 'central-apnea', label: 'CA', color: 'hsl(180 60% 45%)' },
+  { type: 'hypopnea', label: 'H', color: 'hsl(220 70% 55%)' },
+  { type: 'unclassified-apnea', label: 'UA', color: 'hsl(45 80% 50%)' },
+];
+
+const ALGORITHM_EVENT_DEFS: { type: EventType; label: string; color: string }[] = [
+  { type: 'rera', label: 'RERA', color: 'hsl(262 83% 58%)' },
+  { type: 'flow-limitation', label: 'FL', color: 'hsl(38 92% 50%)' },
+  { type: 'm-shape', label: 'M', color: 'hsl(0 84% 60%)' },
+];
+
+const ALL_EVENT_TYPES: EventType[] = [
+  ...MACHINE_EVENT_DEFS.map((d) => d.type),
+  ...ALGORITHM_EVENT_DEFS.map((d) => d.type),
+];
+
 export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Props) {
   const { user } = useAuth();
   const [state, setState] = useState<WaveformState>(waveformOrchestrator.getState());
   const [showPressure, setShowPressure] = useState(false);
-  const [showEvents, setShowEvents] = useState(true);
+  const [visibleTypes, setVisibleTypes] = useState<Set<EventType>>(() => new Set(ALL_EVENT_TYPES));
   const [cloudLoading, setCloudLoading] = useState(false);
   const [cloudAttempted, setCloudAttempted] = useState(false);
   const cloudAttemptedDates = useRef(new Set<string>());
@@ -36,7 +54,6 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
     const dateStr = selectedNight.dateStr;
 
     if (isDemo) {
-      // Generate synthetic waveform for demo mode only
       const synthetic = generateSyntheticWaveform(
         selectedNight.durationHours,
         selectedNight.ned.breathCount,
@@ -54,14 +71,12 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
     }
 
     if (sdFiles.length > 0) {
-      // Local files available — extract from them
       waveformOrchestrator.extract(sdFiles, dateStr).catch((err) => {
         console.error('[waveform-tab] extraction failed:', err);
       });
       return;
     }
 
-    // No local files — try loading from cloud storage if authenticated
     if (user && !cloudAttemptedDates.current.has(dateStr)) {
       cloudAttemptedDates.current.add(dateStr);
       setCloudLoading(true);
@@ -91,7 +106,6 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
         console.error('[waveform-tab] retry failed:', err);
       });
     } else if (user) {
-      // Retry cloud load
       cloudAttemptedDates.current.delete(selectedNight.dateStr);
       setCloudLoading(true);
       setCloudAttempted(false);
@@ -106,6 +120,31 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
         .finally(() => setCloudLoading(false));
     }
   }, [sdFiles, selectedNight.dateStr, user]);
+
+  const waveform = state.waveform;
+
+  // Per-type event counts
+  const eventCounts = useMemo(() => {
+    if (!waveform) return new Map<EventType, number>();
+    const counts = new Map<EventType, number>();
+    for (const t of ALL_EVENT_TYPES) counts.set(t, 0);
+    for (const e of waveform.events) {
+      counts.set(e.type, (counts.get(e.type) ?? 0) + 1);
+    }
+    return counts;
+  }, [waveform]);
+
+  const toggleEventType = useCallback((type: EventType) => {
+    setVisibleTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+  }, []);
 
   // Cloud loading state
   if (cloudLoading) {
@@ -122,7 +161,6 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
     );
   }
 
-  // Extraction loading state
   if (state.status === 'loading') {
     return (
       <Card className="border-border/50">
@@ -137,7 +175,6 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
     );
   }
 
-  // Error state
   if (state.status === 'error') {
     return (
       <Card className="border-border/50">
@@ -152,7 +189,6 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
     );
   }
 
-  // No files available — no local files, cloud attempted but no files found
   if (!isDemo && sdFiles.length === 0 && (cloudAttempted || !user)) {
     return (
       <Card className="border-border/50">
@@ -186,8 +222,7 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
     );
   }
 
-  // No waveform data yet
-  if (!state.waveform) {
+  if (!waveform) {
     return (
       <Card className="border-border/50">
         <CardContent className="flex flex-col items-center justify-center gap-3 py-16">
@@ -197,8 +232,6 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
       </Card>
     );
   }
-
-  const waveform = state.waveform;
 
   const isFromCloud = sdFiles.length === 0 && !isDemo && cloudAttempted;
 
@@ -212,8 +245,8 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
         </div>
       )}
 
-      {/* Controls */}
-      <div className="flex flex-wrap items-center gap-2">
+      {/* Controls — per-type toggles */}
+      <div className="flex flex-wrap items-center gap-1.5">
         <Button
           variant={showPressure ? 'secondary' : 'outline'}
           size="sm"
@@ -224,23 +257,75 @@ export function WaveformTab({ selectedNight, isDemo, sdFiles, onReUpload }: Prop
           {showPressure ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
           Pressure
         </Button>
-        <Button
-          variant={showEvents ? 'secondary' : 'outline'}
-          size="sm"
-          onClick={() => setShowEvents(!showEvents)}
-          disabled={waveform.events.length === 0}
-          className="gap-1.5 text-xs"
-        >
-          {showEvents ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
-          Events ({waveform.events.length})
-        </Button>
+
+        <div className="mx-1 h-4 w-px bg-border/50" />
+
+        {/* Machine event toggles */}
+        <span className="hidden text-[9px] font-medium uppercase tracking-wider text-muted-foreground/50 sm:inline">Machine</span>
+        {MACHINE_EVENT_DEFS.map((def) => {
+          const count = eventCounts.get(def.type) ?? 0;
+          const isOn = visibleTypes.has(def.type);
+          return (
+            <button
+              key={def.type}
+              onClick={() => toggleEventType(def.type)}
+              disabled={count === 0}
+              aria-pressed={isOn}
+              aria-label={`${def.label}: ${isOn ? 'visible' : 'hidden'} (${count})`}
+              className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                count === 0
+                  ? 'cursor-not-allowed border-transparent bg-transparent text-muted-foreground/30'
+                  : isOn
+                    ? 'border-border bg-card text-foreground'
+                    : 'border-transparent bg-transparent text-muted-foreground/50 line-through'
+              }`}
+            >
+              <div
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: isOn && count > 0 ? def.color : 'hsl(215 20% 30%)' }}
+              />
+              {def.label} ({count})
+            </button>
+          );
+        })}
+
+        <div className="mx-1 h-4 w-px bg-border/50" />
+
+        {/* Algorithm event toggles */}
+        <span className="hidden text-[9px] font-medium uppercase tracking-wider text-muted-foreground/50 sm:inline">AirwayLab</span>
+        {ALGORITHM_EVENT_DEFS.map((def) => {
+          const count = eventCounts.get(def.type) ?? 0;
+          const isOn = visibleTypes.has(def.type);
+          return (
+            <button
+              key={def.type}
+              onClick={() => toggleEventType(def.type)}
+              disabled={count === 0}
+              aria-pressed={isOn}
+              aria-label={`${def.label}: ${isOn ? 'visible' : 'hidden'} (${count})`}
+              className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[10px] font-medium transition-colors ${
+                count === 0
+                  ? 'cursor-not-allowed border-transparent bg-transparent text-muted-foreground/30'
+                  : isOn
+                    ? 'border-border bg-card text-foreground'
+                    : 'border-transparent bg-transparent text-muted-foreground/50 line-through'
+              }`}
+            >
+              <div
+                className="h-2 w-2 rounded-full"
+                style={{ backgroundColor: isOn && count > 0 ? def.color : 'hsl(215 20% 30%)' }}
+              />
+              {def.label} ({count})
+            </button>
+          );
+        })}
       </div>
 
       {/* Waveform chart */}
       <FlowWaveform
         waveform={waveform}
         showPressure={showPressure}
-        showEvents={showEvents}
+        visibleEventTypes={visibleTypes}
       />
 
       {/* Stats bar */}

--- a/lib/parsers/eve-parser.ts
+++ b/lib/parsers/eve-parser.ts
@@ -1,0 +1,169 @@
+// ============================================================
+// AirwayLab — EVE.edf Parser (Machine-Recorded Events)
+// Parses EDF+ Annotations (TAL format) from ResMed EVE.edf files.
+// Extracts apnea, hypopnea, and other machine-scored events.
+// ============================================================
+
+export interface MachineEvent {
+  /** Seconds from session start */
+  onsetSec: number;
+  /** Duration in seconds */
+  durationSec: number;
+  /** Raw annotation label from EVE.edf */
+  rawLabel: string;
+  /** Normalised event type */
+  type: 'obstructive-apnea' | 'central-apnea' | 'hypopnea' | 'unclassified-apnea';
+}
+
+/** Map lowercase annotation labels to normalised event types */
+const LABEL_MAP: Record<string, MachineEvent['type']> = {
+  'obstructive apnea': 'obstructive-apnea',
+  'central apnea': 'central-apnea',
+  'hypopnea': 'hypopnea',
+  'apnea': 'unclassified-apnea',
+};
+
+/** Labels to silently skip (not events) */
+const SKIP_LABELS = new Set(['recording starts', '']);
+
+/**
+ * Parse an EVE.edf file and extract machine-recorded events.
+ * Returns an empty array if the file can't be parsed (non-fatal).
+ */
+export function parseEVE(buffer: ArrayBuffer): MachineEvent[] {
+  try {
+    return parseEVEUnsafe(buffer);
+  } catch {
+    return [];
+  }
+}
+
+function parseEVEUnsafe(buffer: ArrayBuffer): MachineEvent[] {
+  if (buffer.byteLength < 256) return [];
+
+  const decoder = new TextDecoder('ascii');
+
+  // --- Fixed header (256 bytes) ---
+  const headerBytes = parseInt(readField(buffer, decoder, 184, 8)) || 0;
+  const numDataRecords = parseInt(readField(buffer, decoder, 236, 8)) || 0;
+  const numSignals = parseInt(readField(buffer, decoder, 252, 4)) || 0;
+
+  if (numSignals === 0 || numDataRecords === 0 || headerBytes === 0) return [];
+  if (buffer.byteLength < headerBytes) return [];
+
+  // --- Find "EDF Annotations" signal ---
+  let annotIdx = -1;
+  for (let i = 0; i < numSignals; i++) {
+    const label = readField(buffer, decoder, 256 + i * 16, 16);
+    if (label.toLowerCase().includes('edf annotation')) {
+      annotIdx = i;
+      break;
+    }
+  }
+
+  if (annotIdx === -1) return [];
+
+  // --- Read numSamples per signal (needed to compute record layout) ---
+  const samplesPerSignal: number[] = [];
+  const samplesOffset = 256 + numSignals * (16 + 80 + 8 + 8 + 8 + 8 + 8 + 80);
+  for (let i = 0; i < numSignals; i++) {
+    samplesPerSignal.push(
+      parseInt(readField(buffer, decoder, samplesOffset + i * 8, 8)) || 0
+    );
+  }
+
+  // Annotation signal bytes per record = numSamples * 2 (EDF stores as int16 but TAL uses raw bytes)
+  const annotBytesPerRecord = samplesPerSignal[annotIdx] * 2;
+  if (annotBytesPerRecord === 0) return [];
+
+  // Compute byte offset of annotation signal within each data record
+  let annotOffsetInRecord = 0;
+  for (let i = 0; i < annotIdx; i++) {
+    annotOffsetInRecord += samplesPerSignal[i] * 2;
+  }
+
+  const recordSize = samplesPerSignal.reduce((sum, n) => sum + n * 2, 0);
+
+  // --- Parse each data record's annotation bytes ---
+  const events: MachineEvent[] = [];
+  const utf8Decoder = new TextDecoder('utf-8');
+
+  for (let rec = 0; rec < numDataRecords; rec++) {
+    const recordStart = headerBytes + rec * recordSize;
+    const annotStart = recordStart + annotOffsetInRecord;
+    const annotEnd = annotStart + annotBytesPerRecord;
+
+    if (annotEnd > buffer.byteLength) break;
+
+    const annotBytes = new Uint8Array(buffer, annotStart, annotBytesPerRecord);
+    const annotStr = utf8Decoder.decode(annotBytes);
+
+    // Split on \x00 to get individual TALs
+    const tals = annotStr.split('\x00');
+
+    for (const tal of tals) {
+      if (tal.length === 0) continue;
+
+      // Parse TAL: +onset\x14\x14 (timekeeping) or +onset\x15duration\x14annotation\x14
+      const event = parseTAL(tal);
+      if (event) events.push(event);
+    }
+  }
+
+  // Sort by onset time
+  events.sort((a, b) => a.onsetSec - b.onsetSec);
+
+  return events;
+}
+
+/**
+ * Parse a single TAL (Time-stamped Annotation List) string.
+ * Format: +onset\x15duration\x14annotation\x14
+ * Returns null if it's a timekeeping TAL or unrecognised annotation.
+ */
+function parseTAL(tal: string): MachineEvent | null {
+  // Find the onset (before \x15 or \x14)
+  const durationSepIdx = tal.indexOf('\x15');
+  const annotSepIdx = tal.indexOf('\x14');
+
+  if (annotSepIdx === -1) return null;
+
+  // If no \x15, this is a timekeeping TAL (+onset\x14\x14) — skip
+  if (durationSepIdx === -1 || durationSepIdx > annotSepIdx) return null;
+
+  const onsetStr = tal.slice(0, durationSepIdx);
+  const durationStr = tal.slice(durationSepIdx + 1, annotSepIdx);
+
+  // Extract annotation text between first \x14 and second \x14 (or end)
+  const restAfterFirstSep = tal.slice(annotSepIdx + 1);
+  const secondSepIdx = restAfterFirstSep.indexOf('\x14');
+  const annotationText = secondSepIdx >= 0
+    ? restAfterFirstSep.slice(0, secondSepIdx)
+    : restAfterFirstSep;
+
+  const onset = parseFloat(onsetStr.replace('+', ''));
+  const duration = parseFloat(durationStr);
+
+  if (isNaN(onset) || isNaN(duration)) return null;
+
+  const labelLower = annotationText.toLowerCase().trim();
+
+  // Skip non-event annotations
+  if (SKIP_LABELS.has(labelLower)) return null;
+
+  // Map to event type
+  const type = LABEL_MAP[labelLower];
+  if (!type) return null;
+
+  return {
+    onsetSec: onset,
+    durationSec: duration,
+    rawLabel: annotationText.trim(),
+    type,
+  };
+}
+
+function readField(buffer: ArrayBuffer, decoder: TextDecoder, offset: number, length: number): string {
+  if (offset + length > buffer.byteLength) return '';
+  return decoder.decode(new Uint8Array(buffer, offset, length)).trim();
+}

--- a/lib/parsers/night-grouper.ts
+++ b/lib/parsers/night-grouper.ts
@@ -148,6 +148,19 @@ export function findSTRFile(
 }
 
 /**
+ * Filter uploaded files to only valid EVE.edf event files (any size).
+ * EVE files contain machine-scored events (apnea, hypopnea, etc.) in EDF+ Annotations format.
+ */
+export function filterEVEFiles(
+  files: { name: string; path: string; size: number }[]
+): { name: string; path: string; size: number }[] {
+  return files.filter((f) => {
+    const name = f.name.toLowerCase();
+    return name.endsWith('eve.edf') && (name === 'eve.edf' || name.charAt(name.length - 8) === '_');
+  });
+}
+
+/**
  * Find Identification file from file list (case-insensitive).
  */
 export function findIdentificationFile(

--- a/lib/waveform-orchestrator.ts
+++ b/lib/waveform-orchestrator.ts
@@ -66,7 +66,7 @@ class WaveformOrchestrator {
     this.setState({ status: 'loading', waveform: null, error: null });
 
     try {
-      // Pre-filter to BRP files only — avoids reading non-flow files into memory
+      // Pre-filter to BRP + EVE files — avoids reading non-relevant files into memory
       const brpFiles = files.filter((f) => {
         const path =
           (f as unknown as { webkitRelativePath?: string }).webkitRelativePath || f.name;
@@ -79,20 +79,33 @@ class WaveformOrchestrator {
         return null;
       }
 
-      // Further filter to only BRP files matching the target date's DATALOG folder.
+      // Also find EVE.edf files (machine-recorded events, tiny ~1KB)
+      const eveFiles = files.filter((f) => {
+        const path =
+          (f as unknown as { webkitRelativePath?: string }).webkitRelativePath || f.name;
+        const name = (path.split('/').pop() || '').toLowerCase();
+        return name.endsWith('eve.edf') || name.endsWith('_eve.edf');
+      });
+
+      // Further filter to only files matching the target date's DATALOG folder.
       // A night like "2026-03-10" has files in DATALOG/20260310/.
       // This avoids reading ALL BRP files into memory (60+ files for large SD cards).
       const dateCompact = targetDate.replace(/-/g, ''); // "20260310"
-      const dateFiltered = brpFiles.filter((f) => {
+      const filterByDate = (f: File) => {
         const path =
           (f as unknown as { webkitRelativePath?: string }).webkitRelativePath || f.name;
         return path.includes(`DATALOG/${dateCompact}/`) || path.includes(`/${dateCompact}_`);
-      });
+      };
+
+      const dateFilteredBRP = brpFiles.filter(filterByDate);
+      const dateFilteredEVE = eveFiles.filter(filterByDate);
 
       // Fall back to all BRP files if no path-based match (non-standard folder structure)
-      const filesToRead = dateFiltered.length > 0 ? dateFiltered : brpFiles;
+      const brpToRead = dateFilteredBRP.length > 0 ? dateFilteredBRP : brpFiles;
+      const eveToRead = dateFilteredEVE.length > 0 ? dateFilteredEVE : eveFiles;
 
-      // Read only matching BRP files into ArrayBuffers
+      // Read BRP + EVE files into ArrayBuffers
+      const filesToRead = [...brpToRead, ...eveToRead];
       const fileBuffers = await readFiles(filesToRead);
 
       // Run worker

--- a/lib/waveform-types.ts
+++ b/lib/waveform-types.ts
@@ -56,7 +56,8 @@ export interface WaveformEvent {
   /** End time in elapsed seconds */
   endSec: number;
   /** Event type identifier */
-  type: 'rera' | 'flow-limitation' | 'm-shape';
+  type: 'rera' | 'flow-limitation' | 'm-shape'
+    | 'obstructive-apnea' | 'central-apnea' | 'hypopnea' | 'unclassified-apnea';
   /** Human-readable label */
   label: string;
 }

--- a/lib/waveform-worker.ts
+++ b/lib/waveform-worker.ts
@@ -6,6 +6,7 @@
 
 import { parseEDF } from './parsers/edf-parser';
 import { groupByNight, filterBRPFiles } from './parsers/night-grouper';
+import { parseEVE } from './parsers/eve-parser';
 import {
   downsampleFlow,
   downsamplePressure,
@@ -116,7 +117,31 @@ function extractWaveform(
   const respiratoryRate = computeRespiratoryRate(combinedFlow, avgSamplingRate, bucketSeconds);
 
   // Detect events from flow patterns (flatness-based detection)
-  const events = detectEventsFromFlow(combinedFlow, avgSamplingRate);
+  const algorithmEvents = detectEventsFromFlow(combinedFlow, avgSamplingRate);
+
+  // Parse machine-recorded events from EVE.edf files (non-fatal — missing EVE is fine)
+  const machineEvents: WaveformEvent[] = [];
+  const eveFiles = files.filter((f) => /eve\.edf$/i.test(f.path));
+  for (const eveFile of eveFiles) {
+    try {
+      const parsed = parseEVE(eveFile.buffer);
+      for (const me of parsed) {
+        machineEvents.push({
+          startSec: me.onsetSec,
+          endSec: me.onsetSec + me.durationSec,
+          type: me.type,
+          label: `${me.rawLabel} (${me.durationSec}s)`,
+        });
+      }
+    } catch {
+      // EVE parse failure is non-fatal
+    }
+  }
+
+  // Merge machine + algorithm events, sorted by start time
+  const events = [...machineEvents, ...algorithmEvents].sort(
+    (a, b) => a.startSec - b.startSec
+  );
 
   // Leak data placeholder — real leak extraction requires parsing separate EDF channels
   const leak: import('./waveform-types').LeakPoint[] = [];


### PR DESCRIPTION
## Summary

- **EVE.edf parser**: New parser extracts machine-recorded events (Obstructive Apnea, Central Apnea, Hypopnea, Unclassified Apnea) from ResMed EVE files using EDF+ TAL format — matching OSCAR's event types (OA, CA, H, UA)
- **Per-type event toggles**: All event types now have individual toggle buttons grouped by source (Machine: OA/CA/H/UA, AirwayLab: RERA/FL/M) with event counts and color-coded dots on Graphs, Waveform, and Oximetry tabs
- **SpO₂ trace toggles**: ODI-3 events and Heart Rate can be individually toggled on/off in Graphs and Oximetry tabs

## Files Changed

| File | Purpose |
|------|---------|
| `lib/parsers/eve-parser.ts` | New EVE.edf TAL parser |
| `__tests__/eve-parser.test.ts` | 15 tests covering parsing, error resilience, label mapping |
| `lib/waveform-types.ts` | Extended `WaveformEvent.type` union with machine event types |
| `lib/waveform-worker.ts` | Imports EVE parser, merges machine + algorithm events |
| `lib/waveform-orchestrator.ts` | Pre-filters EVE files alongside BRP, date-scoped loading |
| `lib/parsers/night-grouper.ts` | Added `filterEVEFiles()` utility |
| `components/charts/flow-waveform.tsx` | `visibleEventTypes` prop, per-type colors + short labels |
| `components/dashboard/graphs-tab.tsx` | Per-type toggles for all event types + SpO₂ toggles |
| `components/dashboard/waveform-tab.tsx` | Per-type toggles for all event types |
| `components/dashboard/oximetry-tab.tsx` | ODI-3 and Heart Rate toggles |
| `CHANGELOG.md` | Feature entry |

## Test plan

- [x] TypeScript: passes (`npx tsc --noEmit`)
- [x] Lint: passes (`npm run lint`)
- [x] Tests: 491 passed, 0 failed (`npm test`)
- [x] Build: passes (`npm run build`)
- [ ] Manual: Upload SD card with EVE.edf files, verify OA/CA/H/UA events appear on charts
- [ ] Manual: Toggle individual event types on/off, verify chart updates
- [ ] Manual: Verify SpO₂ ODI-3 and HR toggles work on both Graphs and Oximetry tabs
- [ ] Manual: Verify demo mode still works (no EVE files = no machine events, toggles show count 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)