### PR TITLE
fix: add test_email param to announcement endpoint

### DIFF
--- a/app/api/email/announce/route.ts
+++ b/app/api/email/announce/route.ts
@@ -33,6 +33,15 @@ export async function POST(request: NextRequest) {
 
   const body = await request.json().catch(() => ({}));
   const dryRun = body.dry_run !== false; // default to dry run
+  const testEmail: string | undefined = body.test_email;
+
+  // Test mode: send to a single address for preview, no backfill or DB queries
+  if (testEmail) {
+    const unsubscribeUrl = getUnsubscribeUrl('test-user-preview');
+    const { subject, html } = buildAnnouncementEmail(unsubscribeUrl);
+    const sent = await sendEmail({ to: testEmail, subject, html, unsubscribeUrl });
+    return NextResponse.json({ test: true, sent, to: testEmail });
+  }
 
   const supabase = getSupabaseAdmin();
   if (!supabase) {


### PR DESCRIPTION
Adds `test_email` parameter to POST /api/email/announce for previewing the email before sending to all users. No backfill, no DB queries in test mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)