### PR TITLE
fix: guard community comparison against undefined API response

### DIFF
--- a/app/api/community-insights/route.ts
+++ b/app/api/community-insights/route.ts
@@ -39,14 +39,15 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch community data' }, { status: 500 });
     }
 
-    // Return null/insufficient if fewer than 20 ratings
-    if (!data || data.total_ratings < 20) {
-      return NextResponse.json({ insufficient: true, totalRatings: data?.total_ratings ?? 0 });
+    // Return insufficient if missing data or fewer than 20 ratings
+    const totalRatings = typeof data?.total_ratings === 'number' ? data.total_ratings : 0;
+    if (!data || totalRatings < 20) {
+      return NextResponse.json({ insufficient: true, totalRatings });
     }
 
     return NextResponse.json({
-      avgRating: Number(data.avg_rating),
-      totalRatings: data.total_ratings,
+      avgRating: Number(data.avg_rating) || 0,
+      totalRatings,
       sameBucketAvgRating: data.same_bucket_avg_rating !== null ? Number(data.same_bucket_avg_rating) : null,
       sameBucketCount: data.same_bucket_count ?? 0,
     });

--- a/components/dashboard/community-comparison.tsx
+++ b/components/dashboard/community-comparison.tsx
@@ -50,7 +50,7 @@ export function CommunityComparison({ night, symptomRating, isContributeConsente
       })
       .then((data) => {
         if (controller.signal.aborted) return;
-        if (data.insufficient) {
+        if (data.insufficient || typeof data.totalRatings !== 'number' || typeof data.avgRating !== 'number') {
           setInsufficient(true);
           setStats(null);
         } else {
@@ -142,14 +142,14 @@ export function CommunityComparison({ night, symptomRating, isContributeConsente
           <p className="text-xs font-medium text-muted-foreground">
             Community Comparison
             <span className="ml-1.5 text-[10px] font-normal text-muted-foreground/70">
-              ({stats.totalRatings.toLocaleString()} ratings)
+              ({(stats.totalRatings ?? 0).toLocaleString()} ratings)
             </span>
           </p>
           <div className="mt-1.5 grid grid-cols-2 gap-3">
             <div>
               <p className="text-[10px] text-muted-foreground/80">Community avg. rating</p>
               <p className="font-mono text-sm font-semibold tabular-nums">
-                {stats.avgRating.toFixed(1)}/5
+                {(stats.avgRating ?? 0).toFixed(1)}/5
               </p>
             </div>
             {symptomRating !== null && (


### PR DESCRIPTION
## Summary
- Fixes crash: `Cannot read properties of undefined (reading 'toLocaleString')` in Overview tab
- **Root cause:** After PR #138 removed CSRF from the community-insights GET route, the endpoint now returns data — but when the Supabase RPC returns unexpected data (missing `total_ratings`), the API guard `data.total_ratings < 20` silently passes (NaN comparison returns false), and the component calls `.toLocaleString()` on `undefined`
- **API fix:** Validates `total_ratings` is a number before comparison, defaults to 0
- **Component fix:** Validates response shape (checks `totalRatings` and `avgRating` are numbers) before setting stats; adds `?? 0` fallback on render path

## Test plan
- [ ] Upload SD card data, verify Overview tab renders without crash
- [ ] Check Community Comparison section loads correctly for consented users
- [ ] Verify insufficient data state still shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)