### PR TITLE
feat: always show data in Graphs tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Device settings extraction status** — Track whether device settings were actually extracted or are fallback defaults (`settingsSource` field). Clear messaging when settings are unavailable instead of misleading zeros/dashes. (settings-extraction-fallback-ux)
 - **Device diagnostic collection** — Automatically save unknown device STR.edf signal labels and identification text to Supabase when settings extraction fails, enabling future device support. (settings-extraction-fallback-ux)
 - **Tonic desaturation insight** — New insight rule detects when T<94% is elevated with low ODI3, indicating baseline respiratory depression (e.g., alcohol) rather than obstructive events. (research-validation-fixes)
+- **Graphs tab always shows data** — TrendChart now renders for single-night users (was 2+ only) with a dynamic title ("Night Metrics" / "Multi-Night Trends"). When no waveform data is available, the Glasgow Radar chart renders as a fallback from persisted metrics, replacing the old full-page "re-upload" placeholder with a compact info banner. (graphs-tab-always-show-data)
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

- TrendChart now renders for single-night users (was 2+ only) with dynamic title ("Night Metrics" / "Multi-Night Trends")
- When no waveform data is available, Glasgow Radar chart renders as fallback from persisted metrics
- Full-page "re-upload" placeholder replaced with compact info banner

## Build Complete: Graphs Tab — Always Show Data

**Branch:** feat/graphs-tab-always-show-data
**Spec:** specs/graphs-tab-always-show-data.md

### Files Changed
- `components/dashboard/graphs-tab.tsx` — TrendChart guard `>1` → `>0`, GlasgowRadar fallback, compact info banner
- `components/charts/trend-chart.tsx` — Dynamic title based on night count
- `__tests__/graphs-tab-always-show-data.test.ts` — 18 tests covering rendering conditions, data logic, edge cases
- `CHANGELOG.md` — Added feature entry

### Tests
- 18 passed, 0 failed

### Build Verification
- TypeScript: ✓
- Lint: ✓
- Tests: ✓
- Build: ✓

## Test plan
- [ ] Upload SD card data → Graphs tab shows TrendChart + full waveform stack (no regression)
- [ ] Load demo → Graphs tab shows TrendChart + synthetic waveform (no regression)
- [ ] Refresh page with persisted data (no SD card) → Graphs tab shows TrendChart + Glasgow Radar + info banner
- [ ] Single night only → TrendChart title says "Night Metrics"
- [ ] Multiple nights → TrendChart title says "Multi-Night Trends"
- [ ] Mobile viewport renders correctly
- [ ] NightSelector switches update both TrendChart and Glasgow Radar

## Pre-Merge Checklist
- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [x] Self-review: no regressions, loading/error/empty states handled
- [x] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)