### PR TITLE
feat: auto-merge Sentry auto-fix PRs when CI passes

### DIFF
--- a/.github/workflows/auto-fix-error.yml
+++ b/.github/workflows/auto-fix-error.yml
@@ -78,3 +78,27 @@ jobs:
           model: claude-sonnet-4-6
           prompt_file: .github/prompts/fix-sentry-error.md
           issue_number: ${{ github.event.issue.number }}
+
+      - name: Enable auto-merge
+        if: |
+          steps.check-branch.outputs.exists == 'false' &&
+          steps.rate-limit.outputs.exceeded == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="fix/sentry-${{ github.event.issue.number }}"
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null)
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found — Claude Code may have applied needs-human label instead"
+            exit 0
+          fi
+
+          # Check for hold label
+          HOLD=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | map(select(. == "hold")) | length')
+          if [ "$HOLD" -gt 0 ]; then
+            echo "PR #$PR_NUMBER has 'hold' label — skipping auto-merge"
+            exit 0
+          fi
+
+          gh pr merge "$PR_NUMBER" --auto --squash || echo "Auto-merge could not be enabled (check repo settings)"


### PR DESCRIPTION
## Summary

- Adds "Enable auto-merge" step to `.github/workflows/auto-fix-error.yml`
- After Claude Code creates a fix PR, `gh pr merge --auto --squash` queues it for automatic merge once all 5 required CI checks pass (Lint, Test, Typecheck, Build, E2E Tests)
- Skips gracefully if no PR exists (Claude applied `needs-human` instead) or if PR has `hold` label

## Guardrails

- **CI gate:** All 5 required checks must pass before GitHub allows the merge
- **Protected modules:** Claude Code won't modify `lib/parsers/`, `lib/analyzers/`, `workers/` — no PR is created for these
- **Hold label:** Add `hold` to any auto-fix PR to prevent auto-merge
- **Rate limit:** Existing 5/day cap on auto-fix runs
- **Graceful failure:** If auto-merge isn't enabled on the repo, logs a warning instead of failing

## Pre-requisites (manual, one-time)

1. Enable "Allow auto-merge" in repo settings (Settings → General → Pull Requests)
2. Configure Sentry alert rules to auto-create GitHub issues with `sentry` label (documented in `specs/auto-fix-sentry-errors.md`)

## Verification

- TypeScript: pass
- Lint: pass
- Tests: 778/778 pass
- Build: pass

## Test plan

- [ ] Verify workflow YAML syntax is valid
- [ ] Enable auto-merge in repo settings
- [ ] Test end-to-end: create issue with `sentry` label → verify auto-merge queues

🤖 Generated with [Claude Code](https://claude.com/claude-code)