### PR TITLE
feat: legal pages, AI consent modal, compliance infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,12 @@ Per-breath analysis: NED = (Qpeak − Qmid) / Qpeak × 100, Flatness Index = mea
 - Plus Jakarta Sans (body) + JetBrains Mono (code/data)
 - Error messages: never expose raw errors to users; map to user-friendly text
 - Medical compliance: all AI-generated insights must include "discuss with your clinician" language
+- Legal pages: Privacy Policy (`/privacy`), Terms of Service (`/terms`), Accessibility (`/accessibility`), Contact (`/contact`) — keep updated when data flows change
+- Every page that collects or displays health data must include the medical disclaimer component
+- Every server feature that sends data externally must have an explicit consent step — no implicit consent via feature gates alone
+- Every new API route must log the action type + user ID (anonymised if unauthenticated) for audit purposes
+- Account deletion requests must be fulfillable within 30 days — any new data store must have a documented deletion path
+- Any new third-party integration must be added to the Privacy Policy's processor list before deployment
 
 ## Anti-Patterns
 
@@ -181,6 +187,10 @@ Per-breath analysis: NED = (Qpeak − Qmid) / Qpeak × 100, Flatness Index = mea
 - **Never install dependencies without discussion.** Each dependency is maintenance cost against the 2hr/week budget.
 - **Never use `any` or `@ts-ignore`.** If TypeScript complains, the types are wrong — fix them.
 - **Never present analysis as medical advice.** Always include "discuss with your clinician" language. This is a consumer health tool, not a medical device.
+- **Never deploy a new third-party data integration without updating the Privacy Policy.** The processor table in `/privacy` must reflect all services that receive user data.
+- **Never store health data server-side without documenting retention period and deletion mechanism.** Every table with health-related data must have a documented retention schedule and a path to deletion for DSAR requests.
+- **Never add automated decision-making (AI/ML) features without an explicit user consent step.** GDPR requires informed consent for automated processing of health data. Use the `AIConsentModal` pattern or similar.
+- **Never remove or weaken medical disclaimers from any output.** All exports (CSV, JSON, PDF, forum), reports, AI insights, and chart images must include the standard disclaimer language.
 
 ## Common Gotchas
 

