### PR TITLE
fix: harden auto-fix workflow against prompt injection

### DIFF
--- a/.github/prompts/fix-sentry-error.md
+++ b/.github/prompts/fix-sentry-error.md
@@ -19,15 +19,44 @@ A production error was detected by Sentry and filed as a GitHub issue. Read the 
 
 ## Constraints
 
-### Protected modules — NEVER modify
+### Allowed files — you may ONLY modify files in these paths
 
-These contain clinically validated algorithms. Do not change any logic in:
+You may only create or edit files within the following directories:
 
-- `lib/parsers/` — data parsing engine
-- `lib/analyzers/` — analysis engine
-- `workers/` — web workers
+- `components/` — React components (UI fixes)
+- `hooks/` — custom React hooks
+- `app/` page/layout files (`page.tsx`, `layout.tsx`, `loading.tsx`, `error.tsx`) — NOT `app/api/`
+- `lib/utils.ts` — utility functions
+- `lib/thresholds.ts` — display thresholds
+- `lib/metric-explanations.ts` — metric display text
+- `lib/insights.ts` — rule-based insights
+- `lib/export.ts`, `lib/forum-export.ts`, `lib/pdf-report.ts` — export utilities
+- `lib/persistence.ts` — localStorage logic
+- `lib/analytics.ts` — Plausible analytics helpers
+- `public/` — static assets
 
-If the error originates in a protected module, **do not attempt a fix**. Instead:
+### Forbidden paths — NEVER modify
+
+Do NOT modify, create, or delete files in any of these paths. If the error originates here, apply `needs-human` and stop.
+
+- `app/api/` — API routes (auth, data flows, external integrations)
+- `lib/parsers/` — clinically validated data parsing
+- `lib/analyzers/` — clinically validated analysis engines
+- `lib/auth/` — authentication logic
+- `lib/supabase/` — database client configuration
+- `lib/env.ts` — environment variable definitions
+- `lib/csrf.ts` — CSRF protection
+- `lib/rate-limit.ts` — rate limiting
+- `lib/ai-insights-client.ts` — AI API client
+- `workers/` — web worker orchestration
+- `supabase/migrations/` — database migrations
+- `.github/` — CI/CD workflows and prompts
+- `middleware.ts` — request middleware
+- `next.config.mjs` — Next.js configuration (security headers, CSP)
+- `sentry.*.config.ts` — Sentry configuration
+- `.env*` — environment files
+
+If the error originates in a forbidden path, **do not attempt a fix**. Instead:
 1. Comment on the issue with your root cause analysis
 2. Apply the `needs-human` label
 3. Stop — do not open a PR

--- a/.github/workflows/auto-fix-error.yml
+++ b/.github/workflows/auto-fix-error.yml
@@ -79,10 +79,11 @@ jobs:
           prompt_file: .github/prompts/fix-sentry-error.md
           issue_number: ${{ github.event.issue.number }}
 
-      - name: Enable auto-merge
+      - name: Gate sensitive file changes
         if: |
           steps.check-branch.outputs.exists == 'false' &&
           steps.rate-limit.outputs.exceeded == 'false'
+        id: file-gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -91,14 +92,65 @@ jobs:
 
           if [ -z "$PR_NUMBER" ]; then
             echo "No PR found — Claude Code may have applied needs-human label instead"
+            echo "has_pr=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Check for hold label
-          HOLD=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | map(select(. == "hold")) | length')
-          if [ "$HOLD" -gt 0 ]; then
-            echo "PR #$PR_NUMBER has 'hold' label — skipping auto-merge"
-            exit 0
+          echo "has_pr=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+          # Check if PR touches sensitive files (security-critical paths)
+          SENSITIVE_PATTERNS="app/api/ lib/auth/ lib/env.ts lib/supabase/ lib/csrf.ts lib/rate-limit.ts supabase/migrations/ .github/ sentry middleware.ts next.config"
+          CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || echo "")
+
+          SENSITIVE=false
+          for pattern in $SENSITIVE_PATTERNS; do
+            if echo "$CHANGED_FILES" | grep -q "$pattern"; then
+              echo "⚠️  PR touches sensitive path: $pattern"
+              SENSITIVE=true
+            fi
+          done
+
+          if [ "$SENSITIVE" = "true" ]; then
+            echo "sensitive=true" >> "$GITHUB_OUTPUT"
+            gh pr edit "$PR_NUMBER" --add-label "hold,security-review" 2>/dev/null || true
+
+            # Build the flagged files list
+            FLAGGED=""
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              for p in $SENSITIVE_PATTERNS; do
+                if echo "$f" | grep -q "$p"; then
+                  FLAGGED="${FLAGGED}- \`${f}\` (matches \`${p}\`)\n"
+                  break
+                fi
+              done
+            done <<< "$CHANGED_FILES"
+
+            COMMENT_BODY="⚠️ **Security gate triggered** — this auto-fix touches sensitive files (API routes, auth, config, or infrastructure).
+
+Auto-merge has been blocked. Manual review required before merging.
+
+**Changed files flagged:**
+$(echo -e "$FLAGGED")"
+
+            gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY" 2>/dev/null || true
+          else
+            echo "sensitive=false" >> "$GITHUB_OUTPUT"
           fi
 
-          gh pr merge "$PR_NUMBER" --auto --squash || echo "Auto-merge could not be enabled (check repo settings)"
+      - name: Notify — PR ready for review
+        if: |
+          steps.file-gate.outputs.has_pr == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.file-gate.outputs.pr_number }}"
+          SENSITIVE="${{ steps.file-gate.outputs.sensitive }}"
+
+          if [ "$SENSITIVE" = "true" ]; then
+            echo "PR #$PR_NUMBER blocked — touches sensitive files. Review required."
+          else
+            echo "PR #$PR_NUMBER ready for review on Vercel preview."
+            gh pr comment "$PR_NUMBER" --body "Auto-fix PR is ready. Please verify the Vercel preview before merging." 2>/dev/null || true
+          fi


### PR DESCRIPTION
## Summary

Security hardening for the Sentry auto-fix CI pipeline, identified during a full security audit.

- **Removed auto-merge** — PRs generated by the auto-fix workflow now require manual review and Vercel preview verification before merging. Previously, `gh pr merge --auto --squash` would merge PRs as soon as CI passed.
- **Added file-path security gate** — After Claude Code generates a fix, the workflow scans the PR diff for sensitive paths (`app/api/`, `lib/auth/`, `lib/env.ts`, `supabase/migrations/`, `.github/`, etc.). If detected, the PR gets `hold` + `security-review` labels and a comment listing flagged files.
- **Switched from blocklist to allowlist** — The fix prompt previously blocked 3 directories. Now it uses a positive allowlist (components, hooks, page files, specific lib utilities) + a comprehensive forbidden list (17 paths covering API routes, auth, config, infra, CI/CD).

## Test plan

- [ ] Verify workflow YAML is valid (CI should parse it)
- [ ] Verify the prompt file renders correctly on GitHub
- [ ] Manual test: trigger a Sentry error → confirm PR is created without auto-merge
- [ ] Manual test: if PR touches `app/api/`, confirm `hold` label is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)