### PR TITLE
chore: extract shared file-path-utils for webkitRelativePath access

### DIFF
--- a/components/upload/error-data-submission.tsx
+++ b/components/upload/error-data-submission.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react';
 import { HelpCircle, CheckCircle, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { getFilePath } from '@/lib/file-path-utils';
 
 interface Props {
   error: string;
@@ -20,10 +21,7 @@ export function ErrorDataSubmission({ error, files }: Props) {
   const handleSubmit = useCallback(async () => {
     setStatus('sending');
     try {
-      const fileNames = files.slice(0, 50).map((f) => {
-        const rel = (f as unknown as { webkitRelativePath?: string }).webkitRelativePath;
-        return rel || f.name;
-      });
+      const fileNames = files.slice(0, 50).map((f) => getFilePath(f));
 
       const res = await fetch('/api/submit-error-data', {
         method: 'POST',

--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -15,6 +15,7 @@ import type {
   WorkerSettingsDiagnostic,
 } from './types';
 import { loadPersistedResults, persistResults, persistNightsIncremental } from './persistence';
+import { getFilePath } from './file-path-utils';
 import {
   extractNightDate,
   buildManifest,
@@ -117,8 +118,7 @@ export class AnalysisOrchestrator {
         // No manifest — fall back to date-based dedup
         const uploadDates = new Set<string>();
         for (const file of sdArr) {
-          const path =
-            (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || file.name;
+          const path = getFilePath(file);
           const date = extractNightDate(path);
           if (date) uploadDates.add(date);
         }
@@ -145,8 +145,7 @@ export class AnalysisOrchestrator {
 
         if (newDates.size > 0 && unchangedDates.length > 0) {
           filesToProcess = sdArr.filter((file) => {
-            const path =
-              (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || file.name;
+            const path = getFilePath(file);
             const date = extractNightDate(path);
             return date === null || newDates.has(date);
           });
@@ -579,8 +578,7 @@ async function readFileList(
     const batch = files.slice(i, i + BATCH_SIZE);
     const batchResults = await Promise.all(
       batch.map(async (file) => {
-        const path =
-          (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || file.name;
+        const path = getFilePath(file);
         const buffer = await file.arrayBuffer();
         return { buffer, path };
       })

--- a/lib/contribute-waveforms.ts
+++ b/lib/contribute-waveforms.ts
@@ -9,6 +9,7 @@ import * as Sentry from '@sentry/nextjs';
 import { parseEDF } from './parsers/edf-parser';
 import { filterBRPFiles, groupByNight } from './parsers/night-grouper';
 import { ENGINE_VERSION } from './engine-version';
+import { getFilePath, getFileName } from './file-path-utils';
 import {
   getContributedWaveformDates,
   trackContributedWaveformDate,
@@ -173,10 +174,8 @@ async function extractFlowForNight(
 } | null> {
   // Build file list for BRP filtering
   const fileList = files.map((f) => ({
-    name:
-      (f as unknown as { webkitRelativePath?: string }).webkitRelativePath?.split('/').pop() ||
-      f.name,
-    path: (f as unknown as { webkitRelativePath?: string }).webkitRelativePath || f.name,
+    name: getFileName(f),
+    path: getFilePath(f),
     size: f.size,
   }));
 
@@ -185,11 +184,7 @@ async function extractFlowForNight(
   // Parse BRP files
   const parsedEdfs: EDFFile[] = [];
   for (const brp of brpFiles) {
-    const fileData = files.find((f) => {
-      const path =
-        (f as unknown as { webkitRelativePath?: string }).webkitRelativePath || f.name;
-      return path === brp.path;
-    });
+    const fileData = files.find((f) => getFilePath(f) === brp.path);
     if (!fileData) continue;
     try {
       const buffer = await fileData.arrayBuffer();

--- a/lib/file-manifest.ts
+++ b/lib/file-manifest.ts
@@ -4,6 +4,8 @@
 // nights and only analyze new/modified data.
 // ============================================================
 
+import { getFilePath } from './file-path-utils';
+
 const MANIFEST_KEY = 'airwaylab_file_manifest';
 
 export interface FileFingerprint {
@@ -31,9 +33,7 @@ const DATE_FOLDER_RE = /(\d{8})\//;
  * Create a fingerprint from a File object.
  */
 export function fingerprintFile(file: File): FileFingerprint {
-  const path =
-    (file as unknown as { webkitRelativePath?: string }).webkitRelativePath ||
-    file.name;
+  const path = getFilePath(file);
   return { path, size: file.size, lastModified: file.lastModified };
 }
 
@@ -56,9 +56,7 @@ export function extractNightDate(path: string): string | null {
 export function groupFilesByNight(files: File[]): Map<string, File[]> {
   const groups = new Map<string, File[]>();
   for (const file of files) {
-    const path =
-      (file as unknown as { webkitRelativePath?: string }).webkitRelativePath ||
-      file.name;
+    const path = getFilePath(file);
     const date = extractNightDate(path) ?? '__unknown__';
     const arr = groups.get(date) ?? [];
     arr.push(file);

--- a/lib/file-path-utils.ts
+++ b/lib/file-path-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared helpers for accessing File.webkitRelativePath.
+ *
+ * TypeScript's File type omits the non-standard webkitRelativePath property
+ * set by <input webkitdirectory>. These helpers centralise the type cast
+ * so the rest of the codebase can access the path without repeating it.
+ */
+
+/** Return the browser-relative path from a directory upload, or file.name as fallback. */
+export function getFilePath(file: File): string {
+  return (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || file.name;
+}
+
+/** Return the raw webkitRelativePath (may be undefined if not a directory upload). */
+export function getRelativePath(file: File): string | undefined {
+  return (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || undefined;
+}
+
+/** Extract just the filename from the webkitRelativePath, falling back to file.name. */
+export function getFileName(file: File): string {
+  return getFilePath(file).split('/').pop() || file.name;
+}

--- a/lib/storage/synced-registry.ts
+++ b/lib/storage/synced-registry.ts
@@ -17,12 +17,10 @@ interface SyncedData {
   entries: Record<string, SyncedEntry>;
 }
 
+import { getFilePath } from '@/lib/file-path-utils';
+
 function makeKey(filePath: string, fileSize: number, lastModified: number): string {
   return `${filePath}|${fileSize}|${lastModified}`;
-}
-
-function getFilePath(file: File): string {
-  return (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || file.name;
 }
 
 export class SyncedRegistry {

--- a/lib/storage/upload-orchestrator.ts
+++ b/lib/storage/upload-orchestrator.ts
@@ -15,6 +15,7 @@ import type { UploadState, UploadResult } from './types';
 import type { WorkerMessage } from './hash-worker';
 import { HashCache } from './hash-cache';
 import { hasCloudSyncConsent } from '@/components/upload/cloud-sync-nudge';
+import { getFilePath } from '@/lib/file-path-utils';
 
 type UploadListener = (state: UploadState) => void;
 
@@ -22,10 +23,6 @@ const CONCURRENCY = 10;
 const RETRY_DELAY_MS = 2000;
 /** Abort after this many consecutive failures with the same error */
 const FAIL_FAST_THRESHOLD = 3;
-
-function getFilePath(file: File): string {
-  return (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || file.name;
-}
 
 class UploadOrchestrator {
   private state: UploadState = {

--- a/lib/upload-validation.ts
+++ b/lib/upload-validation.ts
@@ -3,6 +3,8 @@
 // Quick checks before sending files to the analysis worker.
 // ============================================================
 
+import { getFilePath } from './file-path-utils';
+
 export interface ValidationResult {
   valid: boolean;
   edfCount: number;
@@ -29,10 +31,7 @@ export function validateSDFiles(files: File[]): ValidationResult {
   );
 
   // Check for DATALOG folder structure
-  const paths = files.map((f) => {
-    const rel = (f as unknown as { webkitRelativePath?: string }).webkitRelativePath;
-    return rel || f.name;
-  });
+  const paths = files.map((f) => getFilePath(f));
 
   const hasDatalog = paths.some((p) =>
     p.toUpperCase().includes('DATALOG')

--- a/lib/waveform-orchestrator.ts
+++ b/lib/waveform-orchestrator.ts
@@ -13,6 +13,7 @@ import type {
 } from './waveform-types';
 import { ENGINE_VERSION } from './engine-version';
 import { storeWaveform, loadWaveform, deleteExpired } from './waveform-idb';
+import { getFilePath } from './file-path-utils';
 
 type WaveformListener = (state: WaveformState) => void;
 
@@ -98,8 +99,7 @@ class WaveformOrchestrator {
     try {
       // Pre-filter to BRP + EVE files — avoids reading non-relevant files into memory
       const brpFiles = files.filter((f) => {
-        const path =
-          (f as unknown as { webkitRelativePath?: string }).webkitRelativePath || f.name;
+        const path = getFilePath(f);
         const name = (path.split('/').pop() || '').toLowerCase();
         return (name.endsWith('brp.edf') || name.endsWith('_brp.edf')) && f.size > 50 * 1024;
       });
@@ -111,8 +111,7 @@ class WaveformOrchestrator {
 
       // Also find EVE.edf files (machine-recorded events, tiny ~1KB)
       const eveFiles = files.filter((f) => {
-        const path =
-          (f as unknown as { webkitRelativePath?: string }).webkitRelativePath || f.name;
+        const path = getFilePath(f);
         const name = (path.split('/').pop() || '').toLowerCase();
         return name.endsWith('eve.edf') || name.endsWith('_eve.edf');
       });
@@ -120,8 +119,7 @@ class WaveformOrchestrator {
       // Further filter to only files matching the target date's DATALOG folder.
       const dateCompact = targetDate.replace(/-/g, '');
       const filterByDate = (f: File) => {
-        const path =
-          (f as unknown as { webkitRelativePath?: string }).webkitRelativePath || f.name;
+        const path = getFilePath(f);
         return path.includes(`DATALOG/${dateCompact}/`) || path.includes(`/${dateCompact}_`);
       };
 
@@ -269,8 +267,7 @@ async function readFiles(files: File[]): Promise<{ buffer: ArrayBuffer; path: st
     const batch = files.slice(i, i + BATCH_SIZE);
     const batchResults = await Promise.all(
       batch.map(async (file) => {
-        const path =
-          (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || file.name;
+        const path = getFilePath(file);
         const buffer = await file.arrayBuffer();
         return { buffer, path };
       })


### PR DESCRIPTION
## Summary

- Create `lib/file-path-utils.ts` centralising the `File.webkitRelativePath` type cast duplicated 16 times across 8 files
- Three helpers: `getFilePath()`, `getRelativePath()`, `getFileName()`
- Replaces all inline `(file as unknown as { webkitRelativePath?: string }).webkitRelativePath` casts

## Changes

| File | What changed |
|------|-------------|
| `lib/file-path-utils.ts` | **New** — shared `getFilePath()`, `getRelativePath()`, `getFileName()` |
| `lib/file-manifest.ts` | 2 inline casts → `getFilePath()` import |
| `lib/analysis-orchestrator.ts` | 3 inline casts → `getFilePath()` import |
| `lib/contribute-waveforms.ts` | 3 inline casts → `getFilePath()` + `getFileName()` imports |
| `lib/upload-validation.ts` | 1 inline cast → `getFilePath()` import |
| `lib/waveform-orchestrator.ts` | 4 inline casts → `getFilePath()` import |
| `lib/storage/upload-orchestrator.ts` | Replaced local `getFilePath()` with shared import |
| `lib/storage/synced-registry.ts` | Replaced local `getFilePath()` with shared import |
| `components/upload/error-data-submission.tsx` | 1 inline cast → `getFilePath()` import |

## What's NOT changed

- `lib/storage/cloud-file-loader.ts` — uses `Object.defineProperty` to *set* webkitRelativePath (producer side, not consumer cast)
- No logic changes — pure type-safety extraction

## Test plan

- [x] `npx tsc --noEmit` passes (0 new errors)
- [x] `npm test` passes (83 files, 1200 tests)
- [x] `npm run build` compiles successfully
- [ ] Verify Vercel preview: upload SD card data, full pipeline works
- [ ] Verify cloud sync upload still works (uses getFilePath for path resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)