### PR TITLE
chore: add glossary link to header nav

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -52,6 +52,12 @@ export function Header() {
               For Providers
             </Link>
             <Link
+              href="/glossary"
+              className="hidden rounded-md px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:inline-flex sm:px-3 sm:py-2 sm:text-sm"
+            >
+              Glossary
+            </Link>
+            <Link
               href="/about"
               className="hidden rounded-md px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:inline-flex sm:px-3 sm:py-2 sm:text-sm"
             >
@@ -93,6 +99,13 @@ export function Header() {
                       className="block px-4 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                     >
                       For Providers
+                    </Link>
+                    <Link
+                      href="/glossary"
+                      onClick={() => setMobileMenuOpen(false)}
+                      className="block px-4 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                    >
+                      Glossary
                     </Link>
                     <Link
                       href="/about"


### PR DESCRIPTION
## Summary
- Adds Glossary link to desktop header nav (between For Providers and About)
- Adds Glossary link to mobile hamburger menu (same position)

## Test plan
- [ ] Desktop: verify Glossary link appears in header between For Providers and About
- [ ] Mobile: verify Glossary link appears in hamburger menu
- [ ] Click link navigates to /glossary

🤖 Generated with [Claude Code](https://claude.com/claude-code)