### PR TITLE
fix: Glasgow Index text — 9 components, 0–9 scale

### DIFF
--- a/__tests__/glasgow-index.test.ts
+++ b/__tests__/glasgow-index.test.ts
@@ -57,7 +57,7 @@ describe('Glasgow Index Engine', () => {
       expect(result.variableAmp).toBeGreaterThanOrEqual(0);
     });
 
-    it('overall = sum of 8 components (excludes topHeavy)', () => {
+    it('overall = sum of all 9 components', () => {
       const data = makeSineWave(30);
       const result = computeGlasgowIndex(data, 25);
 
@@ -65,6 +65,7 @@ describe('Glasgow Index Engine', () => {
         result.skew +
         result.flatTop +
         result.spike +
+        result.topHeavy +
         result.multiPeak +
         result.noPause +
         result.inspirRate +
@@ -74,12 +75,12 @@ describe('Glasgow Index Engine', () => {
       expect(result.overall).toBeCloseTo(expectedOverall, 1);
     });
 
-    it('overall score is between 0 and 8', () => {
+    it('overall score is between 0 and 9', () => {
       const data = makeSineWave(30);
       const result = computeGlasgowIndex(data, 25);
 
       expect(result.overall).toBeGreaterThanOrEqual(0);
-      expect(result.overall).toBeLessThanOrEqual(8);
+      expect(result.overall).toBeLessThanOrEqual(9);
     });
 
     it('detects flat-topped breathing patterns', () => {
@@ -139,7 +140,7 @@ describe('Glasgow Index Engine', () => {
 
       // Should complete without error and return valid scores
       expect(result.overall).toBeGreaterThanOrEqual(0);
-      expect(result.overall).toBeLessThanOrEqual(8);
+      expect(result.overall).toBeLessThanOrEqual(9);
     });
   });
 });

--- a/__tests__/integration/analysis-engines-real.test.ts
+++ b/__tests__/integration/analysis-engines-real.test.ts
@@ -30,7 +30,7 @@ const singleSessionEdf = () => parseFixture('DATALOG/20260309/20260310_000159_BR
 // ── Test Case 4: Glasgow Index on real flow data ──────────────
 
 describe('Glasgow Index — real data', () => {
-  it('produces overall score in [0, 8] with all 9 components in [0, 1]', () => {
+  it('produces overall score in [0, 9] with all 9 components in [0, 1]', () => {
     const edf = singleSessionEdf();
     const glasgow = computeGlasgowIndex(edf.flowData, edf.samplingRate);
 

--- a/app/about/glasgow-index/page.tsx
+++ b/app/about/glasgow-index/page.tsx
@@ -168,9 +168,8 @@ export default function GlasgowIndexPage() {
               <span className="mt-px shrink-0 font-mono text-xs text-blue-400/70">04</span>
               <span>
                 <strong className="text-foreground">Composite index</strong> &mdash;
-                The overall Glasgow Index sums 8 component scores (Top Heavy is
-                computed but excluded from the overall). The theoretical maximum is
-                8.0, but in practice scores above 3 are extremely uncommon. The
+                The overall Glasgow Index sums all 9 component scores. The theoretical
+                maximum is 9.0, but in practice scores above 3 are extremely uncommon. The
                 original author describes 0&ndash;0.2 as &ldquo;good, clean
                 breathing&rdquo; and 3 as &ldquo;significant problems.&rdquo;
               </span>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -126,7 +126,7 @@ const engines = [
       'Each inspiration is segmented from the raw flow signal using zero-crossing detection with minimum window filtering.',
       'Nine shape descriptors are computed per breath: Skew, Spike, Flat Top, Top Heavy, Multi-Peak, No Pause, Inspiratory Rate, Multi-Breath, and Variable Amplitude.',
       'Each component is scored 0\u20131 based on statistical thresholds derived from the breath population.',
-      'The overall Glasgow Index is the sum of 8 components (Top Heavy is computed but excluded from the total), yielding a 0\u20138 scale where lower is better.',
+      'The overall Glasgow Index is the sum of all 9 components, yielding a 0\u20139 scale where lower is better.',
     ],
     reference: 'Based on Glasgow Sleep Centre flow limitation analysis methodology.',
     link: '/about/glasgow-index',

--- a/app/glossary/page.tsx
+++ b/app/glossary/page.tsx
@@ -174,7 +174,7 @@ const GLOSSARY_TERMS: GlossaryTerm[] = [
     term: 'Glasgow Index',
     category: 'airwaylab-metrics',
     definition:
-      'A composite flow limitation score computed per breath across 9 shape characteristics: skewness, spikiness, flat-top pattern, top-heaviness, multi-peak pattern, no-pause pattern, inspiratory rate variability, multi-breath pattern, and variable amplitude. Each component is scored 0\u20131 based on the proportion of breaths exhibiting that characteristic. The overall Glasgow Index sums 8 components (Top Heavy is computed but excluded from the total), yielding a 0\u20138 scale where lower is better. Scores below 1.0 indicate well-controlled therapy, 1.0\u20132.0 is borderline, and above 2.0 suggests significant flow limitation. Originally developed by DaveSkvn (GPL-3.0).',
+      'A composite flow limitation score computed per breath across 9 shape characteristics: skewness, spikiness, flat-top pattern, top-heaviness, multi-peak pattern, no-pause pattern, inspiratory rate variability, multi-breath pattern, and variable amplitude. Each component is scored 0\u20131 based on the proportion of breaths exhibiting that characteristic. The overall Glasgow Index sums all 9 components, yielding a 0\u20139 scale where lower is better. Scores below 1.0 indicate well-controlled therapy, 1.0\u20132.0 is borderline, and above 2.0 suggests significant flow limitation. Originally developed by DaveSkvn (GPL-3.0).',
     link: '/about/glasgow-index',
   },
   {

--- a/components/dashboard/glasgow-tab.tsx
+++ b/components/dashboard/glasgow-tab.tsx
@@ -59,7 +59,7 @@ export function GlasgowTab({ nights, selectedNight, previousNight, therapyChange
           value={n.glasgow.overall}
           threshold={THRESHOLDS.glasgowOverall}
           previousValue={p?.glasgow.overall}
-          tooltip="Sum of 8 breath-shape components (excluding Top Heavy). Typical scores range from 0 to about 3 — lower is better. Based on the original Glasgow Index by DaveSkvn."
+          tooltip="Sum of all 9 breath-shape components (0–9 scale). Typical scores range from 0 to about 3 — lower is better. Based on the original Glasgow Index by DaveSkvn."
           onClick={clickable ? () => openMetric('Glasgow Overall', (x) => x.glasgow.overall, { threshold: THRESHOLDS.glasgowOverall, description: 'Composite breath-shape abnormality score across all nights' }) : undefined}
         />
         <div className="sm:col-span-2">
@@ -68,7 +68,7 @@ export function GlasgowTab({ nights, selectedNight, previousNight, therapyChange
               <p className="text-xs leading-relaxed text-muted-foreground">
                 The Glasgow Index quantifies flow limitation across 9 breath-shape
                 components. Each component is scored per breath and averaged across the
-                session. The overall index sums 8 components (excluding Top Heavy).
+                session. The overall index sums all 9 components (0–9 scale).
                 Lower values indicate more normal breathing patterns.
               </p>
             </CardContent>

--- a/lib/metric-explanations.ts
+++ b/lib/metric-explanations.ts
@@ -12,7 +12,7 @@ function fmt(n: number, dp = 1): string {
 
 export const METRIC_METHODOLOGIES = {
   glasgowIndex:
-    'Each breath is scored against 9 shape characteristics (skew, spike, flat top, top heavy, multi-peak, no pause, inspiratory rate, multi-breath, variable amplitude). Each component represents the proportion of breaths exhibiting that characteristic (0\u20131). The overall Glasgow Index sums 8 components (excluding Top Heavy). Typical scores range from 0 to about 3 \u2014 scores above 3 are rare and indicate very significant problems. It\u2019s a holistic breath-shape score that catches many types of abnormality, not just classic flow limitation.',
+    'Each breath is scored against 9 shape characteristics (skew, spike, flat top, top heavy, multi-peak, no pause, inspiratory rate, multi-breath, variable amplitude). Each component represents the proportion of breaths exhibiting that characteristic (0\u20131). The overall Glasgow Index sums all 9 components (0\u20139 scale). Typical scores range from 0 to about 3 \u2014 scores above 3 are rare and indicate very significant problems. It\u2019s a holistic breath-shape score that catches many types of abnormality, not just classic flow limitation.',
 
   flScore:
     'Computed by the WAT (Wobble Analysis Tool) engine. For each breath window, it measures the ratio of tidal volume variance in the top half vs the full signal. A higher ratio means more variation is concentrated at the flow peaks, indicating flat-topped (flow-limited) breathing. This is a population-level metric \u2014 it looks at the overall distribution of breath shapes, not individual breaths.',


### PR DESCRIPTION
## Summary
- The Glasgow engine already sums all 9 components (including Top Heavy) on a 0–9 scale
- UI text, docs, glossary, and tests still referenced the old "8 components (excluding Top Heavy)" / 0–8 wording
- Updates 7 files: dashboard tooltip + description, about page, Glasgow Index page, metric explanations, glossary, and both unit/integration test assertions

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Glasgow unit tests pass (sum assertion now includes `topHeavy`, range check 0–9)
- [x] Integration tests pass (range description updated)
- [ ] Verify Glasgow tab tooltip and description text in browser
- [ ] Verify About page methodology text
- [ ] Verify Glossary Glasgow definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)