### PR TITLE
fix: hide contribution nudge for authenticated users

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -563,6 +563,7 @@ function AnalyzePageInner() {
               current={progress.current}
               total={progress.total}
               stage={progress.stage}
+              isAuthenticated={!!user}
             />
           </div>
           {/* Skeleton dashboard preview */}

--- a/components/upload/progress-display.tsx
+++ b/components/upload/progress-display.tsx
@@ -6,9 +6,10 @@ interface ProgressDisplayProps {
   current: number;
   total: number;
   stage: string;
+  isAuthenticated?: boolean;
 }
 
-export function ProgressDisplay({ current, total, stage }: ProgressDisplayProps) {
+export function ProgressDisplay({ current, total, stage, isAuthenticated }: ProgressDisplayProps) {
   const pct = total > 0 ? Math.round((current / total) * 100) : 0;
 
   return (
@@ -40,7 +41,7 @@ export function ProgressDisplay({ current, total, stage }: ProgressDisplayProps)
         <span className="font-mono tabular-nums">{pct}%</span>
       </div>
 
-      {pct > 30 && (
+      {pct > 30 && !isAuthenticated && (
         <p className="mt-3 text-center text-[11px] text-muted-foreground/70">
           After analysis, you&apos;ll have the option to contribute your anonymised scores to help PAP research.
         </p>


### PR DESCRIPTION
## Summary
- Registered users no longer see the "contribute your anonymised scores" message during file upload
- The nudge was showing unconditionally once the progress bar hit 30% -- now gated on `!isAuthenticated`

## Test plan
- [ ] Upload SD card data as anonymous user -- contribution nudge appears at 30%+
- [ ] Upload SD card data as logged-in user -- no contribution nudge shown
- [ ] Vercel preview verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)