### PR TITLE
feat: platform optimization batch 2 — linking, providers, upgrade nudge

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -40,6 +40,7 @@ import { contributeNights, trackContributedDates } from '@/lib/contribute';
 import { contributeWaveformsBackground } from '@/lib/contribute-waveforms';
 import { safeGetItem } from '@/lib/safe-local-storage';
 import { GuidedWalkthrough } from '@/components/dashboard/guided-walkthrough';
+import { PostAnalysisUpgrade } from '@/components/dashboard/post-analysis-upgrade';
 import * as Sentry from '@sentry/nextjs';
 import {
   RotateCcw,
@@ -708,6 +709,9 @@ function AnalyzePageInner() {
 
           {/* Guided Walkthrough — opt-in tour for first-time users */}
           <GuidedWalkthrough isComplete={isComplete} />
+
+          {/* Post-analysis upgrade nudge — one-time, after first results */}
+          {!isDemo && <PostAnalysisUpgrade isComplete={isComplete} />}
 
           {/* Data Contribution — prominent placement at top of dashboard */}
           <DataContribution

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { Sparkles, Wrench, Bug, Shield, Accessibility, Package } from 'lucide-react';
 import { parseChangelog } from '@/lib/changelog-parser';
 
@@ -155,6 +156,18 @@ export default function ChangelogPage() {
             </div>
           </section>
         ))}
+      </div>
+
+      {/* Cross-links */}
+      <div className="mt-12 border-t border-border/50 pt-8">
+        <p className="text-sm text-muted-foreground">
+          Want to understand the analysis behind these features? Read the{' '}
+          <Link href="/about" className="text-primary hover:text-primary/80">methodology documentation</Link>,
+          explore the{' '}
+          <Link href="/blog" className="text-primary hover:text-primary/80">blog</Link> for deep dives,
+          or check the{' '}
+          <Link href="/glossary" className="text-primary hover:text-primary/80">metric glossary</Link> for definitions.
+        </p>
       </div>
     </div>
   );

--- a/app/glossary/page.tsx
+++ b/app/glossary/page.tsx
@@ -514,6 +514,34 @@ export default function GlossaryPage() {
           ))}
       </div>
 
+      {/* Cross-links */}
+      <div className="mt-12 border-t border-border/50 pt-8">
+        <h2 className="mb-3 text-lg font-semibold">Go deeper</h2>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Link
+            href="/about/flow-limitation"
+            className="group rounded-lg border border-border/50 bg-card/30 p-4 transition-all hover:border-primary/30"
+          >
+            <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">Flow Limitation</h3>
+            <p className="mt-1 text-xs text-muted-foreground">How AirwayLab detects and scores airway restriction.</p>
+          </Link>
+          <Link
+            href="/about/glasgow-index"
+            className="group rounded-lg border border-border/50 bg-card/30 p-4 transition-all hover:border-primary/30"
+          >
+            <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">Glasgow Index</h3>
+            <p className="mt-1 text-xs text-muted-foreground">The 9-component breath shape scoring methodology.</p>
+          </Link>
+          <Link
+            href="/about/oximetry-analysis"
+            className="group rounded-lg border border-border/50 bg-card/30 p-4 transition-all hover:border-primary/30"
+          >
+            <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">Oximetry Analysis</h3>
+            <p className="mt-1 text-xs text-muted-foreground">17-metric SpO2 and heart rate analysis framework.</p>
+          </Link>
+        </div>
+      </div>
+
       {/* Medical Disclaimer */}
       <section className="mt-12 mb-8">
         <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-5 sm:p-6">

