### PR TITLE
fix: compute tidal volume per breath instead of per time bucket

### DIFF
--- a/__tests__/provider-grade-chart-browser.test.ts
+++ b/__tests__/provider-grade-chart-browser.test.ts
@@ -194,15 +194,18 @@ function detectEventsFromFlow(
 // ── Tests ────────────────────────────────────────────────────
 
 describe('Tidal Volume computation', () => {
-  it('returns positive values in expected mL range for normal breathing', () => {
+  it('returns per-breath tidal volumes in physiological range for normal breathing', () => {
     // 15 breaths/min, 25 Hz, 60 seconds → amplitude 30 L/min
+    // Expected TV for a sine wave: integral of positive half ≈ 636 mL
     const flow = makeSineFlow(25, 60, 15, 30);
     const tv = computeTidalVolume(flow, 25, 2);
 
     expect(tv.length).toBeGreaterThan(0);
-    const avgTV = tv.reduce((s: number, p: { avg: number }) => s + p.avg, 0) / tv.length;
-    // With 30 L/min amplitude sine wave, inspiratory volume per bucket should be positive
-    expect(avgTV).toBeGreaterThan(0);
+    const nonZero = tv.filter((p: { avg: number }) => p.avg > 0);
+    const avgTV = nonZero.reduce((s: number, p: { avg: number }) => s + p.avg, 0) / nonZero.length;
+    // Per-breath tidal volume should be in physiological range (200-800 mL)
+    expect(avgTV).toBeGreaterThan(200);
+    expect(avgTV).toBeLessThan(800);
     // Each point should have a time value
     expect(tv[0].t).toBe(0);
   });

--- a/lib/waveform-utils.ts
+++ b/lib/waveform-utils.ts
@@ -166,7 +166,8 @@ export function computeFlowStats(
 
 /**
  * Compute estimated tidal volume from raw flow data.
- * Integrates positive flow (inspiration) per breath cycle.
+ * Detects individual breaths via zero-crossings, integrates inspiratory
+ * flow per breath, then maps per-breath TV onto the output time grid.
  */
 export function computeTidalVolume(
   data: Float32Array,
@@ -175,29 +176,75 @@ export function computeTidalVolume(
 ): TidalVolumePoint[] {
   if (data.length === 0 || sampleRate <= 0) return [];
 
+  const dt = 1 / sampleRate; // seconds per sample
   const samplesPerBucket = Math.max(1, Math.round(sampleRate * bucketSeconds));
   const totalBuckets = Math.ceil(data.length / samplesPerBucket);
-  const points: TidalVolumePoint[] = [];
 
+  // Accumulators: sum of TV values and count of breaths per bucket
+  const bucketSum = new Float64Array(totalBuckets);
+  const bucketCount = new Uint16Array(totalBuckets);
+
+  // Detect breaths via negative→positive zero-crossings (start of inspiration)
+  const minBreathSamples = Math.round(sampleRate * 1.5); // min ~1.5s breath
+  const maxBreathSamples = Math.round(sampleRate * 15);  // max ~15s breath
+
+  let breathStart = 0;
+  let prevPositive = data[0] >= 0;
+
+  for (let i = 1; i < data.length; i++) {
+    const positive = data[i] >= 0;
+
+    // Negative→positive crossing = start of new breath
+    if (!prevPositive && positive) {
+      const breathLen = i - breathStart;
+      if (breathLen >= minBreathSamples && breathLen <= maxBreathSamples) {
+        // Integrate positive flow (inspiration) for this breath
+        let positiveSum = 0;
+        for (let j = breathStart; j < i; j++) {
+          if (data[j] > 0) positiveSum += data[j];
+        }
+
+        // Convert: flow (L/min) × dt (s) × (1 min / 60 s) × 1000 mL/L
+        const volumeML = positiveSum * dt * (1000 / 60);
+
+        if (volumeML > 30) { // filter noise-only sub-breaths
+          const breathMid = (breathStart + i) / 2;
+          const bucket = Math.min(
+            Math.floor(breathMid / samplesPerBucket),
+            totalBuckets - 1
+          );
+          bucketSum[bucket] += volumeML;
+          bucketCount[bucket]++;
+        }
+      }
+      breathStart = i;
+    }
+    prevPositive = positive;
+  }
+
+  // Build output: average TV per bucket
+  const points: TidalVolumePoint[] = new Array(totalBuckets);
   for (let b = 0; b < totalBuckets; b++) {
-    const start = b * samplesPerBucket;
-    const end = Math.min(start + samplesPerBucket, data.length);
+    points[b] = {
+      t: +((b * samplesPerBucket) / sampleRate).toFixed(1),
+      avg: bucketCount[b] > 0 ? +(bucketSum[b] / bucketCount[b]).toFixed(0) : 0,
+    };
+  }
 
-    // Integrate positive flow as inspiratory volume (L/min → mL)
-    let positiveSum = 0;
-    for (let i = start; i < end; i++) {
-      if (data[i] > 0) {
-        positiveSum += data[i];
+  // Fill empty buckets with nearest neighbour (breaths don't land in every 2s bucket)
+  for (let i = 0; i < points.length; i++) {
+    if (points[i].avg === 0) {
+      for (let d = 1; d < points.length; d++) {
+        if (i - d >= 0 && points[i - d].avg > 0) {
+          points[i].avg = points[i - d].avg;
+          break;
+        }
+        if (i + d < points.length && points[i + d].avg > 0) {
+          points[i].avg = points[i + d].avg;
+          break;
+        }
       }
     }
-
-    // Convert: flow (L/min) * time (1/sampleRate s) * (1 min / 60 s) * 1000 mL/L
-    const volumeML = (positiveSum / sampleRate) * (1000 / 60);
-
-    points.push({
-      t: +(start / sampleRate).toFixed(1),
-      avg: +volumeML.toFixed(0),
-    });
   }
 
   return points;


### PR DESCRIPTION
## Summary
- **Bug:** Tidal volume chart showed 0-100 mL values — physiologically impossible for adults (normal: 400-700 mL)
- **Root cause:** `computeTidalVolume` integrated positive flow within fixed 2-second time buckets. Since a breath cycle is ~4 seconds, each bucket captured only a partial inspiration
- **Fix:** Detect individual breath boundaries via zero-crossings, integrate the full inspiratory flow per breath, then map per-breath TV onto the output time grid with nearest-neighbour gap filling

## Test plan
- [x] All 685 unit tests pass
- [x] TypeScript strict check passes
- [x] Updated test asserts physiological range (200-800 mL) instead of just > 0
- [x] Verified analytically: 30 L/min sine at 15 bpm → 636 mL (correct)
- [ ] Manual: upload SD card data and verify TV chart shows realistic values

🤖 Generated with [Claude Code](https://claude.com/claude-code)