### PR TITLE
fix: decouple CI build from lint/test/typecheck to prevent silent skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test, typecheck]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
The build and e2e jobs had `needs: [lint, test, typecheck]` which caused
them to be silently skipped whenever any upstream job failed. This made
it impossible to know whether the build itself was healthy.

Now lint, test, typecheck, and build all run in parallel. Only e2e still
depends on build (it needs the build output to test against).

https://claude.ai/code/session_01WPm63ViXHE8ycU8zhXzcN9