### PR TITLE
fix: wire up oximetry trace display

### DIFF
--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -9,6 +9,7 @@ import type {
   AnalysisState,
   NightResult,
   OximetryResults,
+  OximetryTraceData,
   WorkerResponse,
 } from './types';
 import { loadPersistedResults, persistResults } from './persistence';
@@ -308,13 +309,14 @@ export class AnalysisOrchestrator {
       });
 
       // Run worker for oximetry-only processing
-      const oximetryByDate = await this.runOximetryWorker(oximetryCSVs);
+      const { oximetryByDate, oximetryTraceByDate } = await this.runOximetryWorker(oximetryCSVs);
 
       // Merge oximetry into cached nights
       const merged = cached.nights.map((night) => {
         const ox = oximetryByDate[night.dateStr];
+        const trace = oximetryTraceByDate[night.dateStr];
         if (ox) {
-          return { ...night, oximetry: ox };
+          return { ...night, oximetry: ox, oximetryTrace: trace ?? null };
         }
         return night;
       });
@@ -352,7 +354,7 @@ export class AnalysisOrchestrator {
 
   private runOximetryWorker(
     oximetryCSVs: string[]
-  ): Promise<Record<string, OximetryResults>> {
+  ): Promise<{ oximetryByDate: Record<string, OximetryResults>; oximetryTraceByDate: Record<string, OximetryTraceData> }> {
     return new Promise((resolve, reject) => {
       const WORKER_TIMEOUT_MS = 60 * 1000; // 1 minute — oximetry is fast
       let settled = false;
@@ -380,7 +382,7 @@ export class AnalysisOrchestrator {
           case 'OXIMETRY_RESULTS':
             settle();
             this.terminate();
-            resolve(msg.oximetryByDate);
+            resolve({ oximetryByDate: msg.oximetryByDate, oximetryTraceByDate: msg.oximetryTraceByDate });
             break;
           case 'ERROR':
             settle();
@@ -479,7 +481,7 @@ function mergeNights(
   for (const n of cached) {
     const freshVersion = map.get(n.dateStr);
     if (freshVersion && !n.oximetry && freshVersion.oximetry) {
-      map.set(n.dateStr, { ...n, oximetry: freshVersion.oximetry });
+      map.set(n.dateStr, { ...n, oximetry: freshVersion.oximetry, oximetryTrace: freshVersion.oximetryTrace });
     } else {
       map.set(n.dateStr, n);
     }

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -14,6 +14,7 @@ import { computeWAT } from '../lib/analyzers/wat-engine';
 import { computeNED } from '../lib/analyzers/ned-engine';
 import { computeOximetry } from '../lib/analyzers/oximetry-engine';
 import { computeSettingsMetrics } from '../lib/analyzers/settings-engine';
+import { buildOximetryTrace } from '../lib/oximetry-trace';
 import type {
   WorkerMessage,
   WorkerProgress,
@@ -25,6 +26,7 @@ import type {
   MachineSettings,
   MachineHypopneaSummary,
   OximetryResults,
+  OximetryTraceData,
 } from '../lib/types';
 
 // Global error handler — catches uncaught errors and sends them as
@@ -42,8 +44,8 @@ self.addEventListener('error', (e: ErrorEvent) => {
 self.onmessage = async (e: MessageEvent<WorkerMessage>) => {
   try {
     if (e.data.type === 'ANALYZE_OXIMETRY') {
-      const results = processOximetryOnly(e.data.oximetryCSVs);
-      const response: WorkerOximetryResult = { type: 'OXIMETRY_RESULTS', oximetryByDate: results, oximetryTraceByDate: {} };
+      const { metrics, traces } = processOximetryOnly(e.data.oximetryCSVs);
+      const response: WorkerOximetryResult = { type: 'OXIMETRY_RESULTS', oximetryByDate: metrics, oximetryTraceByDate: traces };
       self.postMessage(response);
     } else {
       const { files, oximetryCSVs } = e.data;
@@ -311,6 +313,7 @@ async function processFiles(
     // Oximetry: match by night date
     const oxData = oximetryByDate.get(group.nightDate);
     const oximetry = oxData ? computeOximetry(oxData.samples) : null;
+    const oximetryTrace = oxData ? buildOximetryTrace(oxData.samples) : null;
 
     nights.push({
       date: recordingDate,
@@ -322,7 +325,7 @@ async function processFiles(
       wat,
       ned,
       oximetry,
-      oximetryTrace: null,
+      oximetryTrace,
       settingsMetrics: settingsMetricsResult,
     });
   }
@@ -337,18 +340,25 @@ async function processFiles(
  * Process oximetry CSVs only — no EDF parsing, no engine computation.
  * Returns computed OximetryResults keyed by date string.
  */
-function processOximetryOnly(oximetryCSVs: string[]): Record<string, OximetryResults> {
-  const results: Record<string, OximetryResults> = {};
+function processOximetryOnly(oximetryCSVs: string[]): {
+  metrics: Record<string, OximetryResults>;
+  traces: Record<string, OximetryTraceData>;
+} {
+  const metrics: Record<string, OximetryResults> = {};
+  const traces: Record<string, OximetryTraceData> = {};
 
   for (const csv of oximetryCSVs) {
     try {
       const parsed = parseOximetryCSV(csv);
-      const oximetry = computeOximetry(parsed.samples);
-      results[parsed.dateStr] = oximetry;
+      metrics[parsed.dateStr] = computeOximetry(parsed.samples);
+      const trace = buildOximetryTrace(parsed.samples);
+      if (trace) {
+        traces[parsed.dateStr] = trace;
+      }
     } catch (err) {
       console.error('[oximetry] Failed to parse CSV:', err instanceof Error ? err.message : String(err));
     }
   }
 
-  return results;
+  return { metrics, traces };
 }


### PR DESCRIPTION
## Summary
- `buildOximetryTrace()` existed in `lib/oximetry-trace.ts` but was never called — `oximetryTrace` was hardcoded to `null` in the worker
- Now the worker builds traces from parsed samples in both the full analysis path and the oximetry-only path
- Orchestrator passes trace data through to the UI on both flows (including `mergeNights`)

**Result:** SpO₂/HR trace chart now displays after uploading Viatom/Checkme O2 Max CSV.

Note: traces are intentionally stripped on localStorage persistence (too large) — they display during the current session only, which matches the existing design intent.

## Test plan
- [ ] Upload SD card data + oximetry CSV → SpO₂/HR trace chart should render
- [ ] Upload oximetry CSV only (with cached SD data) → trace should render
- [ ] Re-upload same SD data (cached path) → oximetry metrics still display
- [ ] Page reload → trace not shown (expected: stripped from localStorage), metrics still present
- [ ] Console: no new errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)