### PR TITLE
fix: improve metric display precision and fix double-% bug

### DIFF
--- a/components/common/metric-card.tsx
+++ b/components/common/metric-card.tsx
@@ -21,7 +21,7 @@ interface MetricCardProps {
 function formatValue(value: number, format?: string): string {
   if (value == null || isNaN(value)) return '—';
   if (format === 'int') return Math.round(value).toString();
-  if (format === 'pct') return value.toFixed(0) + '%';
+  if (format === 'pct') return value.toFixed(1);
   return value.toFixed(1);
 }
 

--- a/components/dashboard/flow-analysis-tab.tsx
+++ b/components/dashboard/flow-analysis-tab.tsx
@@ -186,7 +186,6 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
             <MetricCard
               label="Flatness Index"
               value={n.ned.fiMean}
-              format="pct"
               previousValue={p?.ned.fiMean}
               compact
               tooltip="Measures how flat (vs rounded) the inspiratory flow peak is. Flatter peaks suggest flow limitation."
@@ -196,7 +195,6 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
               label="FI > 0.85"
               value={n.ned.fiFL85Pct}
               unit="%"
-              format="pct"
               previousValue={p?.ned.fiFL85Pct}
               compact
               tooltip="Percentage of breaths with Flatness Index above 0.85 — a very flat waveform indicating likely flow limitation."
@@ -206,7 +204,6 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
               label="M-Shape"
               value={n.ned.mShapePct}
               unit="%"
-              format="pct"
               previousValue={p?.ned.mShapePct}
               compact
               tooltip="Percentage of breaths with an M-shaped flow pattern — a double-peaked waveform classic for flow limitation."
@@ -215,7 +212,6 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
             <MetricCard
               label="Tpeak/Ti Mean"
               value={n.ned.tpeakMean}
-              format="pct"
               previousValue={p?.ned.tpeakMean}
               compact
               tooltip="Ratio of time to peak flow vs total inspiratory time. Values closer to 0.5 suggest normal ramp; lower values suggest early peaking from obstruction."

--- a/components/dashboard/oximetry-tab.tsx
+++ b/components/dashboard/oximetry-tab.tsx
@@ -273,6 +273,7 @@ export function OximetryTab({ selectedNight, previousNight, nights = [], onUploa
           <MetricCard
             label="HR Ratio"
             value={ox.coupledHRRatio}
+            unit="%"
             format="pct"
             previousValue={pOx?.coupledHRRatio}
             compact
@@ -324,7 +325,6 @@ export function OximetryTab({ selectedNight, previousNight, nights = [], onUploa
               label="HR SD"
               value={ox.hrSD}
               unit="bpm"
-              format="pct"
               previousValue={pOx?.hrSD}
               compact
               tooltip="Standard deviation of heart rate — measures HR variability. Higher values may indicate frequent arousals or autonomic instability."


### PR DESCRIPTION
## Summary
- `format="pct"` in MetricCard was doing `toFixed(0) + '%'` — rounding to integers AND appending `%`. Cards that also had `unit="%"` showed double percent signs.
- Small-value metrics lost meaningful precision: M-Shape 4.8% → "5%", FI Mean 0.72 → "1%", Tpeak/Ti 0.35 → "0%"
- HR SD was using `format="pct"` with `unit="bpm"`, showing "5% bpm" instead of "5.3 bpm"

### Changes
- **metric-card.tsx**: `pct` format now uses `toFixed(1)` without appending `%` — consistent with ComparisonRow behavior. Percent symbol comes from `unit` prop.
- **flow-analysis-tab.tsx**: Removed `format="pct"` from Flatness Index, FI > 0.85, M-Shape, Tpeak/Ti — these use default `toFixed(1)` now
- **oximetry-tab.tsx**: Added missing `unit="%"` to HR Ratio; removed wrong `format="pct"` from HR SD

## Test plan
- [ ] Verify M-Shape shows decimal (e.g. "4.8%" not "5%")
- [ ] Verify Flatness Index shows decimal (e.g. "0.7" not "1%")
- [ ] Verify Tpeak/Ti shows decimal (e.g. "0.35" not "0%")
- [ ] Verify FL Score, NED Mean, SpO₂ Mean show one decimal with single `%`
- [ ] Verify HR SD shows with "bpm" only (no stray `%`)
- [ ] Verify comparison tab (uses separate ComparisonRow, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)