### PR TITLE
fix: graphs tab empty after mid-analysis refresh

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -111,6 +111,17 @@ function AnalyzePageInner() {
   useEffect(() => { userRef.current = user; }, [user]);
   const hasTriggeredAutoUpload = useRef(false);
 
+  // Warn before closing/refreshing while analysis is in progress
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (state.status === 'uploading' || state.status === 'processing') {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [state.status]);
+
   // Track session count for new-user UX (beginner vs returning user)
   useEffect(() => {
     try {

--- a/components/dashboard/graphs-tab.tsx
+++ b/components/dashboard/graphs-tab.tsx
@@ -327,14 +327,15 @@ export function GraphsTab({
             <CardContent className="flex flex-col items-center justify-center gap-3 py-12">
               <Waves className="h-6 w-6 text-muted-foreground/70" />
               <p className="text-sm text-muted-foreground">
-                Waveform data requires your SD card files
+                Re-upload your SD card to view flow waveforms
               </p>
               <p className="max-w-sm text-center text-[11px] leading-relaxed text-muted-foreground/80">
-                Waveforms are extracted directly from your ResMed EDF files.
-                Once extracted, they&apos;re cached locally for instant loading on return visits.
+                Your analysis metrics were restored from a previous session, but waveform graphs
+                need the original EDF files. Re-upload your SD card folder and they&apos;ll be
+                cached for future visits.
               </p>
               {onReUpload && (
-                <Button variant="outline" size="sm" onClick={onReUpload} className="mt-1">Upload SD card</Button>
+                <Button variant="outline" size="sm" onClick={onReUpload} className="mt-1">Re-upload SD card</Button>
               )}
             </CardContent>
           </Card>

--- a/hooks/use-waveform.ts
+++ b/hooks/use-waveform.ts
@@ -25,7 +25,9 @@ export function useWaveform(
     return waveformOrchestrator.subscribe(setState);
   }, []);
 
-  // Extract waveform when night changes
+  // Extract waveform when night or available files change.
+  // sdFiles.length is included so that when files become available
+  // (e.g. re-upload from a persisted session), extraction triggers.
   useEffect(() => {
     let cancelled = false;
     const dateStr = selectedNight.dateStr;
@@ -91,8 +93,7 @@ export function useWaveform(
     }
 
     return () => { cancelled = true; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNight.dateStr, isDemo, user]);
+  }, [selectedNight.dateStr, isDemo, user, sdFiles.length]);
 
   const retry = useCallback(() => {
     if (sdFiles.length > 0) {


### PR DESCRIPTION
## Summary
- **useWaveform stale closure**: `sdFiles.length` added to effect dependency array so waveform extraction re-triggers when files become available (e.g. re-upload from a persisted session)
- **Graphs tab messaging**: Empty state now explains that metrics were restored but waveforms need the original EDF files, with a "Re-upload SD card" CTA
- **beforeunload guard**: Warns before closing/refreshing while analysis is in progress to prevent the mid-analysis refresh scenario

## Test plan
- [ ] Upload SD card, verify Graphs tab loads waveforms normally
- [ ] Refresh mid-analysis → re-upload → verify Graphs tab works after second upload
- [ ] Load persisted session (no SD files) → verify Graphs tab shows improved messaging
- [ ] Verify beforeunload prompt fires during active analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)