--- a/app/accessibility/page.tsx
+++ b/app/accessibility/page.tsx
@@ -1,0 +1,123 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Accessibility — AirwayLab',
+  description:
+    'AirwayLab accessibility statement. Our commitment to making sleep analysis accessible to everyone.',
+  openGraph: {
+    title: 'Accessibility — AirwayLab',
+    description: 'AirwayLab accessibility statement and WCAG 2.1 conformance information.',
+  },
+};
+
+export default function AccessibilityPage() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8 sm:py-12">
+      <div className="mb-10">
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+          Accessibility Statement
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Last updated: 12 March 2026
+        </p>
+      </div>
+
+      <div className="prose-sm space-y-8 text-sm leading-relaxed text-muted-foreground [&_h2]:mb-3 [&_h2]:mt-0 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:text-foreground [&_h3]:mb-2 [&_h3]:mt-0 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-foreground [&_strong]:text-foreground [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-primary/80">
+        <section>
+          <h2>Our Commitment</h2>
+          <p>
+            AirwayLab is committed to ensuring that our sleep analysis tool is accessible to all
+            users, including those with disabilities. We strive to conform to the{' '}
+            <strong>Web Content Accessibility Guidelines (WCAG) 2.1 Level AA</strong> standard.
+          </p>
+        </section>
+
+        <section>
+          <h2>What We&rsquo;ve Implemented</h2>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>Semantic HTML with proper heading hierarchy across all pages</li>
+            <li>Skip-to-content link for keyboard navigation</li>
+            <li>ARIA labels and roles on interactive elements, charts, and modals</li>
+            <li>Keyboard-navigable controls (tabs, checkboxes, dropdowns, modals)</li>
+            <li>Visible focus indicators on interactive elements</li>
+            <li>Screen reader announcements for dynamic content changes</li>
+            <li>Sufficient colour contrast ratios for text and UI elements</li>
+            <li>Responsive design that supports zoom up to 200%</li>
+            <li>No content that flashes more than 3 times per second</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Known Limitations</h2>
+          <p>
+            We are aware of the following accessibility limitations and are working to address
+            them:
+          </p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>
+              <strong>Charts and visualisations:</strong> Recharts-based charts include ARIA
+              labels but may not convey full data detail to screen reader users. We provide
+              tabular data exports (CSV, JSON) as an alternative.
+            </li>
+            <li>
+              <strong>Dark-only theme:</strong> AirwayLab currently only supports a dark colour
+              scheme. Users who require a light theme can use browser extensions or OS-level
+              colour inversion.
+            </li>
+            <li>
+              <strong>PDF reports:</strong> Generated PDF reports may not be fully accessible to
+              screen readers. The underlying data is available in accessible CSV and JSON formats.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Browser &amp; Assistive Technology Support</h2>
+          <p>
+            AirwayLab is tested with:
+          </p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>Latest versions of Chrome, Firefox, Safari, and Edge</li>
+            <li>macOS VoiceOver</li>
+            <li>Keyboard-only navigation</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Feedback &amp; Contact</h2>
+          <p>
+            We welcome feedback on the accessibility of AirwayLab. If you encounter any barriers
+            or have suggestions for improvement, please contact us:
+          </p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>
+              Email:{' '}
+              <a href="mailto:accessibility@airwaylab.app">accessibility@airwaylab.app</a>
+            </li>
+            <li>
+              GitHub:{' '}
+              <a
+                href="https://github.com/airwaylab-app/airwaylab/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                File an accessibility issue
+              </a>
+            </li>
+          </ul>
+          <p>
+            We aim to respond to accessibility feedback within 5 business days and to provide a
+            remediation timeline for confirmed issues.
+          </p>
+        </section>
+
+        <div className="pt-4 text-xs">
+          <Link href="/" className="text-primary hover:underline">
+            &larr; Back to AirwayLab
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/analyze/loading.tsx
+++ b/app/analyze/loading.tsx
@@ -1,0 +1,47 @@
+export default function AnalyzeLoading() {
+  return (
+    <div className="container mx-auto max-w-7xl px-4 py-8">
+      {/* Header skeleton */}
+      <div className="mb-6 flex items-center justify-between">
+        <div className="h-8 w-48 animate-pulse rounded-lg bg-muted/30" />
+        <div className="flex gap-2">
+          <div className="h-9 w-24 animate-pulse rounded-lg bg-muted/30" />
+          <div className="h-9 w-24 animate-pulse rounded-lg bg-muted/30" />
+        </div>
+      </div>
+
+      {/* Night selector skeleton */}
+      <div className="mb-6 h-12 animate-pulse rounded-xl bg-muted/20" />
+
+      {/* Metric cards skeleton */}
+      <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-border/50 bg-card/30 p-4"
+          >
+            <div className="mb-2 h-3 w-20 animate-pulse rounded bg-muted/30" />
+            <div className="mb-1 h-7 w-16 animate-pulse rounded bg-muted/40" />
+            <div className="h-3 w-32 animate-pulse rounded bg-muted/20" />
+          </div>
+        ))}
+      </div>
+
+      {/* Insights skeleton */}
+      <div className="rounded-xl border border-border/50 bg-card/30 p-5">
+        <div className="mb-4 h-5 w-24 animate-pulse rounded bg-muted/30" />
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex gap-3">
+              <div className="h-4 w-4 shrink-0 animate-pulse rounded bg-muted/30" />
+              <div className="flex-1 space-y-1.5">
+                <div className="h-4 w-3/4 animate-pulse rounded bg-muted/30" />
+                <div className="h-3 w-full animate-pulse rounded bg-muted/20" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/consent-audit/route.ts
+++ b/app/api/consent-audit/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSupabaseServer } from '@/lib/supabase/server';
+import { validateOrigin } from '@/lib/csrf';
+import crypto from 'crypto';
+
+const ConsentAuditSchema = z.object({
+  consentType: z.enum(['ai_insights', 'data_contribution', 'cloud_storage', 'email_notifications']),
+  action: z.enum(['granted', 'withdrawn']),
+});
+
+/**
+ * POST /api/consent-audit
+ *
+ * Records a consent action in the audit trail for GDPR compliance.
+ * Requires authentication.
+ */
+export async function POST(request: NextRequest) {
+  if (!validateOrigin(request)) {
+    return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
+  }
+
+  const supabase = getSupabaseServer();
+  if (!supabase) {
+    return NextResponse.json({ error: 'Auth not configured' }, { status: 503 });
+  }
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: z.infer<typeof ConsentAuditSchema>;
+  try {
+    const raw = await request.json();
+    const parsed = ConsentAuditSchema.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request data' }, { status: 400 });
+    }
+    body = parsed.data;
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  // Hash IP for audit without storing raw IP
+  const forwarded = request.headers.get('x-forwarded-for');
+  const ip = forwarded?.split(',')[0]?.trim() ?? 'unknown';
+  const ipHash = crypto.createHash('sha256').update(ip).digest('hex').slice(0, 16);
+
+  const userAgent = request.headers.get('user-agent') ?? 'unknown';
+
+  const { error: insertError } = await supabase
+    .from('consent_audit')
+    .insert({
+      user_id: user.id,
+      consent_type: body.consentType,
+      action: body.action,
+      ip_hash: ipHash,
+      user_agent: userAgent.slice(0, 500),
+    });
+
+  if (insertError) {
+    console.error('[consent-audit] Insert failed:', insertError.message);
+    return NextResponse.json({ error: 'Failed to record consent' }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,133 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Mail, Github, MessageSquare, Shield, FileText, Accessibility } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Contact — AirwayLab',
+  description:
+    'Get in touch with AirwayLab. Report issues, request features, ask questions, or reach out for privacy and accessibility concerns.',
+  openGraph: {
+    title: 'Contact — AirwayLab',
+    description: 'Get in touch with AirwayLab for support, privacy, or accessibility concerns.',
+  },
+};
+
+const channels = [
+  {
+    icon: MessageSquare,
+    title: 'Bugs & Feature Requests',
+    description: 'Report issues or suggest features via GitHub Issues.',
+    link: 'https://github.com/airwaylab-app/airwaylab/issues',
+    linkText: 'Open an issue',
+    external: true,
+  },
+  {
+    icon: Mail,
+    title: 'General Questions',
+    description: 'For questions about AirwayLab, partnerships, or press inquiries.',
+    link: 'mailto:hello@airwaylab.app',
+    linkText: 'hello@airwaylab.app',
+    external: false,
+  },
+  {
+    icon: Shield,
+    title: 'Privacy & Data Requests',
+    description: 'For data access, deletion, or privacy-related questions (GDPR, CCPA).',
+    link: 'mailto:privacy@airwaylab.app',
+    linkText: 'privacy@airwaylab.app',
+    external: false,
+  },
+  {
+    icon: FileText,
+    title: 'Billing & Subscriptions',
+    description: 'For refund requests, billing questions, or subscription issues.',
+    link: 'mailto:billing@airwaylab.app',
+    linkText: 'billing@airwaylab.app',
+    external: false,
+  },
+  {
+    icon: Accessibility,
+    title: 'Accessibility',
+    description: 'Report accessibility barriers or suggest improvements.',
+    link: 'mailto:accessibility@airwaylab.app',
+    linkText: 'accessibility@airwaylab.app',
+    external: false,
+  },
+  {
+    icon: Github,
+    title: 'Source Code',
+    description: 'AirwayLab is open source under GPL-3.0. Browse the code, contribute, or fork.',
+    link: 'https://github.com/airwaylab-app/airwaylab',
+    linkText: 'View on GitHub',
+    external: true,
+  },
+];
+
+export default function ContactPage() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8 sm:py-12">
+      <div className="mb-10">
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Contact</h1>
+        <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+          AirwayLab is built and maintained by a small team. We read every message and aim to
+          respond within 2 business days. For bugs and feature requests, GitHub Issues is the
+          fastest channel.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {channels.map((channel) => (
+          <a
+            key={channel.title}
+            href={channel.link}
+            target={channel.external ? '_blank' : undefined}
+            rel={channel.external ? 'noopener noreferrer' : undefined}
+            className="group rounded-xl border border-border/50 bg-card/30 p-5 transition-colors hover:border-border hover:bg-card/50"
+          >
+            <div className="mb-2 flex items-center gap-2.5">
+              <channel.icon className="h-4 w-4 text-muted-foreground group-hover:text-foreground" />
+              <h2 className="text-sm font-semibold text-foreground">{channel.title}</h2>
+            </div>
+            <p className="mb-3 text-xs leading-relaxed text-muted-foreground">
+              {channel.description}
+            </p>
+            <span className="text-xs font-medium text-primary group-hover:underline">
+              {channel.linkText}
+            </span>
+          </a>
+        ))}
+      </div>
+
+      <div className="mt-8 rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          <strong className="text-foreground">Security vulnerabilities:</strong> If you discover
+          a security issue, please email{' '}
+          <a
+            href="mailto:security@airwaylab.app"
+            className="text-primary underline underline-offset-2 hover:text-primary/80"
+          >
+            security@airwaylab.app
+          </a>{' '}
+          directly. Do not open a public GitHub issue for security vulnerabilities.
+        </p>
+      </div>
+
+      <div className="mt-6 text-xs text-muted-foreground/60">
+        <p>
+          Also see:{' '}
+          <Link href="/privacy" className="text-primary hover:underline">
+            Privacy Policy
+          </Link>{' '}
+          &middot;{' '}
+          <Link href="/terms" className="text-primary hover:underline">
+            Terms of Service
+          </Link>{' '}
+          &middot;{' '}
+          <Link href="/accessibility" className="text-primary hover:underline">
+            Accessibility
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,436 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Shield, ExternalLink } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy — AirwayLab',
+  description:
+    'How AirwayLab handles your data. Privacy-first architecture: all core analysis runs in your browser. No cookies, no fingerprinting.',
+  openGraph: {
+    title: 'Privacy Policy — AirwayLab',
+    description: 'How AirwayLab handles your data. Privacy-first, browser-based sleep analysis.',
+  },
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8 sm:py-12">
+      <div className="mb-10">
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Privacy Policy</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Last updated: 12 March 2026
+        </p>
+        <div className="mt-4 flex items-center gap-1.5 text-xs text-emerald-500">
+          <Shield className="h-3.5 w-3.5 shrink-0" />
+          <span>
+            AirwayLab is privacy-first by design. All core analysis runs in your browser.
+          </span>
+        </div>
+      </div>
+
+      <div className="prose-sm space-y-8 text-sm leading-relaxed text-muted-foreground [&_h2]:mb-3 [&_h2]:mt-0 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:text-foreground [&_h3]:mb-2 [&_h3]:mt-0 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-foreground [&_strong]:text-foreground [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-primary/80">
+        {/* 1. Who We Are */}
+        <section>
+          <h2>1. Who We Are</h2>
+          <p>
+            AirwayLab (&ldquo;we&rdquo;, &ldquo;us&rdquo;, &ldquo;our&rdquo;) is an open-source
+            sleep and airway analysis tool operated under the domain airwaylab.app. AirwayLab is
+            not a medical device and is not cleared or approved by the FDA, CE, TGA, or any
+            regulatory body. It is provided for educational and informational purposes only.
+          </p>
+          <p>
+            For privacy questions, contact us at{' '}
+            <a href="mailto:privacy@airwaylab.app">privacy@airwaylab.app</a>.
+          </p>
+        </section>
+
+        {/* 2. Two-Tier Architecture */}
+        <section>
+          <h2>2. How AirwayLab Processes Data</h2>
+          <p>
+            AirwayLab uses a <strong>two-tier architecture</strong> designed to keep your health
+            data under your control:
+          </p>
+
+          <div className="my-4 rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
+            <h3>Tier 1 — Browser-Only (Default)</h3>
+            <p>
+              All core analysis runs entirely in your browser using Web Workers. Your EDF files
+              are parsed, flow data extracted, and all four analysis engines execute without any
+              network request. <strong>No data leaves your device.</strong> This is the default
+              for all users, including those without an account.
+            </p>
+          </div>
+
+          <div className="my-4 rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">
+            <h3>Tier 2 — Server-Enhanced (Opt-In Only)</h3>
+            <p>
+              Certain features require server communication and are only activated with your
+              explicit, informed consent. These include AI-powered insights, cloud file storage,
+              and anonymised data contribution. Every server interaction requires a separate
+              consent action — we never bundle or pre-select consent.
+            </p>
+          </div>
+        </section>
+
+        {/* 3. What We Collect */}
+        <section>
+          <h2>3. What Personal Data We Collect</h2>
+
+          <h3>3.1 Account Data (if you create an account)</h3>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>Email address (for authentication and account communications)</li>
+            <li>Display name (optional, for supporter acknowledgement)</li>
+            <li>Subscription tier and billing status (via Stripe)</li>
+          </ul>
+
+          <h3 className="mt-4">3.2 Payment Data</h3>
+          <p>
+            Payment processing is handled entirely by{' '}
+            <a href="https://stripe.com/privacy" target="_blank" rel="noopener noreferrer">
+              Stripe <ExternalLink className="inline h-3 w-3" />
+            </a>
+            . We never see or store your credit card number, CVV, or full billing details. We
+            receive only your Stripe customer ID and subscription status.
+          </p>
+
+          <h3 className="mt-4">3.3 Health Data (only with your explicit consent)</h3>
+          <p>
+            If you opt in to specific features, we process the following health-related data:
+          </p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>
+              <strong>AI Insights:</strong> Aggregate analysis metrics (Glasgow Index, WAT, NED,
+              oximetry scores), machine settings, and optional night notes. Raw waveforms and
+              per-breath data are <strong>never</strong> sent.
+            </li>
+            <li>
+              <strong>Data Contribution:</strong> Anonymised aggregate metrics and device model.
+              No dates, timestamps, names, or identifiers are included.
+            </li>
+            <li>
+              <strong>Cloud Storage:</strong> Encrypted raw SD card files stored in EU-region
+              servers, accessible only to your account.
+            </li>
+          </ul>
+
+          <h3 className="mt-4">3.4 Automatically Collected Data</h3>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>
+              <strong>Page views:</strong> Collected by Plausible Analytics — a privacy-first,
+              cookie-free analytics service. No personal data, no IP tracking, no fingerprinting.
+            </li>
+            <li>
+              <strong>Error reports:</strong> Collected by Sentry when errors occur. May include
+              browser type, page URL, and error stack traces. Does not include health data.
+            </li>
+            <li>
+              <strong>Product analytics:</strong> Collected by PostHog for feature usage patterns.
+              No health data is included.
+            </li>
+          </ul>
+
+          <h3 className="mt-4">3.5 What We Do NOT Collect</h3>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>Cookies (we use none)</li>
+            <li>Browser fingerprints</li>
+            <li>IP addresses for tracking (Plausible does not store IPs)</li>
+            <li>Raw sleep waveforms (never transmitted to any server)</li>
+            <li>Per-breath analysis data</li>
+            <li>Device serial numbers or user names from PAP machines</li>
+          </ul>
+        </section>
+
+        {/* 4. Legal Basis */}
+        <section>
+          <h2>4. Legal Basis for Processing (GDPR)</h2>
+          <p>If you are in the European Economic Area, we process your data under:</p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>
+              <strong>Contract (Art. 6(1)(b)):</strong> Account creation, subscription
+              management, and service delivery.
+            </li>
+            <li>
+              <strong>Consent (Art. 6(1)(a)):</strong> AI insights, data contribution, cloud
+              storage, and email communications. You can withdraw consent at any time.
+            </li>
+            <li>
+              <strong>Legitimate interest (Art. 6(1)(f)):</strong> Error monitoring (Sentry),
+              anonymous usage analytics (Plausible), and security protections.
+            </li>
+          </ul>
+        </section>
+
+        {/* 5. Data Retention */}
+        <section>
+          <h2>5. Data Retention</h2>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>
+              <strong>Browser localStorage:</strong> Analysis results auto-expire after 30 days.
+              You can clear them at any time.
+            </li>
+            <li>
+              <strong>Shared analysis links:</strong> Expire after 30 days and are then
+              permanently deleted.
+            </li>
+            <li>
+              <strong>Account data:</strong> Retained until you request deletion.
+            </li>
+            <li>
+              <strong>Contributed data:</strong> Retained indefinitely for research purposes.
+              Since it is fully anonymised, it cannot be traced back to you.
+            </li>
+            <li>
+              <strong>Cloud-stored files:</strong> Retained until you delete them or request
+              account deletion.
+            </li>
+            <li>
+              <strong>Analytics (Plausible):</strong> Aggregate data only, no personal data
+              retained.
+            </li>
+            <li>
+              <strong>Error logs (Sentry):</strong> Retained for 90 days.
+            </li>
+          </ul>
+        </section>
+
+        {/* 6. Third-Party Processors */}
+        <section>
+          <h2>6. Service Providers &amp; Data Processors</h2>
+          <p>
+            We use the following third-party services. Each processes only the minimum data
+            required for its function:
+          </p>
+          <div className="my-3 overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border/50 text-left text-muted-foreground/70">
+                  <th className="pb-2 pr-4 font-medium">Service</th>
+                  <th className="pb-2 pr-4 font-medium">Purpose</th>
+                  <th className="pb-2 pr-4 font-medium">Data Region</th>
+                  <th className="pb-2 font-medium">Data Processed</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/30">
+                <tr>
+                  <td className="py-2 pr-4 font-medium text-foreground">Supabase</td>
+                  <td className="py-2 pr-4">Database &amp; authentication</td>
+                  <td className="py-2 pr-4">EU (West)</td>
+                  <td className="py-2">Account data, subscriptions, contributed metrics</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-medium text-foreground">Anthropic (Claude)</td>
+                  <td className="py-2 pr-4">AI-powered insights</td>
+                  <td className="py-2 pr-4">US</td>
+                  <td className="py-2">Aggregate metrics only (opt-in)</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-medium text-foreground">Stripe</td>
+                  <td className="py-2 pr-4">Payment processing</td>
+                  <td className="py-2 pr-4">US/EU</td>
+                  <td className="py-2">Payment and subscription data</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-medium text-foreground">Vercel</td>
+                  <td className="py-2 pr-4">Hosting &amp; CDN</td>
+                  <td className="py-2 pr-4">Global edge</td>
+                  <td className="py-2">HTTP requests (no health data)</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-medium text-foreground">Plausible</td>
+                  <td className="py-2 pr-4">Privacy-first analytics</td>
+                  <td className="py-2 pr-4">EU</td>
+                  <td className="py-2">Page views only, no personal data</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-medium text-foreground">Sentry</td>
+                  <td className="py-2 pr-4">Error monitoring</td>
+                  <td className="py-2 pr-4">US</td>
+                  <td className="py-2">Error traces, browser type, page URL</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-medium text-foreground">PostHog</td>
+                  <td className="py-2 pr-4">Product analytics</td>
+                  <td className="py-2 pr-4">EU</td>
+                  <td className="py-2">Feature usage patterns, no health data</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-medium text-foreground">Resend</td>
+                  <td className="py-2 pr-4">Transactional email</td>
+                  <td className="py-2 pr-4">US</td>
+                  <td className="py-2">Email address, message content</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* 7. Client-Side Storage */}
+        <section>
+          <h2>7. Client-Side Storage (localStorage)</h2>
+          <p>
+            AirwayLab uses your browser&rsquo;s localStorage (not cookies) to persist analysis
+            results and preferences locally on your device. All keys are prefixed with{' '}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">airwaylab_</code>.
+          </p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>Analysis results (auto-expire after 30 days, 4MB cap)</li>
+            <li>Disclaimer dismissal state</li>
+            <li>Consent preferences (contribution, storage, AI insights)</li>
+            <li>Feature gate state</li>
+          </ul>
+          <p>
+            This data never leaves your browser. You can clear it at any time via your browser
+            settings or by clearing the AirwayLab analysis data from the dashboard.
+          </p>
+        </section>
+
+        {/* 8. Your Rights */}
+        <section>
+          <h2>8. Your Rights</h2>
+          <p>
+            Under GDPR, CCPA/CPRA, and similar data protection laws, you have the right to:
+          </p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>
+              <strong>Access:</strong> Request a copy of the personal data we hold about you.
+            </li>
+            <li>
+              <strong>Portability:</strong> Export your analysis data as CSV, JSON, or PDF at any
+              time from the dashboard — no request needed.
+            </li>
+            <li>
+              <strong>Rectification:</strong> Update your account details via your profile settings.
+            </li>
+            <li>
+              <strong>Erasure:</strong> Request deletion of your account and all associated data.
+              We process deletion requests within 30 days.
+            </li>
+            <li>
+              <strong>Withdraw consent:</strong> Disable any opt-in feature (AI insights, data
+              contribution, cloud storage) at any time via the dashboard.
+            </li>
+            <li>
+              <strong>Opt out of analytics:</strong> Plausible respects your browser&rsquo;s
+              Do Not Track setting. You can also use a browser extension to block analytics.
+            </li>
+          </ul>
+          <p className="mt-2">
+            To exercise these rights, email{' '}
+            <a href="mailto:privacy@airwaylab.app">privacy@airwaylab.app</a>. We will respond
+            within 30 days.
+          </p>
+        </section>
+
+        {/* 9. Children */}
+        <section>
+          <h2>9. Children&rsquo;s Privacy</h2>
+          <p>
+            AirwayLab is intended for adults aged 18 and over who have been diagnosed with
+            sleep-disordered breathing. We do not knowingly collect personal data from children
+            under 16 (or 13 in jurisdictions where COPPA applies). If you believe a child has
+            provided us with personal data, please contact us at{' '}
+            <a href="mailto:privacy@airwaylab.app">privacy@airwaylab.app</a> and we will
+            promptly delete it.
+          </p>
+        </section>
+
+        {/* 10. Data Breach */}
+        <section>
+          <h2>10. Data Breach Notification</h2>
+          <p>
+            In the event of a data breach affecting your personal data, we will:
+          </p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>Notify the relevant supervisory authority within 72 hours (as required by GDPR)</li>
+            <li>Notify affected users without undue delay via email</li>
+            <li>
+              Publish a notice on this page with details of the breach, data affected, and
+              remediation steps
+            </li>
+          </ul>
+          <p>
+            To report a security vulnerability, email{' '}
+            <a href="mailto:security@airwaylab.app">security@airwaylab.app</a>.
+          </p>
+        </section>
+
+        {/* 11. International Transfers */}
+        <section>
+          <h2>11. International Data Transfers</h2>
+          <p>
+            Our primary database is hosted in the EU (Supabase EU-West region). Some services
+            (Anthropic, Sentry, Resend) process data in the US. For EU users, these transfers are
+            governed by Standard Contractual Clauses (SCCs) or the EU-US Data Privacy Framework
+            where applicable.
+          </p>
+          <p>
+            AI insights are opt-in. If you choose not to use AI features, no health-related data
+            is transferred outside the EU.
+          </p>
+        </section>
+
+        {/* 12. CCPA */}
+        <section>
+          <h2>12. California Privacy Rights (CCPA/CPRA)</h2>
+          <p>
+            If you are a California resident, you have additional rights under the CCPA/CPRA:
+          </p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>Right to know what personal information we collect and how we use it</li>
+            <li>Right to delete your personal information</li>
+            <li>Right to opt out of the sale of personal information — <strong>we do not sell your data</strong></li>
+            <li>Right to non-discrimination for exercising your privacy rights</li>
+          </ul>
+          <p className="mt-2">
+            Categories of personal information collected in the preceding 12 months: identifiers
+            (email), commercial information (subscription status), and internet activity
+            (anonymous page views). We do not sell or share personal information for
+            cross-context behavioural advertising.
+          </p>
+        </section>
+
+        {/* 13. Changes */}
+        <section>
+          <h2>13. Changes to This Policy</h2>
+          <p>
+            We may update this Privacy Policy to reflect changes in our practices or legal
+            requirements. Material changes will be communicated via a notice on the site and, for
+            account holders, via email. The &ldquo;Last updated&rdquo; date at the top of this
+            page indicates when the policy was last revised.
+          </p>
+        </section>
+
+        {/* 14. Contact */}
+        <section>
+          <h2>14. Contact</h2>
+          <p>
+            For privacy questions, data requests, or concerns:
+          </p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>
+              Email: <a href="mailto:privacy@airwaylab.app">privacy@airwaylab.app</a>
+            </li>
+            <li>
+              GitHub:{' '}
+              <a
+                href="https://github.com/airwaylab-app/airwaylab/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                airwaylab-app/airwaylab <ExternalLink className="inline h-3 w-3" />
+              </a>
+            </li>
+          </ul>
+        </section>
+
+        {/* Back link */}
+        <div className="pt-4 text-xs">
+          <Link href="/" className="text-primary hover:underline">
+            &larr; Back to AirwayLab
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -55,5 +55,29 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/privacy`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.4,
+    },
+    {
+      url: `${baseUrl}/terms`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.4,
+    },
+    {
+      url: `${baseUrl}/accessibility`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.3,
+    },
+    {
+      url: `${baseUrl}/contact`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
   ];
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,329 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service — AirwayLab',
+  description:
+    'Terms of Service for AirwayLab. Read our terms for using the sleep analysis platform.',
+  openGraph: {
+    title: 'Terms of Service — AirwayLab',
+    description: 'Terms of Service for AirwayLab sleep analysis platform.',
+  },
+};
+
+export default function TermsPage() {
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-8 sm:py-12">
+      <div className="mb-10">
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Terms of Service</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Last updated: 12 March 2026
+        </p>
+      </div>
+
+      <div className="prose-sm space-y-8 text-sm leading-relaxed text-muted-foreground [&_h2]:mb-3 [&_h2]:mt-0 [&_h2]:text-base [&_h2]:font-semibold [&_h2]:text-foreground [&_h3]:mb-2 [&_h3]:mt-0 [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:text-foreground [&_strong]:text-foreground [&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-primary/80">
+        {/* 1. Acceptance */}
+        <section>
+          <h2>1. Acceptance of Terms</h2>
+          <p>
+            By accessing or using AirwayLab (&ldquo;the Service&rdquo;), you agree to be bound by
+            these Terms of Service (&ldquo;Terms&rdquo;). If you do not agree, do not use the
+            Service. We may update these Terms from time to time — continued use after changes
+            constitutes acceptance.
+          </p>
+        </section>
+
+        {/* 2. Eligibility */}
+        <section>
+          <h2>2. Eligibility</h2>
+          <p>
+            You must be at least <strong>18 years old</strong> to use AirwayLab. By creating an
+            account, you represent that you are 18 or older and have the legal capacity to enter
+            into these Terms. AirwayLab is intended for individuals who have been diagnosed with
+            sleep-disordered breathing and use PAP therapy.
+          </p>
+        </section>
+
+        {/* 3. Medical Disclaimer */}
+        <section>
+          <h2>3. Medical Disclaimer</h2>
+          <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+            <p className="font-medium text-foreground">
+              AirwayLab is not a medical device. It has not been cleared, approved, or certified
+              by the FDA, CE, TGA, or any other regulatory body.
+            </p>
+            <p className="mt-2">
+              The Service is provided <strong>for educational and informational purposes
+              only</strong>. Analysis results, insights (including AI-generated insights), scores,
+              and recommendations are not medical advice, diagnosis, or treatment
+              recommendations.
+            </p>
+            <p className="mt-2">
+              <strong>Always consult qualified healthcare providers</strong> before making any
+              changes to your PAP therapy settings, treatment plan, or health-related decisions
+              based on information from AirwayLab. Never disregard professional medical advice or
+              delay seeking treatment because of something you have read or seen on AirwayLab.
+            </p>
+            <p className="mt-2">
+              You acknowledge that you use AirwayLab at your own risk and that we are not
+              responsible for any health outcomes resulting from your use of the Service.
+            </p>
+          </div>
+        </section>
+
+        {/* 4. Description of Service */}
+        <section>
+          <h2>4. Description of Service</h2>
+          <p>
+            AirwayLab is a browser-based tool that analyses PAP (CPAP/BiPAP/ASV) therapy data
+            from ResMed SD cards. The Service includes:
+          </p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>Client-side analysis of EDF flow data (runs entirely in your browser)</li>
+            <li>Optional AI-powered insights via Claude (requires account and consent)</li>
+            <li>Optional cloud file storage (requires account and consent)</li>
+            <li>Optional anonymised data contribution (requires consent)</li>
+            <li>Data export in CSV, JSON, PDF, and forum formats</li>
+          </ul>
+        </section>
+
+        {/* 5. Accounts */}
+        <section>
+          <h2>5. Accounts</h2>
+          <p>
+            An account is optional for core analysis. If you create an account, you are
+            responsible for maintaining the confidentiality of your credentials and for all
+            activity under your account. You must provide accurate information and promptly update
+            it if it changes.
+          </p>
+          <p>
+            We may suspend or terminate accounts that violate these Terms, are used for
+            fraudulent purposes, or remain inactive for more than 12 months.
+          </p>
+        </section>
+
+        {/* 6. Subscriptions & Payment */}
+        <section>
+          <h2>6. Subscriptions &amp; Payment</h2>
+          <h3>6.1 Tiers</h3>
+          <p>
+            AirwayLab offers a free Community tier and paid tiers (Supporter and Champion).
+            The free tier includes complete analysis functionality and will always remain free.
+            Paid tiers add convenience features like unlimited AI insights, cloud sync, and
+            enhanced exports.
+          </p>
+
+          <h3 className="mt-4">6.2 Billing</h3>
+          <p>
+            Paid subscriptions are billed in advance on a monthly or annual basis via Stripe.
+            Subscriptions automatically renew at the end of each billing period unless cancelled.
+            By subscribing, you authorise recurring charges until you cancel.
+          </p>
+
+          <h3 className="mt-4">6.3 Cancellation</h3>
+          <p>
+            You can cancel your subscription at any time from your account settings or via the
+            Stripe customer portal. Upon cancellation, you retain access to paid features until
+            the end of your current billing period. After that, your account reverts to the free
+            Community tier.
+          </p>
+
+          <h3 className="mt-4">6.4 Refunds</h3>
+          <p>
+            We offer a <strong>full refund within 14 days</strong> of your first subscription
+            payment if you are not satisfied, no questions asked. After 14 days, or for
+            subsequent billing periods, refunds are not available — you can cancel to prevent
+            future charges. To request a refund, email{' '}
+            <a href="mailto:billing@airwaylab.app">billing@airwaylab.app</a>.
+          </p>
+
+          <h3 className="mt-4">6.5 Price Changes</h3>
+          <p>
+            We may change subscription prices with 30 days&rsquo; notice via email. Existing
+            subscribers are grandfathered at their current price until the end of their current
+            billing period.
+          </p>
+        </section>
+
+        {/* 7. Acceptable Use */}
+        <section>
+          <h2>7. Acceptable Use</h2>
+          <p>You agree not to:</p>
+          <ul className="ml-4 list-disc space-y-1">
+            <li>
+              Attempt to re-identify anonymised data contributed by other users
+            </li>
+            <li>
+              Use the Service to provide medical advice, diagnosis, or treatment to others
+            </li>
+            <li>
+              Scrape, reverse-engineer, or attempt to extract data from the Service beyond what
+              is provided through the export features
+            </li>
+            <li>
+              Use the Service in any way that violates applicable law or regulation
+            </li>
+            <li>
+              Interfere with the security, integrity, or availability of the Service
+            </li>
+            <li>
+              Create multiple accounts to circumvent usage limits
+            </li>
+          </ul>
+        </section>
+
+        {/* 8. Intellectual Property */}
+        <section>
+          <h2>8. Intellectual Property &amp; Open Source</h2>
+          <p>
+            AirwayLab is open-source software licensed under the{' '}
+            <a
+              href="https://www.gnu.org/licenses/gpl-3.0.html"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GNU General Public License v3.0 (GPL-3.0)
+            </a>
+            . The Glasgow Index engine is based on GPL-3.0 code by DaveSkvn.
+          </p>
+          <p>
+            You are free to use, study, modify, and distribute the source code under the terms of
+            the GPL-3.0 licence. The AirwayLab name, logo, and brand identity remain our
+            property.
+          </p>
+          <p>
+            Your sleep data remains yours. We claim no ownership over data you upload, analyse,
+            or export. For data you voluntarily contribute to the anonymised research dataset,
+            you grant us a non-exclusive, irrevocable licence to use that anonymised data for
+            research purposes.
+          </p>
+        </section>
+
+        {/* 9. Privacy */}
+        <section>
+          <h2>9. Privacy</h2>
+          <p>
+            Your use of the Service is also governed by our{' '}
+            <Link href="/privacy">Privacy Policy</Link>, which describes how we collect, use, and
+            protect your data. By using the Service, you acknowledge that you have read and
+            understood the Privacy Policy.
+          </p>
+        </section>
+
+        {/* 10. HIPAA */}
+        <section>
+          <h2>10. HIPAA Disclaimer</h2>
+          <p>
+            AirwayLab is a consumer health tool, not a HIPAA-covered entity or business
+            associate. We do not offer HIPAA-compliant services or sign Business Associate
+            Agreements (BAAs). Healthcare providers should not use AirwayLab to process, store,
+            or transmit Protected Health Information (PHI).
+          </p>
+        </section>
+
+        {/* 11. Disclaimer of Warranties */}
+        <section>
+          <h2>11. Disclaimer of Warranties</h2>
+          <p>
+            THE SERVICE IS PROVIDED &ldquo;AS IS&rdquo; AND &ldquo;AS AVAILABLE&rdquo; WITHOUT
+            WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+            WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT,
+            OR ACCURACY.
+          </p>
+          <p>
+            We do not warrant that the Service will be uninterrupted, error-free, or free of
+            harmful components. Analysis results may contain errors — always verify important
+            findings with your healthcare provider.
+          </p>
+        </section>
+
+        {/* 12. Limitation of Liability */}
+        <section>
+          <h2>12. Limitation of Liability</h2>
+          <p>
+            TO THE MAXIMUM EXTENT PERMITTED BY LAW, AIRWAYLAB AND ITS OPERATORS SHALL NOT BE
+            LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES,
+            INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR HEALTH OUTCOMES, ARISING
+            OUT OF OR RELATED TO YOUR USE OF THE SERVICE.
+          </p>
+          <p>
+            OUR TOTAL LIABILITY FOR ANY CLAIMS ARISING FROM YOUR USE OF THE SERVICE SHALL NOT
+            EXCEED THE AMOUNT YOU PAID US IN THE 12 MONTHS PRECEDING THE CLAIM, OR $100,
+            WHICHEVER IS GREATER.
+          </p>
+          <p>
+            You acknowledge that the Service analyses health data using automated algorithms and
+            AI, which may produce inaccurate results. You assume full responsibility for
+            decisions made based on the Service&rsquo;s output.
+          </p>
+        </section>
+
+        {/* 13. Indemnification */}
+        <section>
+          <h2>13. Indemnification</h2>
+          <p>
+            You agree to indemnify, defend, and hold harmless AirwayLab and its operators from
+            any claims, damages, losses, or expenses (including reasonable legal fees) arising
+            from your use of the Service, violation of these Terms, or infringement of any third
+            party&rsquo;s rights.
+          </p>
+        </section>
+
+        {/* 14. Termination */}
+        <section>
+          <h2>14. Termination</h2>
+          <p>
+            You may stop using the Service at any time. You can request account deletion via your
+            account settings or by emailing{' '}
+            <a href="mailto:privacy@airwaylab.app">privacy@airwaylab.app</a>. We process
+            deletion requests within 30 days.
+          </p>
+          <p>
+            We may terminate or suspend your access for violation of these Terms, with or without
+            notice. Upon termination, your right to use the Service ceases immediately. Sections
+            3, 8, 11, 12, 13, and 15 survive termination.
+          </p>
+        </section>
+
+        {/* 15. Governing Law */}
+        <section>
+          <h2>15. Governing Law &amp; Disputes</h2>
+          <p>
+            These Terms are governed by the laws of the Netherlands, without regard to conflict
+            of law principles. Any disputes arising from these Terms or your use of the Service
+            shall be resolved in the competent courts of the Netherlands.
+          </p>
+          <p>
+            If you are in the EU, you retain any mandatory consumer protection rights under the
+            laws of your country of residence.
+          </p>
+        </section>
+
+        {/* 16. Severability */}
+        <section>
+          <h2>16. Severability</h2>
+          <p>
+            If any provision of these Terms is found to be unenforceable, the remaining
+            provisions will continue in full force and effect.
+          </p>
+        </section>
+
+        {/* 17. Contact */}
+        <section>
+          <h2>17. Contact</h2>
+          <p>
+            Questions about these Terms? Email{' '}
+            <a href="mailto:legal@airwaylab.app">legal@airwaylab.app</a>.
+          </p>
+        </section>
+
+        {/* Back link */}
+        <div className="pt-4 text-xs">
+          <Link href="/" className="text-primary hover:underline">
+            &larr; Back to AirwayLab
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/common/disclaimer.tsx
+++ b/components/common/disclaimer.tsx
@@ -25,8 +25,9 @@ export function Disclaimer() {
         <div className="flex items-start gap-2.5 text-xs text-amber-300/90 sm:items-center sm:text-sm">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500 sm:mt-0" />
           <span>
-            Not medical advice. AirwayLab is a free research tool. Always consult
-            qualified healthcare providers for treatment decisions.
+            Not medical advice. AirwayLab is not a medical device and is not FDA/CE cleared.
+            Always consult qualified healthcare providers for treatment decisions.{' '}
+            <a href="/terms#medical-disclaimer" className="underline underline-offset-2 hover:text-amber-200">Learn more</a>
           </span>
         </div>
         <button

--- a/components/dashboard/ai-consent-modal.tsx
+++ b/components/dashboard/ai-consent-modal.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Sparkles, Shield, ExternalLink, X } from 'lucide-react';
+
+const CONSENT_KEY = 'airwaylab_ai_insights_consent';
+
+/**
+ * Returns whether the user has previously given AI insights consent.
+ */
+export function hasAIInsightsConsent(): boolean {
+  if (typeof window === 'undefined') return false;
+  return localStorage.getItem(CONSENT_KEY) === 'granted';
+}
+
+/**
+ * Saves the AI insights consent state.
+ */
+export function setAIInsightsConsent(granted: boolean): void {
+  localStorage.setItem(CONSENT_KEY, granted ? 'granted' : 'denied');
+}
+
+interface AIConsentModalProps {
+  open: boolean;
+  onConsent: () => void;
+  onDecline: () => void;
+}
+
+/**
+ * Modal that explains what data is sent to Claude for AI insights and
+ * requires explicit consent before the first API call.
+ *
+ * Shown once — consent is persisted in localStorage.
+ */
+export function AIConsentModal({ open, onConsent, onDecline }: AIConsentModalProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      // Small delay for enter animation
+      requestAnimationFrame(() => setVisible(true));
+    } else {
+      setVisible(false);
+    }
+  }, [open]);
+
+  const handleConsent = useCallback(() => {
+    setAIInsightsConsent(true);
+    // Fire-and-forget: log consent to server audit trail
+    fetch('/api/consent-audit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({ consentType: 'ai_insights', action: 'granted' }),
+    }).catch(() => { /* non-blocking */ });
+    onConsent();
+  }, [onConsent]);
+
+  const handleDecline = useCallback(() => {
+    setAIInsightsConsent(false);
+    onDecline();
+  }, [onDecline]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 transition-opacity ${
+        visible ? 'opacity-100' : 'opacity-0'
+      }`}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ai-consent-title"
+    >
+      <div className="relative w-full max-w-md rounded-xl border border-border bg-card p-6 shadow-xl">
+        <button
+          onClick={handleDecline}
+          className="absolute right-3 top-3 rounded-md p-1 text-muted-foreground/50 transition-colors hover:text-muted-foreground"
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <div className="mb-4 flex items-center gap-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+            <Sparkles className="h-4 w-4 text-primary" />
+          </div>
+          <h2 id="ai-consent-title" className="text-base font-semibold text-foreground">
+            AI-Powered Insights
+          </h2>
+        </div>
+
+        <p className="mb-3 text-sm leading-relaxed text-muted-foreground">
+          AI insights use Anthropic&rsquo;s Claude to analyse your therapy data and find patterns
+          the rule-based system might miss.
+        </p>
+
+        <div className="mb-4 rounded-lg border border-border/50 bg-muted/20 p-3">
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
+            What is sent to Claude
+          </h3>
+          <ul className="space-y-1.5 text-xs text-muted-foreground">
+            <li className="flex items-start gap-2">
+              <span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-primary/60" />
+              Aggregate scores (Glasgow, WAT, NED, oximetry)
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-primary/60" />
+              Machine settings (pressure, EPR, mask type)
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-1 h-1 w-1 shrink-0 rounded-full bg-primary/60" />
+              Night notes you entered (if any)
+            </li>
+          </ul>
+
+          <div className="mt-3 flex items-center gap-1.5 text-xs text-emerald-500">
+            <Shield className="h-3 w-3 shrink-0" />
+            <span>Raw waveforms and per-breath data are never sent.</span>
+          </div>
+        </div>
+
+        <p className="mb-4 text-xs leading-relaxed text-muted-foreground/70">
+          Data is processed by Anthropic (US) under their{' '}
+          <a
+            href="https://www.anthropic.com/policies/privacy-policy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-0.5 text-primary underline underline-offset-2 hover:text-primary/80"
+          >
+            privacy policy <ExternalLink className="h-2.5 w-2.5" />
+          </a>
+          . See our{' '}
+          <a
+            href="/privacy"
+            className="text-primary underline underline-offset-2 hover:text-primary/80"
+          >
+            Privacy Policy
+          </a>{' '}
+          for full details. You can withdraw consent at any time.
+        </p>
+
+        <div className="flex gap-3">
+          <button
+            onClick={handleDecline}
+            className="flex-1 rounded-md border border-border bg-background px-4 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            No thanks
+          </button>
+          <button
+            onClick={handleConsent}
+            className="flex-1 rounded-md bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Enable AI Insights
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -21,6 +21,7 @@ import { MetricDetailModal } from '@/components/dashboard/metric-detail-modal';
 import { NextSteps } from '@/components/dashboard/next-steps';
 import { MetricExplanation } from '@/components/common/metric-explanation';
 import { loadNightNotes } from '@/lib/night-notes';
