### PR TITLE
chore: bump version to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-03-12
+
 ### Added
 
 - **Hypopnea & Amplitude Stability Detection** — new Airway Stability section in Flow Analysis tab with Brief Obstruction Index, Hypopnea Index, and Amplitude CV metrics. Machine-preferred/algorithm-fallback for hypopnea counting via EVE.edf. NED-invisible event flagging. 5-minute epoch stability analysis. 3 new insight rules, CSV/forum export columns, threshold definitions. Engine version bumped to 0.7.0 (hypopnea-amplitude-stability)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airwaylab",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

- Bumps version from 1.1.0 → 1.2.0
- Moves Unreleased changelog entries into v1.2.0 section (hypopnea & amplitude stability detection, InfoTooltip fix)
- Closes stale PR #86 (v1.1.0 was already on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)