### PR TITLE
fix: unmask Sentry replays except health data

### DIFF
--- a/components/share/shared-view-client.tsx
+++ b/components/share/shared-view-client.tsx
@@ -88,7 +88,7 @@ export function SharedViewClient({
 
   return (
     <ThresholdsProvider>
-      <div className="container mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8">
+      <div className="container mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8" data-sentry-mask>
         {/* Header banner */}
         <div className="mb-6 flex flex-col gap-3 rounded-xl border border-primary/20 bg-primary/[0.04] px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -27,8 +27,11 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature
   integrations: [
     Sentry.replayIntegration({
-      maskAllText: true,
-      blockAllMedia: true,
+      // Unmask by default so we can debug upload flows, errors, and navigation.
+      // Health data in analysis results is masked via data-sentry-mask on the container.
+      maskAllText: false,
+      blockAllMedia: false,
+      mask: ['[data-sentry-mask]'],
       // Detect dead clicks (no DOM mutation within 7s) and rage clicks (3+ rapid clicks)
       slowClickTimeout: 7000,
       // Capture request/response bodies for API routes in replays (metrics only, never raw waveforms)


### PR DESCRIPTION
## Summary

Sentry replays were completely masked (`maskAllText: true, blockAllMedia: true`), making them useless for debugging upload errors, navigation issues, and user flows.

**Before:** Every text node shows as `****` in replays. Can't debug anything.
**After:** All pages are readable. Only the analysis results dashboard (where health data lives) is masked via `data-sentry-mask`.

### What's visible in replays now
- Landing page, upload flow, error messages, navigation, modals, blog, settings

### What stays masked
- Analysis results on `/analyze` (scores, metrics, insights, charts)
- Shared analysis view on `/shared/[id]`

## Files changed
- `instrumentation-client.ts` -- flip `maskAllText`/`blockAllMedia` to false, add `mask: ['[data-sentry-mask]']`
- `app/analyze/page.tsx` -- add `data-sentry-mask` to results dashboard container
- `components/share/shared-view-client.tsx` -- add `data-sentry-mask` to shared view container

Closes #191, closes #192

## Test plan
- [ ] Verify Vercel preview deploy
- [ ] Trigger a Sentry replay (visit site in production after deploy)
- [ ] Confirm landing page text is visible in replay
- [ ] Confirm analysis results are masked in replay
- [ ] Upload invalid files and verify error flow is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)