### PR TITLE
feat: email notifications for feedback and error submissions

### DIFF
--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -3,12 +3,62 @@ import * as Sentry from '@sentry/nextjs';
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
+import { serverEnv } from '@/lib/env';
 
 const limiter = new RateLimiter({ windowMs: 3_600_000, max: 5 });
 
 // ── Allowed feedback types ────────────────────────────────────
 const ALLOWED_TYPES = ['feature', 'bug', 'support', 'feedback'] as const;
+const TYPE_LABELS: Record<string, string> = {
+  feature: 'Feature request',
+  bug: 'Bug report',
+  support: 'Support request',
+  feedback: 'Feedback',
+};
 const MAX_PAYLOAD_BYTES = 8_000; // 8 KB
+
+async function sendNotificationEmail(fields: {
+  type: string;
+  message: string;
+  email: string | null;
+  page: string | null;
+}) {
+  const apiKey = serverEnv.RESEND_API_KEY;
+  if (!apiKey) return;
+
+  try {
+    const label = TYPE_LABELS[fields.type] ?? 'Feedback';
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        from: 'AirwayLab <noreply@airwaylab.app>',
+        to: ['dev@airwaylab.app'],
+        subject: `${label}: ${fields.message.slice(0, 60)}${fields.message.length > 60 ? '...' : ''}`,
+        text: [
+          `New ${label.toLowerCase()} on airwaylab.app`,
+          '',
+          `Type: ${label}`,
+          `Page: ${fields.page ?? '—'}`,
+          `Email: ${fields.email ?? '—'}`,
+          '',
+          `Message:`,
+          fields.message,
+        ].join('\n'),
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      console.error('[feedback] Resend error:', res.status, body);
+    }
+  } catch (err) {
+    console.error('[feedback] Notification email failed:', err);
+  }
+}
 
 /**
  * POST /api/feedback
@@ -101,6 +151,13 @@ export async function POST(request: NextRequest) {
         Sentry.captureException(error, { tags: { route: 'feedback' } });
         return NextResponse.json({ error: 'Server error' }, { status: 500 });
       }
+      // Fire-and-forget notification email
+      sendNotificationEmail({
+        type: cleanType,
+        message: (message as string).trim(),
+        email: typeof email === 'string' ? email.trim() || null : null,
+        page: cleanPage,
+      });
     } else {
       console.info(`[feedback] ${cleanType}: ${message.slice(0, 100)} (Supabase not configured)`);
     }

--- a/app/api/submit-error-data/route.ts
+++ b/app/api/submit-error-data/route.ts
@@ -3,10 +3,49 @@ import * as Sentry from '@sentry/nextjs';
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
+import { serverEnv } from '@/lib/env';
 
 const limiter = new RateLimiter({ windowMs: 3_600_000, max: 3 });
 
 const MAX_PAYLOAD_BYTES = 256_000; // 256 KB
+
+async function sendNotificationEmail(fields: {
+  fileNames: string[];
+  errorMessage: string;
+  email: string | null;
+}) {
+  const apiKey = serverEnv.RESEND_API_KEY;
+  if (!apiKey) return;
+
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        from: 'AirwayLab <noreply@airwaylab.app>',
+        to: ['dev@airwaylab.app'],
+        subject: `Unsupported format: ${fields.fileNames.slice(0, 3).join(', ')}`,
+        text: [
+          'New unsupported data format submission on airwaylab.app',
+          '',
+          `Files (${fields.fileNames.length}): ${fields.fileNames.slice(0, 10).join(', ')}`,
+          `Error: ${fields.errorMessage.slice(0, 500)}`,
+          `Email: ${fields.email ?? '—'}`,
+        ].join('\n'),
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      console.error('[submit-error-data] Resend error:', res.status, body);
+    }
+  } catch (err) {
+    console.error('[submit-error-data] Notification email failed:', err);
+  }
+}
 
 /**
  * POST /api/submit-error-data
@@ -82,6 +121,13 @@ export async function POST(request: NextRequest) {
       if (error) {
         console.error('[submit-error-data] Supabase error:', error.message);
         Sentry.captureException(error, { tags: { route: 'submit-error-data' } });
+      } else {
+        // Fire-and-forget notification email
+        sendNotificationEmail({
+          fileNames: sanitizedFiles,
+          errorMessage: errorMessage.slice(0, 2000),
+          email: email?.trim() || null,
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
- Adds Resend email notification to `POST /api/feedback` (feedback, bugs, feature requests, support)
- Adds Resend email notification to `POST /api/submit-error-data` (unsupported format reports)
- Both fire-and-forget — notification failure doesn't block the response
- Provider interest (`/api/provider-interest`) already had this

All three user-facing submission forms now email `dev@airwaylab.app`:
| Form | Route | Subject format |
|------|-------|----------------|
| Feedback widget | `/api/feedback` | `Bug report: first 60 chars...` |
| Unsupported format | `/api/submit-error-data` | `Unsupported format: file1, file2` |
| Provider interest | `/api/provider-interest` | `New provider interest: Name` |

## Test plan
- [ ] Submit feedback via the widget on /analyze — verify email arrives at dev@airwaylab.app
- [ ] Submit a bug report — verify subject says "Bug report"
- [ ] Verify request still returns 200 even if RESEND_API_KEY is missing (graceful no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)