### PR TITLE
fix: remove CSRF origin check from community-insights GET route

### DIFF
--- a/app/api/community-insights/route.ts
+++ b/app/api/community-insights/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { getSupabaseServiceRole } from '@/lib/supabase/server';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
-import { validateOrigin } from '@/lib/csrf';
 
 /** Rate limit: 10 requests per minute per IP */
 const communityRateLimiter = new RateLimiter({
@@ -11,11 +10,6 @@ const communityRateLimiter = new RateLimiter({
 });
 
 export async function GET(request: NextRequest) {
-  // CSRF protection
-  if (!validateOrigin(request)) {
-    return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
-  }
-
   // Rate limiting
   const ip = getRateLimitKey(request);
   if (communityRateLimiter.isLimited(ip)) {


### PR DESCRIPTION
## Summary
- Browsers don't send an `Origin` header on same-origin GET requests, so `validateOrigin()` always returned `false` on the `/api/community-insights` GET route
- This caused a 403 on every request, showing "Unable to load community data" in the Community Comparison widget
- Removed the CSRF check — it's only meaningful for state-changing (POST) requests. Rate limiting remains in place.

## Test plan
- [ ] Verify Community Comparison widget loads data on Vercel preview (requires contribute consent + sufficient community data)
- [ ] Confirm no console errors on the community-insights fetch
- [ ] Spot-check other dashboard tabs for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)