### PR TITLE
fix: correct glottic narrowing mechanism in AI prompt

### DIFF
--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -67,7 +67,7 @@ Rules:
 - Prioritise actionable findings over general observations
 - Generate at least one "actionable" type insight with concrete investigation suggestions
 - Do not repeat what the rule-based system would already catch (simple threshold checks)
-- Never recommend pressure increases as a blanket solution. Higher pressure can cause reflex glottic narrowing that reduces effective ventilation (Jounieaux 1995). Frame therapy discussion in terms of timing and synchrony (cycling, rise time, trigger sensitivity) rather than pressure magnitude. Brief obstructions (1-2 breath events) typically do not respond to EPAP changes.
+- Never recommend pressure increases as a blanket solution. In S-mode (spontaneous breathing), glottic narrowing is NOT the limiting factor (Parreira 1996b, Oppersma 2018). The real risk of higher PS is ventilatory instability: increased tidal volume lowers PaCO2 below the apnea threshold, causing central events. Frame therapy discussion in terms of timing and synchrony (cycling, rise time, trigger sensitivity) rather than pressure magnitude. Brief obstructions (1-2 breath events) typically do not respond to EPAP changes.
 - Keep body text to 1 sentence (max ~30 words). Be data-dense, not verbose.
 - If running low on space, finish the current insight and close the array. Fewer complete insights are better than many truncated ones.
 


### PR DESCRIPTION
## Summary

- Jounieaux 1995 (controlled/passive ventilation) was incorrectly cited as the pressure ceiling mechanism for S-mode BiPAP users
- Parreira 1996b and Oppersma 2018 show **no glottic involvement in spontaneous breathing**
- Updated AI system prompt to cite correct risk: ventilatory instability (Vt-driven hypocapnia below apnea threshold causing central events)
- The recommendation ("don't blanket-recommend pressure increases") is unchanged — only the mechanism is corrected

## Why this matters

The AI prompt instructs Claude how to reason about therapy recommendations. Citing the wrong mechanism could lead to incorrect reasoning in edge cases — e.g., dismissing a legitimate PS increase by claiming glottic narrowing risk when the actual risk is central apneas from hypocapnia.

## Test plan

- [ ] Verify AI insights still generate correctly on Vercel preview
- [ ] Confirm no pressure-increase recommendations appear without appropriate caveats
- [ ] Check that ventilatory instability framing appears in relevant AI outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)