### PR TITLE
fix: handle markdown-wrapped JSON in AI insights response

### DIFF
--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -324,7 +324,20 @@ export async function POST(request: NextRequest) {
     // Parse insights from JSON response
     let insights: Insight[];
     try {
-      insights = JSON.parse(textBlock.text);
+      // Strip markdown code fences and extract JSON array
+      let jsonText = textBlock.text.trim();
+      // Remove ```json ... ``` or ``` ... ``` wrappers
+      const fenceMatch = jsonText.match(/```(?:json)?\s*([\s\S]*?)```/);
+      if (fenceMatch) {
+        jsonText = fenceMatch[1].trim();
+      }
+      // If model included preamble text, extract the JSON array
+      const arrayStart = jsonText.indexOf('[');
+      const arrayEnd = jsonText.lastIndexOf(']');
+      if (arrayStart !== -1 && arrayEnd > arrayStart) {
+        jsonText = jsonText.slice(arrayStart, arrayEnd + 1);
+      }
+      insights = JSON.parse(jsonText);
     } catch {
       Sentry.captureMessage('AI insights: JSON parse failed on AI response', {
         level: 'error',


### PR DESCRIPTION
## Summary
- Haiku occasionally wraps its JSON output in markdown code fences (` ```json ... ``` `) or includes preamble text before the array, causing `JSON.parse()` to fail
- The parser now strips markdown fences and extracts the JSON array by finding `[` ... `]` boundaries before parsing
- Fixes Sentry issue `4c3cb97ddeae4dd682ecbc63f9a27fe7` (production error on `POST /api/ai-insights`)

## Test plan
- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified — trigger AI insights and confirm they render
- [ ] Self-review: no regressions, existing parse-failure Sentry reporting preserved as fallback
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)