--- a/app/providers/page.tsx
+++ b/app/providers/page.tsx
@@ -246,6 +246,158 @@ export default function ProvidersPage() {
         </div>
       </section>
 
+      {/* ─── Before/After Scenario ─── */}
+      <section className="container mx-auto px-4 py-14 sm:px-6 sm:py-20">
+        <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
+          What This Looks Like in Practice
+        </h2>
+        <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+          A typical remote consult scenario, using real metric ranges from AirwayLab&apos;s analysis engines.
+        </p>
+
+        <div className="mt-8 grid gap-6 sm:grid-cols-2">
+          {/* Before */}
+          <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-5 sm:p-6">
+            <div className="mb-3 flex items-center gap-2">
+              <div className="h-2.5 w-2.5 rounded-full bg-amber-400" />
+              <h3 className="text-sm font-semibold text-amber-400">Initial Assessment</h3>
+            </div>
+            <p className="mb-3 text-xs text-muted-foreground">
+              Patient reports persistent fatigue despite 6 months of CPAP. Machine-reported AHI: 2.1/hr.
+            </p>
+            <div className="space-y-1.5 text-xs">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Glasgow Index</span>
+                <span className="font-mono font-medium text-amber-400">3.2</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">FL Score</span>
+                <span className="font-mono font-medium text-amber-400">62%</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">NED Mean</span>
+                <span className="font-mono font-medium text-amber-400">28%</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">RERA Index</span>
+                <span className="font-mono font-medium text-amber-400">8.4/hr</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">IFL Risk</span>
+                <span className="font-mono font-medium text-red-400">High</span>
+              </div>
+            </div>
+            <p className="mt-3 text-[11px] text-muted-foreground/70">
+              CPAP 10 cmH2O, EPR 3. Significant residual flow limitation invisible to AHI.
+            </p>
+          </div>
+
+          {/* After */}
+          <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-5 sm:p-6">
+            <div className="mb-3 flex items-center gap-2">
+              <div className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
+              <h3 className="text-sm font-semibold text-emerald-400">After Adjustment</h3>
+            </div>
+            <p className="mb-3 text-xs text-muted-foreground">
+              Provider switched to BiPAP (EPAP 8, IPAP 14, PS 6) based on flow limitation data.
+              Follow-up at 4 weeks.
+            </p>
+            <div className="space-y-1.5 text-xs">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Glasgow Index</span>
+                <span className="font-mono font-medium text-emerald-400">1.1</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">FL Score</span>
+                <span className="font-mono font-medium text-emerald-400">24%</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">NED Mean</span>
+                <span className="font-mono font-medium text-emerald-400">12%</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">RERA Index</span>
+                <span className="font-mono font-medium text-emerald-400">2.1/hr</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">IFL Risk</span>
+                <span className="font-mono font-medium text-emerald-400">Low</span>
+              </div>
+            </div>
+            <p className="mt-3 text-[11px] text-muted-foreground/70">
+              Patient reports improved energy. Objective metrics confirm therapy response.
+            </p>
+          </div>
+        </div>
+
+        <p className="mt-6 text-xs text-muted-foreground/70">
+          Illustrative scenario using typical metric ranges. Not based on a specific patient.
+          Always verify with clinical assessment.
+        </p>
+      </section>
+
+      {/* ─── FAQ ─── */}
+      <section className="border-y border-border/50 bg-card/20">
+        <div className="container mx-auto px-4 py-14 sm:px-6 sm:py-20">
+          <h2 className="mb-8 text-2xl font-bold tracking-tight sm:text-3xl">
+            Common Questions
+          </h2>
+          <div className="space-y-6">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Is patient data shared with AirwayLab?</h3>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                No. All analysis runs in the patient&apos;s browser. Raw waveform data never leaves
+                their device. When they share a link, only aggregate scores (not raw data) are stored,
+                encrypted, and auto-deleted after 30 days. Patients can revoke access at any time.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">What devices are supported?</h3>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                Currently ResMed AirSense 10 and AirCurve 10 series. AirSense 11 support is in
+                development. Pulse oximetry from Viatom/Checkme O2 Max is supported for combined
+                analysis. See the{' '}
+                <Link href="/about" className="text-primary hover:text-primary/80">
+                  methodology page
+                </Link>{' '}
+                for details.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Can I use this for billing or clinical documentation?</h3>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                AirwayLab is not a medical device and is not FDA-cleared or CE-marked. It is an
+                educational tool. The analysis provides objective data points that may inform clinical
+                decisions, but should not be cited as diagnostic evidence. PDF and CSV exports can
+                supplement clinical notes.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">How does this compare to OSCAR?</h3>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                OSCAR is a desktop application for interactive waveform browsing. AirwayLab adds
+                automated flow limitation scoring (Glasgow Index, NED, WAT), RERA detection, and
+                composite metrics that OSCAR doesn&apos;t compute. Many providers use both. See our{' '}
+                <Link href="/blog" className="text-primary hover:text-primary/80">
+                  comparison article
+                </Link>{' '}
+                for details.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">Is there a cost for providers?</h3>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                The core analysis is free and always will be. Paid tiers unlock AI-powered insights,
+                cloud sync, and extended trend views. Clinic-specific features (multi-patient dashboards,
+                branded reports) are on the{' '}
+                <Link href="/pricing" className="text-primary hover:text-primary/80">roadmap</Link>.
+                Early adopters who shape what we build get priority access.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* ─── Roadmap ─── */}
       <section className="container mx-auto px-4 py-14 sm:px-6 sm:py-20">
         <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -393,6 +393,41 @@ export default function ResearchPage() {
         </div>
       </section>
 
+      {/* ---- Related Resources ---- */}
+      <section className="mb-12">
+        <h2 className="mb-4 text-lg font-semibold tracking-tight">Related reading</h2>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Link
+            href="/blog/beyond-ahi"
+            className="group rounded-lg border border-border/50 bg-card/30 p-4 transition-all hover:border-primary/30"
+          >
+            <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">Beyond AHI</h3>
+            <p className="mt-1 text-xs text-muted-foreground">Why the standard sleep apnea metric misses critical breathing events.</p>
+          </Link>
+          <Link
+            href="/blog/understanding-flow-limitation"
+            className="group rounded-lg border border-border/50 bg-card/30 p-4 transition-all hover:border-primary/30"
+          >
+            <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">Understanding Flow Limitation</h3>
+            <p className="mt-1 text-xs text-muted-foreground">What flow limitation is and how AirwayLab detects it from PAP data.</p>
+          </Link>
+          <Link
+            href="/about"
+            className="group rounded-lg border border-border/50 bg-card/30 p-4 transition-all hover:border-primary/30"
+          >
+            <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">Analysis Methodology</h3>
+            <p className="mt-1 text-xs text-muted-foreground">Detailed documentation of all four analysis engines and their algorithms.</p>
+          </Link>
+          <Link
+            href="/glossary"
+            className="group rounded-lg border border-border/50 bg-card/30 p-4 transition-all hover:border-primary/30"
+          >
+            <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">Metric Glossary</h3>
+            <p className="mt-1 text-xs text-muted-foreground">Definitions of every metric AirwayLab computes, with clinical context.</p>
+          </Link>
+        </div>
+      </section>
+
       {/* ---- Medical Disclaimer ---- */}
       <section className="mb-8">
         <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-5 sm:p-6">

--- a/app/supporters/page.tsx
+++ b/app/supporters/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
-import { Crown } from 'lucide-react';
+import Link from 'next/link';
+import { Crown, Heart } from 'lucide-react';
 import { getSupabaseServiceRole } from '@/lib/supabase/server';
 
 export const metadata: Metadata = {
@@ -108,7 +109,22 @@ export default async function SupportersPage() {
         </div>
       )}
 
-      <div className="mt-12 text-center">
+      {/* Become a supporter CTA */}
+      <div className="mt-12 rounded-xl border border-primary/20 bg-primary/5 p-6 text-center">
+        <Heart className="mx-auto h-5 w-5 text-primary/60" />
+        <h3 className="mt-2 text-sm font-semibold">Help keep AirwayLab free and open-source</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Supporters fund continued development and get AI-powered insights, cloud sync, and more.
+        </p>
+        <Link
+          href="/pricing"
+          className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          See plans
+        </Link>
+      </div>
+
+      <div className="mt-6 text-center">
         <p className="text-xs text-muted-foreground">
           Only supporters who opt in are shown. Toggle visibility in your
           account settings.

--- a/components/dashboard/post-analysis-upgrade.tsx
+++ b/components/dashboard/post-analysis-upgrade.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { Sparkles, X, TrendingUp, Cloud } from 'lucide-react';
+import { useAuth } from '@/lib/auth/auth-context';
+import { events } from '@/lib/analytics';
+
+const STORAGE_KEY = 'airwaylab_post_analysis_upgrade_dismissed';
+
+interface Props {
+  isComplete: boolean;
+}
+
+/**
+ * One-time upgrade nudge shown after a user's first successful analysis.
+ * Only appears for community-tier users who haven't dismissed it.
+ * Designed to surface at the peak value moment — right after seeing results.
+ */
+export function PostAnalysisUpgrade({ isComplete }: Props) {
+  const { tier } = useAuth();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isComplete || tier !== 'community') return;
+
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === '1') return;
+    } catch {
+      return;
+    }
+
+    // Small delay so it doesn't compete with the walkthrough prompt
+    const timer = setTimeout(() => setVisible(true), 2000);
+    return () => clearTimeout(timer);
+  }, [isComplete, tier]);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    setVisible(false);
+    try {
+      localStorage.setItem(STORAGE_KEY, '1');
+    } catch { /* noop */ }
+    events.upgradeNudgeDismissed('post_analysis');
+  };
+
+  return (
+    <div className="animate-fade-in-up rounded-xl border border-primary/20 bg-gradient-to-r from-primary/[0.06] to-transparent px-4 py-4">
+      <div className="flex items-start gap-3">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+          <Sparkles className="h-4 w-4 text-primary" />
+        </div>
+        <div className="flex-1">
+          <div className="flex items-start justify-between">
+            <h3 className="text-sm font-semibold text-foreground">Your analysis is ready</h3>
+            <button
+              onClick={dismiss}
+              className="rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-muted-foreground"
+              aria-label="Dismiss"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            You just got Glasgow Index, flow limitation scores, and RERA detection — free, in your browser.
+            Want to go deeper?
+          </p>
+          <div className="mt-3 grid gap-2 sm:grid-cols-3">
+            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+              <Sparkles className="h-3 w-3 shrink-0 text-primary/50" />
+              <span>AI-powered therapy insights</span>
+            </div>
+            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+              <TrendingUp className="h-3 w-3 shrink-0 text-primary/50" />
+              <span>90-night trend tracking</span>
+            </div>
+            <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+              <Cloud className="h-3 w-3 shrink-0 text-primary/50" />
+              <span>Cloud sync across devices</span>
+            </div>
+          </div>
+          <div className="mt-3 flex items-center gap-3">
+            <Link
+              href="/pricing"
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+              onClick={() => events.upgradeNudgeClicked('post_analysis')}
+            >
+              See supporter benefits
+            </Link>
+            <button
+              onClick={dismiss}
+              className="text-[11px] text-muted-foreground/50 transition-colors hover:text-muted-foreground"
+            >
+              Maybe later
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -248,4 +248,13 @@ export const events = {
   // ── Community benchmarks ──────────────────────────────────────
   /** Community benchmarks loaded and viewed */
   communityBenchmarksViewed: () => trackEvent('Community Benchmarks Viewed'),
+
+  // ── Post-analysis upgrade nudge ──────────────────────────────
+  /** Post-analysis upgrade nudge dismissed */
+  upgradeNudgeDismissed: (source: string) =>
+    trackEvent('Upgrade Nudge Dismissed', { source }),
+
+  /** Post-analysis upgrade nudge CTA clicked */
+  upgradeNudgeClicked: (source: string) =>
+    trackEvent('Upgrade Nudge Clicked', { source }),
 } as const;


### PR DESCRIPTION
## Summary
- **Internal linking** on leaf pages (research → blog/glossary, glossary → methodology pages, changelog → blog/glossary, supporters → pricing CTA)
- **Providers page enhanced** with before/after clinical scenario (synthetic, realistic metric ranges) and 5-item FAQ covering privacy, devices, billing, OSCAR comparison, and pricing
- **PostAnalysisUpgrade component** — one-time celebration card after first successful analysis for community-tier users. Shows AI insights, trend tracking, cloud sync as upgrade benefits. 2s delay to avoid stacking with GuidedWalkthrough. Dismisses permanently via localStorage.
- **Analytics events** for upgrade nudge (dismissed, clicked) to track conversion

Source: platform optimization audit (2026-03-17), batch 2 of 2

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes (0 errors, 2 pre-existing warnings)
- [ ] `npm test` passes (1165/1165)
- [ ] `npm run build` passes
- [ ] Vercel preview: /research shows "Related reading" section with 4 cards
- [ ] Vercel preview: /glossary shows "Go deeper" section with 3 methodology cards
- [ ] Vercel preview: /changelog shows cross-link text at bottom
- [ ] Vercel preview: /supporters shows pricing CTA card
- [ ] Vercel preview: /providers shows before/after scenario + FAQ section
- [ ] Vercel preview: /analyze — after first analysis, post-analysis upgrade card appears (community tier only)
- [ ] Vercel preview: upgrade card dismisses permanently
- [ ] Mobile: all new sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)