+import { AIConsentModal, hasAIInsightsConsent } from '@/components/dashboard/ai-consent-modal';
 import { getGlasgowExplanation, getEAIExplanation, getNEDExplanation, getIFLRiskExplanation, METRIC_METHODOLOGIES } from '@/lib/metric-explanations';
 import { computeIFLRisk, getIFLContextNote } from '@/lib/ifl-risk';
 import type { GlasgowComponents } from '@/lib/types';
@@ -69,13 +70,15 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
   const [aiLoading, setAiLoading] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
+  // AI consent modal state
+  const [showAIConsent, setShowAIConsent] = useState(false);
+  const [aiConsentGranted, setAiConsentGranted] = useState(() => hasAIInsightsConsent());
+
   // Check if user can use AI insights (signed in + has quota or is paid)
   const hasAIAccess = !!user && canAccess('ai_insights', tier);
 
-  // H4: Cancel in-flight AI requests when night changes + L3: prevent stale responses
-  useEffect(() => {
-    if (!hasAIAccess || isDemo) return;
-
+  // Trigger AI fetch — called directly or after consent is granted
+  const triggerAIFetch = useCallback(() => {
     // Cancel any in-flight request
     abortRef.current?.abort();
     const controller = new AbortController();
@@ -83,7 +86,6 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
 
     setAiLoading(true);
     const selectedIdx = nights.indexOf(selectedNight);
-
     const notes = loadNightNotes(selectedNight.dateStr);
 
     fetchAIInsights(
@@ -94,7 +96,6 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
       notes
     )
       .then((result) => {
-        // L3: Don't update state if this request was aborted (stale)
         if (controller.signal.aborted) return;
         if (result) {
           incrementAIUsage();
@@ -111,10 +112,23 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         setAiLoading(false);
       });
 
-    return () => {
-      controller.abort();
-    };
-  }, [hasAIAccess, isDemo, nights, selectedNight, therapyChangeDate]);
+    return () => { controller.abort(); };
+  }, [nights, selectedNight, therapyChangeDate]);
+
+  // H4: Cancel in-flight AI requests when night changes + L3: prevent stale responses
+  // Now gated by consent — show modal if consent not yet given
+  useEffect(() => {
+    if (!hasAIAccess || isDemo) return;
+
+    if (!aiConsentGranted) {
+      // Show consent modal on first eligible load
+      setShowAIConsent(true);
+      return;
+    }
+
+    const cleanup = triggerAIFetch();
+    return cleanup;
+  }, [hasAIAccess, isDemo, aiConsentGranted, triggerAIFetch]);
 
   // Demo mode: load static AI insights instantly (no API call, no credits)
   useEffect(() => {
@@ -622,6 +636,18 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           onClose={() => setDetailMetric(null)}
         />
       )}
+
+      {/* AI Insights Consent Modal */}
+      <AIConsentModal
+        open={showAIConsent}
+        onConsent={() => {
+          setShowAIConsent(false);
+          setAiConsentGranted(true);
+        }}
+        onDecline={() => {
+          setShowAIConsent(false);
+        }}
+      />
     </div>
   );
 }

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -84,6 +84,27 @@ export function Footer() {
               </a>
             </nav>
           </div>
+
+          {/* Legal */}
+          <div>
+            <h4 className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Legal
+            </h4>
+            <nav className="flex flex-col gap-2 text-xs text-muted-foreground">
+              <Link href="/privacy" className="transition-colors hover:text-foreground">
+                Privacy Policy
+              </Link>
+              <Link href="/terms" className="transition-colors hover:text-foreground">
+                Terms of Service
+              </Link>
+              <Link href="/accessibility" className="transition-colors hover:text-foreground">
+                Accessibility
+              </Link>
+              <Link href="/contact" className="transition-colors hover:text-foreground">
+                Contact
+              </Link>
+            </nav>
+          </div>
         </div>
 
         {/* Bottom bar */}
@@ -93,7 +114,9 @@ export function Footer() {
             <span>100% client-side processing — your data never leaves your device.</span>
           </div>
           <p className="text-[11px] text-muted-foreground/60">
-            GPL-3.0 · Not a medical device · For educational and informational purposes only
+            GPL-3.0 · Not a medical device · Not FDA/CE cleared · For educational and informational purposes only ·{' '}
+            <Link href="/privacy" className="hover:text-muted-foreground transition-colors">Privacy</Link>{' · '}
+            <Link href="/terms" className="hover:text-muted-foreground transition-colors">Terms</Link>
           </p>
         </div>
       </div>

--- a/supabase/migrations/015_consent_audit_trail.sql
+++ b/supabase/migrations/015_consent_audit_trail.sql
@@ -1,0 +1,38 @@
+-- Consent audit trail: records every consent grant/withdrawal for GDPR compliance.
+-- Each row captures a point-in-time consent action from an authenticated user.
+
+CREATE TABLE IF NOT EXISTS public.consent_audit (
+  id          uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id     uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  consent_type text NOT NULL CHECK (consent_type IN (
+    'ai_insights',
+    'data_contribution',
+    'cloud_storage',
+    'email_notifications'
+  )),
+  action      text NOT NULL CHECK (action IN ('granted', 'withdrawn')),
+  ip_hash     text,          -- SHA-256 of IP for audit without storing raw IP
+  user_agent  text,          -- Browser user-agent string
+  created_at  timestamptz DEFAULT now() NOT NULL
+);
+
+-- Index for efficient user-specific queries (DSAR requests)
+CREATE INDEX IF NOT EXISTS idx_consent_audit_user_id ON public.consent_audit(user_id);
+
+-- Index for type-based queries
+CREATE INDEX IF NOT EXISTS idx_consent_audit_type ON public.consent_audit(consent_type, created_at DESC);
+
+-- RLS: users can read their own consent history, inserts via authenticated
+ALTER TABLE public.consent_audit ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own consent history"
+  ON public.consent_audit FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own consent records"
+  ON public.consent_audit FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+-- No UPDATE or DELETE policies — consent audit is append-only


### PR DESCRIPTION
## Summary
- **Privacy Policy** (`/privacy`) — covers data categories, GDPR legal basis, retention schedules, all 8 third-party processors, user rights (access/portability/erasure), children's privacy, breach notification, CCPA section, international transfers
- **Terms of Service** (`/terms`) — 18+ eligibility, medical device disclaimer (not FDA/CE cleared), subscription terms with 14-day refund policy, ROSCA auto-renewal compliance, acceptable use, HIPAA disclaimer, limitation of liability, indemnification, NL governing law
- **Accessibility statement** (`/accessibility`) — WCAG 2.1 AA target conformance, known limitations (charts, dark-only, PDFs), browser/AT support list, feedback channel
- **Contact page** (`/contact`) — 6 structured channels (bugs, general, privacy, billing, accessibility, security)
- **AI consent modal** — explicit consent required before first AI insights API call; explains what data goes to Claude; persists in localStorage + logs to server audit trail
- **Consent audit trail** — Supabase migration for append-only `consent_audit` table with RLS, hashed IP, user agent
- **Footer** updated with Legal column + strengthened "Not FDA/CE cleared" disclaimer
- **Dashboard loading skeleton** for analyze page
- **CLAUDE.md** updated with 7 new compliance conventions and 4 new anti-patterns

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — no warnings
- [x] `npm test` — 502/502 passing
- [x] `npm run build` — clean, all new pages render
- [ ] Verify `/privacy`, `/terms`, `/accessibility`, `/contact` pages render correctly
- [ ] Verify footer Legal column links work
- [ ] Verify AI consent modal appears on first AI insights eligible load
- [ ] Verify consent modal doesn't reappear after granting consent
- [ ] Run Supabase migration `015_consent_audit_trail.sql` in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)