### PR TITLE
fix: align Glasgow Index with original 0-9 scoring and reduce EAI over-detection

### DIFF
--- a/__tests__/glasgow-radar.test.ts
+++ b/__tests__/glasgow-radar.test.ts
@@ -118,7 +118,7 @@ describe('GlasgowRadar data contract', () => {
     const glasgow = makeGlasgow({ skew: 0.35, spike: 0.20 });
     const data = buildRadarData(glasgow, EXPECTED_REFERENCE_VALUES);
     // Replicate the ARIA label logic from the component
-    const ariaLabel = `Glasgow Index radar chart. Overall score: ${glasgow.overall.toFixed(1)} out of 8. Shows 9 component scores: ${data.map((d) => `${d.component}: ${d.value.toFixed(2)}`).join(', ')}.`;
+    const ariaLabel = `Glasgow Index radar chart. Overall score: ${glasgow.overall.toFixed(1)} out of 9. Shows 9 component scores: ${data.map((d) => `${d.component}: ${d.value.toFixed(2)}`).join(', ')}.`;
     expect(ariaLabel).toContain('Skew: 0.35');
     expect(ariaLabel).toContain('Spike: 0.20');
     expect(ariaLabel).not.toContain('Skew: 35');

--- a/__tests__/ifl-risk.test.ts
+++ b/__tests__/ifl-risk.test.ts
@@ -74,7 +74,7 @@ describe('computeIFLRisk', () => {
   });
 
   it('returns 100 when all inputs are maximum', () => {
-    const night = makeNight({ flScore: 100, nedMean: 100, fiMean: 0.0, glasgowOverall: 8 });
+    const night = makeNight({ flScore: 100, nedMean: 100, fiMean: 0.0, glasgowOverall: 9 });
     expect(computeIFLRisk(night)).toBe(100);
   });
 
@@ -82,11 +82,11 @@ describe('computeIFLRisk', () => {
     // FL Score 50 × 0.35 = 17.5
     // NED Mean 40 × 0.30 = 12.0
     // FI (1 - 0.6) × 100 = 40 × 0.20 = 8.0
-    // Glasgow (3 / 8) × 100 = 37.5 × 0.15 = 5.625
-    // Total = 43.125
+    // Glasgow (3 / 9) × 100 = 33.33 × 0.15 = 5.0
+    // Total = 42.5
     const night = makeNight({ flScore: 50, nedMean: 40, fiMean: 0.6, glasgowOverall: 3 });
     const result = computeIFLRisk(night);
-    expect(result).toBeCloseTo(43.125, 1);
+    expect(result).toBeCloseTo(42.5, 1);
   });
 
   it('scores green for mild FL data', () => {

--- a/__tests__/insights.test.ts
+++ b/__tests__/insights.test.ts
@@ -159,8 +159,8 @@ describe('generateInsights', () => {
   describe('symptom rating cross-reference', () => {
     it('generates symptom-fl-correlation when IFL >45 and rating <=2', () => {
       // Build a night with IFL >45 but minimal other warning triggers
-      // IFL Risk = 70*0.35 + 35*0.30 + 35*0.20 + (2.0/8)*100*0.15
-      //          = 24.5 + 10.5 + 7.0 + 3.75 = 45.75 → above threshold
+      // IFL Risk = 70*0.35 + 35*0.30 + 35*0.20 + (2.0/9)*100*0.15
+      //          = 24.5 + 10.5 + 7.0 + 3.33 = 45.33 → above threshold
       const highFLNight: NightResult = {
         ...SAMPLE_NIGHTS[2],
         wat: { ...SAMPLE_NIGHTS[2].wat, flScore: 70, regularityScore: 25, periodicityIndex: 10 },
@@ -176,10 +176,10 @@ describe('generateInsights', () => {
 
     it('generates symptom-fl-asymptomatic when IFL >45 and rating >=4', () => {
       // Build a night with IFL >45 but minimal other warning triggers
-      // IFL Risk = 65*0.35 + 35*0.30 + (1-0.65)*100*0.20 + (2.0/8)*100*0.15
-      //          = 22.75 + 10.5 + 7.0 + 3.75 = 44.0... need slightly more
-      // IFL Risk = 70*0.35 + 35*0.30 + (1-0.65)*100*0.20 + (2.0/8)*100*0.15
-      //          = 24.5 + 10.5 + 7.0 + 3.75 = 45.75 → just above threshold
+      // IFL Risk = 65*0.35 + 35*0.30 + (1-0.65)*100*0.20 + (2.0/9)*100*0.15
+      //          = 22.75 + 10.5 + 7.0 + 3.33 = 43.58... need slightly more
+      // IFL Risk = 70*0.35 + 35*0.30 + (1-0.65)*100*0.20 + (2.0/9)*100*0.15
+      //          = 24.5 + 10.5 + 7.0 + 3.33 = 45.33 → just above threshold
       const highFLNight: NightResult = {
         ...SAMPLE_NIGHTS[2],
         wat: { ...SAMPLE_NIGHTS[2].wat, flScore: 70, regularityScore: 25, periodicityIndex: 10 },

--- a/__tests__/integration/analysis-engines-real.test.ts
+++ b/__tests__/integration/analysis-engines-real.test.ts
@@ -35,7 +35,7 @@ describe('Glasgow Index — real data', () => {
     const glasgow = computeGlasgowIndex(edf.flowData, edf.samplingRate);
 
     expect(glasgow.overall).toBeGreaterThanOrEqual(0);
-    expect(glasgow.overall).toBeLessThanOrEqual(8);
+    expect(glasgow.overall).toBeLessThanOrEqual(9);
 
     const components = [
       'skew', 'spike', 'flatTop', 'topHeavy', 'multiPeak',

--- a/components/charts/glasgow-radar.tsx
+++ b/components/charts/glasgow-radar.tsx
@@ -72,7 +72,7 @@ export const GlasgowRadar = memo(function GlasgowRadar({ glasgow }: Props) {
         <div
           className="relative h-[300px] w-full sm:h-[380px]"
           role="img"
-          aria-label={`Glasgow Index radar chart. Overall score: ${glasgow.overall.toFixed(1)} out of 8. Shows 9 component scores: ${data.map((d) => `${d.component}: ${d.value.toFixed(2)}`).join(', ')}.`}
+          aria-label={`Glasgow Index radar chart. Overall score: ${glasgow.overall.toFixed(1)} out of 9. Shows 9 component scores: ${data.map((d) => `${d.component}: ${d.value.toFixed(2)}`).join(', ')}.`}
         >
           <span className="pointer-events-none absolute bottom-1 right-2 z-10 select-none text-[9px] text-muted-foreground/30">
             airwaylab.app

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -327,12 +327,12 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
             const flNorm = n.wat.flScore;
             const nedNorm = n.ned.nedMean;
             const fiNorm = (1 - n.ned.fiMean) * 100;
-            const glNorm = (n.glasgow.overall / 8) * 100;
+            const glNorm = (n.glasgow.overall / 9) * 100;
             const components = [
               { label: 'FL Score', value: n.wat.flScore, unit: '%', norm: flNorm, weight: 0.35, contribution: flNorm * 0.35 },
               { label: 'NED Mean', value: n.ned.nedMean, unit: '%', norm: nedNorm, weight: 0.30, contribution: nedNorm * 0.30 },
               { label: 'Flatness Index', value: n.ned.fiMean, unit: '', norm: fiNorm, weight: 0.20, contribution: fiNorm * 0.20 },
-              { label: 'Glasgow Index', value: n.glasgow.overall, unit: '/8', norm: glNorm, weight: 0.15, contribution: glNorm * 0.15 },
+              { label: 'Glasgow Index', value: n.glasgow.overall, unit: '/9', norm: glNorm, weight: 0.15, contribution: glNorm * 0.15 },
             ];
             return (
               <div className="overflow-x-auto">

--- a/lib/analyzers/glasgow-index.ts
+++ b/lib/analyzers/glasgow-index.ts
@@ -34,7 +34,7 @@ interface Inspiration {
 
 /**
  * Compute the Glasgow Index for a single EDF session.
- * Returns 9 component scores (each 0-1) and an overall score (0-8).
+ * Returns 9 component scores (each 0-1) and an overall score (0-9).
  */
 export function computeGlasgowIndex(flowData: Float32Array, _samplingRate: number): GlasgowComponents {
   const len = flowData.length;
@@ -120,11 +120,12 @@ export function computeNightGlasgow(sessions: EDFFile[]): GlasgowComponents {
   weighted.multiBreath = round2(weighted.multiBreath);
   weighted.variableAmp = round2(weighted.variableAmp);
 
-  // Overall = sum of 8 components (excludes topHeavy)
+  // Overall = sum of all 9 components (matches original Glasgow Index methodology)
   weighted.overall = round2(
     weighted.skew +
       weighted.flatTop +
       weighted.spike +
+      weighted.topHeavy +
       weighted.multiPeak +
       weighted.noPause +
       weighted.inspirRate +
@@ -470,9 +471,9 @@ function prepIndices(inspirations: Inspiration[]): GlasgowComponents {
   const multiBreath = round2(multiBreathCount / total);
   const variableAmp = round2(ampVarCount / total);
 
-  // Overall = sum of 8 (excludes topHeavy)
+  // Overall = sum of all 9 components (matches original Glasgow Index methodology)
   const overall = round2(
-    skew + flatTop + spike + multiPeak + noPause + inspirRate + multiBreath + variableAmp
+    skew + flatTop + spike + topHeavy + multiPeak + noPause + inspirRate + multiBreath + variableAmp
   );
 
   return {

--- a/lib/analyzers/ned-engine.ts
+++ b/lib/analyzers/ned-engine.ts
@@ -442,8 +442,8 @@ function computeEAI(breaths: Breath[], samplingRate: number): number {
   if (breathData.length < 10) return 0;
 
   const BASELINE_WINDOW = 120; // seconds
-  const RATE_THRESHOLD = 0.25; // 25% rate increase
-  const VOLUME_THRESHOLD = 0.40; // 40% volume increase
+  const RATE_THRESHOLD = 0.35; // 35% rate increase (raised to reduce over-detection vs PSG)
+  const VOLUME_THRESHOLD = 0.50; // 50% volume increase (raised to reduce over-detection vs PSG)
   const REFRACTORY = 30; // seconds between events
   const MIN_FL_PRECEDING = 2; // minimum flow-limited breaths before spike
 

--- a/lib/ifl-risk.ts
+++ b/lib/ifl-risk.ts
@@ -28,13 +28,13 @@ function safe(v: number): number {
  * - FL Score (0–100): already normalised
  * - NED Mean (0–100): already normalised
  * - FI Mean (0–1): inverted → (1 - fi) × 100
- * - Glasgow Overall (0–8): scaled → (overall / 8) × 100
+ * - Glasgow Overall (0–9): scaled → (overall / 9) × 100
  */
 export function computeIFLRisk(night: NightResult): number {
   const flScoreNorm = safe(night.wat.flScore);
   const nedMeanNorm = safe(night.ned.nedMean);
   const fiInvertedNorm = (1 - safe(night.ned.fiMean)) * 100;
-  const glasgowNorm = (safe(night.glasgow.overall) / 8) * 100;
+  const glasgowNorm = (safe(night.glasgow.overall) / 9) * 100;
 
   const risk =
     flScoreNorm * W_FL_SCORE +


### PR DESCRIPTION
## Summary
- **Glasgow Index**: Added topHeavy back into overall sum, restoring the original 0-9 range (was incorrectly 0-8). Matches DaveSkvn's methodology.
- **EAI thresholds**: Raised rate spike 25%→35% and volume spike 40%→50% to reduce over-detection vs PSG arousal index. User reported EAI ~60 vs in-lab AI of 20.
- Updated IFL Risk normalization (`/8` → `/9`), UI labels, and all affected tests.

## Context
Triggered by user feedback (johntimothylally@gmail.com) who flagged both the Glasgow scoring discrepancy and unrealistically high EAI values compared to recent in-lab titration.

## Test plan
- [x] All 615 tests pass
- [x] TypeScript strict check passes
- [x] Production build succeeds
- [ ] Verify Glasgow scores shift slightly upward in UI after deploy
- [ ] Verify EAI values are lower (closer to PSG range) after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)