### PR TITLE
fix: show error feedback when billing portal fails on account page

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -43,6 +43,9 @@ export default function AccountPage() {
   const [statsLoading, setStatsLoading] = useState(false);
   const [statsError, setStatsError] = useState(false);
 
+  const [portalLoading, setPortalLoading] = useState(false);
+  const [portalError, setPortalError] = useState(false);
+
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleteState, setDeleteState] = useState<
     'idle' | 'deleting' | 'success' | 'error'
@@ -140,22 +143,46 @@ export default function AccountPage() {
             </span>
           </div>
           {isPaid ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full"
-              onClick={async () => {
-                try {
-                  const res = await fetch('/api/customer-portal', { method: 'POST', credentials: 'same-origin' });
-                  const data = await res.json();
-                  if (data.url) window.location.href = data.url;
-                } catch (err) {
-                  Sentry.captureException(err, { tags: { action: 'customer-portal' } });
-                }
-              }}
-            >
-              Manage subscription
-            </Button>
+            <div className="space-y-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                disabled={portalLoading}
+                onClick={async () => {
+                  setPortalLoading(true);
+                  setPortalError(false);
+                  try {
+                    const res = await fetch('/api/customer-portal', { method: 'POST', credentials: 'same-origin' });
+                    const data = await res.json();
+                    if (data.url) {
+                      window.location.href = data.url;
+                    } else {
+                      setPortalError(true);
+                    }
+                  } catch (err) {
+                    Sentry.captureException(err, { tags: { action: 'customer-portal' } });
+                    setPortalError(true);
+                  } finally {
+                    setPortalLoading(false);
+                  }
+                }}
+              >
+                {portalLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Opening portal...
+                  </>
+                ) : (
+                  'Manage subscription'
+                )}
+              </Button>
+              {portalError && (
+                <p className="text-sm text-red-400 text-center">
+                  Could not open billing portal. Please try again or contact us via the <a href="/contact" className="underline">contact form</a>.
+                </p>
+              )}
+            </div>
           ) : (
             <Link href="/pricing">
               <Button variant="outline" size="sm" className="w-full">


### PR DESCRIPTION
## Summary
- Account page "Manage subscription" button silently swallowed errors when Stripe customer portal API failed -- users clicked and nothing happened
- Added loading state with spinner + disabled button during request
- Added error message with contact form link on failure
- Matches existing error handling pattern in `user-menu.tsx`

**Root cause context:** User reported they couldn't cancel or upgrade their subscription. Primary fix was enabling Stripe's billing portal in the dashboard (cancel + switch plans). This PR addresses the secondary issue: silent error handling that made debugging impossible from the user's perspective.

## Test plan
- [ ] Click "Manage subscription" on `/account` as a paid user -- should redirect to Stripe portal
- [ ] Simulate portal failure (e.g., disconnect network) -- should show error message with contact link
- [ ] Button shows loading spinner and is disabled during request
- [ ] Error clears on retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)