### PR TITLE
fix: scroll to top when contribution nudge dialog opens

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -226,6 +226,7 @@ function AnalyzePageInner() {
           // Only show nudge if user has never contributed before
           pendingNightsRef.current = newState.nights;
           setShowContributeNudge(true);
+          window.scrollTo({ top: 0, behavior: 'smooth' });
         }
 
         // Cloud storage: auto-upload raw files if consented


### PR DESCRIPTION
## Summary
- After analysis completes, the page is scrolled down to the dashboard content
- The contribution nudge dialog renders a fixed overlay centered on the viewport, but the modal appears above the user's scroll position — making it invisible
- Adds `window.scrollTo({ top: 0, behavior: 'smooth' })` when the nudge triggers so the modal is actually visible

## Test plan
- [ ] Upload SD card data as a first-time user (no prior contributions)
- [ ] Verify the contribution nudge modal is visible after analysis completes
- [ ] Verify the page smoothly scrolls to top when the modal appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)