### PR TITLE
feat: email AB testing, activation sequence, and webhook tracking

### DIFF
--- a/app/api/email/opt-in/route.ts
+++ b/app/api/email/opt-in/route.ts
@@ -2,10 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { z } from 'zod';
 import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server';
-import { scheduleSequence, cancelAllPending } from '@/lib/email/sequences';
-import { SEQUENCES } from '@/lib/email/templates';
-import { getUnsubscribeUrl } from '@/lib/email/unsubscribe-token';
-import { sendEmail } from '@/lib/email/send';
+import { cancelAllPending } from '@/lib/email/sequences';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 
@@ -19,7 +16,7 @@ const OptInSchema = z.object({
  * POST /api/email/opt-in
  *
  * Toggles email_opt_in for the authenticated user.
- * On opt-in: schedules feature_education sequence, sends step 1 inline.
+ * On opt-in: sets the flag (sequences are scheduled by triggers, not here).
  * On opt-out: cancels all pending email sequences.
  */
 export async function POST(request: NextRequest) {
@@ -71,41 +68,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to update preference' }, { status: 500 });
     }
 
-    if (opt_in) {
-      // Schedule feature_education sequence
-      await scheduleSequence(supabase, user.id, 'feature_education');
-
-      // Send step 1 inline
-      const config = SEQUENCES.feature_education;
-      const unsubscribeUrl = getUnsubscribeUrl(user.id);
-      const template = config.getTemplate(1, unsubscribeUrl);
-
-      if (template) {
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('email')
-          .eq('id', user.id)
-          .single();
-
-        if (profile?.email) {
-          const sent = await sendEmail({
-            to: profile.email,
-            subject: template.subject,
-            html: template.html,
-            unsubscribeUrl,
-          });
-
-          if (sent) {
-            await supabase
-              .from('email_sequences')
-              .update({ status: 'sent', sent_at: new Date().toISOString() })
-              .eq('user_id', user.id)
-              .eq('sequence_name', 'feature_education')
-              .eq('step', 1);
-          }
-        }
-      }
-    } else {
+    if (!opt_in) {
       // Cancel all pending sequences
       await cancelAllPending(supabase, user.id);
     }

--- a/app/api/email/trigger/route.ts
+++ b/app/api/email/trigger/route.ts
@@ -7,20 +7,21 @@ import { SEQUENCES } from '@/lib/email/templates';
 import { getUnsubscribeUrl } from '@/lib/email/unsubscribe-token';
 import { sendEmail } from '@/lib/email/send';
 import { validateOrigin } from '@/lib/csrf';
+import { getABVariant, getVariantSubject } from '@/lib/email/ab';
 
 const TriggerSchema = z.object({
-  sequence: z.enum(['post_upload', 'feature_education']),
+  sequence: z.enum(['post_upload']),
 });
 
 /**
  * POST /api/email/trigger
  *
- * Schedules an email drip sequence for the authenticated user.
- * Step 1 is sent inline (immediately). Steps 2+ are scheduled in DB
- * for the hourly cron to pick up.
+ * Schedules email drip sequences for the authenticated user on first upload.
+ * - post_upload: sent immediately (step 1 inline, steps 2-3 via cron)
+ * - feature_education: scheduled to start 10 days after upload (after post_upload finishes)
+ * - cancels dormancy + activation sequences (user is now active)
  *
- * Also updates last_analysis_at for post_upload triggers and
- * cancels any dormancy sequence (user is active).
+ * Also updates last_analysis_at.
  */
 export async function POST(request: NextRequest) {
   if (!validateOrigin(request)) {
@@ -43,8 +44,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
   }
 
-  const { sequence } = parsed.data;
-
   const supabase = getSupabaseServiceRole();
   if (!supabase) {
     return NextResponse.json({ error: 'Service not configured' }, { status: 503 });
@@ -62,39 +61,52 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true, skipped: 'not_opted_in' });
     }
 
-    // For post_upload: update last_analysis_at and cancel dormancy
-    if (sequence === 'post_upload') {
-      await supabase
-        .from('profiles')
-        .update({ last_analysis_at: new Date().toISOString() })
-        .eq('id', user.id);
+    // Update last_analysis_at and cancel dormancy + activation (user is active)
+    await supabase
+      .from('profiles')
+      .update({ last_analysis_at: new Date().toISOString() })
+      .eq('id', user.id);
 
-      await cancelSequence(supabase, user.id, 'dormancy');
-    }
+    await cancelSequence(supabase, user.id, 'dormancy');
+    await cancelSequence(supabase, user.id, 'activation');
 
-    // Schedule the full sequence (idempotent)
-    await scheduleSequence(supabase, user.id, sequence);
+    // Compute AB variant for subject line test
+    const variant = getABVariant(user.id, 'post_upload_subject');
 
-    // Send step 1 inline (immediately)
-    const config = SEQUENCES[sequence];
+    // Schedule post_upload sequence (idempotent)
+    await scheduleSequence(supabase, user.id, 'post_upload', variant);
+
+    // Schedule feature_education to start after post_upload finishes (day 10)
+    await scheduleSequence(supabase, user.id, 'feature_education', variant);
+
+    // Send post_upload step 1 inline (immediately)
+    const config = SEQUENCES.post_upload;
     const unsubscribeUrl = getUnsubscribeUrl(user.id);
     const template = config.getTemplate(1, unsubscribeUrl);
 
     if (template) {
-      const sent = await sendEmail({
+      // Use variant subject if available
+      const variantSubject = getVariantSubject('post_upload', 1, variant);
+      const subject = variantSubject ?? template.subject;
+
+      const resendId = await sendEmail({
         to: profile.email,
-        subject: template.subject,
+        subject,
         html: template.html,
         unsubscribeUrl,
       });
 
-      if (sent) {
+      if (resendId) {
         // Mark step 1 as sent so cron doesn't re-send
         await supabase
           .from('email_sequences')
-          .update({ status: 'sent', sent_at: new Date().toISOString() })
+          .update({
+            status: 'sent',
+            sent_at: new Date().toISOString(),
+            resend_id: resendId,
+          })
           .eq('user_id', user.id)
-          .eq('sequence_name', sequence)
+          .eq('sequence_name', 'post_upload')
           .eq('step', 1);
       }
     }

--- a/app/api/webhooks/resend/route.ts
+++ b/app/api/webhooks/resend/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+import { z } from 'zod';
+import { getSupabaseServiceRole } from '@/lib/supabase/server';
+import { serverEnv } from '@/lib/env';
+import { cancelAllPending } from '@/lib/email/sequences';
+
+/**
+ * POST /api/webhooks/resend?secret=<RESEND_WEBHOOK_SECRET>
+ *
+ * Receives all events from Resend and updates email_sequences.
+ * Auth via secret query param (no svix dependency needed).
+ *
+ * Configure in Resend dashboard:
+ *   Webhook URL: https://airwaylab.app/api/webhooks/resend?secret=<RESEND_WEBHOOK_SECRET>
+ *   Events: all
+ *
+ * Events are matched to email_sequences rows via the resend_id column.
+ * First event wins (opened_at is set once, not updated on re-opens).
+ */
+
+const ResendEventSchema = z.object({
+  type: z.string(), // Accept any event type -- future-proof
+  created_at: z.string(),
+  data: z.object({
+    email_id: z.string(),
+  }).passthrough(),
+});
+
+// Map Resend event types to email_sequences timestamp columns
+const EVENT_COLUMN_MAP: Record<string, string> = {
+  'email.delivered': 'delivered_at',
+  'email.opened': 'opened_at',
+  'email.clicked': 'clicked_at',
+};
+
+// Events that require special handling beyond a timestamp update
+const SPECIAL_EVENTS = new Set(['email.bounced', 'email.complained']);
+
+export async function POST(request: NextRequest) {
+  // Validate secret
+  const secret = request.nextUrl.searchParams.get('secret');
+  const expectedSecret = serverEnv.RESEND_WEBHOOK_SECRET;
+
+  if (!expectedSecret) {
+    return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 });
+  }
+
+  if (!secret || secret !== expectedSecret) {
+    return NextResponse.json({ error: 'Invalid secret' }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = ResendEventSchema.safeParse(body);
+
+  if (!parsed.success) {
+    console.error('[resend-webhook] Invalid payload:', parsed.error.message);
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const { type, data } = parsed.data;
+
+  const supabase = getSupabaseServiceRole();
+  if (!supabase) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 503 });
+  }
+
+  try {
+    // Handle bounce/complaint: cancel pending emails for the user
+    if (SPECIAL_EVENTS.has(type)) {
+      // Look up user_id from the resend_id
+      const { data: row } = await supabase
+        .from('email_sequences')
+        .select('user_id')
+        .eq('resend_id', data.email_id)
+        .limit(1)
+        .single();
+
+      if (row?.user_id) {
+        await cancelAllPending(supabase, row.user_id);
+
+        if (type === 'email.complained') {
+          // Spam complaint: opt user out entirely
+          await supabase
+            .from('profiles')
+            .update({ email_opt_in: false })
+            .eq('id', row.user_id);
+        }
+
+        console.error(`[resend-webhook] ${type} for user ${row.user_id}, cancelled pending emails`);
+        Sentry.captureMessage(`Email ${type}: ${data.email_id}`, {
+          level: 'warning',
+          tags: { route: 'resend-webhook', event_type: type },
+          extra: { userId: row.user_id },
+        });
+      }
+
+      return NextResponse.json({ received: true, tracked: true });
+    }
+
+    // Handle timestamp events (delivered, opened, clicked)
+    const column = EVENT_COLUMN_MAP[type];
+    if (!column) {
+      return NextResponse.json({ received: true, tracked: false });
+    }
+
+    // Update the row, but only if the column is still null (first event wins)
+    const { error } = await supabase
+      .from('email_sequences')
+      .update({ [column]: new Date().toISOString() })
+      .eq('resend_id', data.email_id)
+      .is(column, null);
+
+    if (error) {
+      console.error(`[resend-webhook] Failed to update ${column} for ${data.email_id}:`, error.message);
+      Sentry.captureException(error, {
+        tags: { route: 'resend-webhook', event_type: type },
+      });
+      return NextResponse.json({ error: 'Update failed' }, { status: 500 });
+    }
+
+    return NextResponse.json({ received: true, tracked: true });
+  } catch (err) {
+    console.error('[resend-webhook] Error:', err);
+    Sentry.captureException(err, { tags: { route: 'resend-webhook' } });
+    return NextResponse.json({ error: 'Handler error' }, { status: 500 });
+  }
+}

--- a/components/common/email-opt-in-toggle.tsx
+++ b/components/common/email-opt-in-toggle.tsx
@@ -8,8 +8,8 @@ import { events } from '@/lib/analytics';
 
 /**
  * Email opt-in toggle for authenticated users.
- * Sets email_opt_in on the user's profile and triggers feature_education
- * drip sequence on first opt-in.
+ * Sets email_opt_in on the user's profile. Email sequences are triggered
+ * by user actions (upload, signup), not by the opt-in toggle itself.
  */
 export function EmailOptInToggle() {
   const { user, profile, refreshProfile } = useAuth();

--- a/lib/email/ab.ts
+++ b/lib/email/ab.ts
@@ -1,0 +1,88 @@
+/**
+ * A/B testing utilities for email sequences.
+ *
+ * Variant assignment is deterministic: hash(userId + testName) -> A | B.
+ * No DB storage needed for assignment -- the variant is computed on-demand
+ * and recorded alongside each sent email for analysis.
+ *
+ * To add a new test:
+ * 1. Add an entry to ACTIVE_TESTS with clear hypothesis and variants
+ * 2. If testing subjects, add entries to SUBJECT_VARIANTS
+ * 3. If testing timing, add logic in the relevant scheduling function
+ */
+
+import { createHash } from 'crypto';
+import type { SequenceName } from './templates';
+
+export type ABVariant = 'A' | 'B';
+
+/**
+ * Deterministic variant assignment.
+ * Same userId + testName always returns the same variant.
+ * Different testNames give independent splits.
+ */
+export function getABVariant(userId: string, testName: string): ABVariant {
+  const hash = createHash('sha256').update(`${userId}:${testName}`).digest();
+  return hash[0] % 2 === 0 ? 'A' : 'B';
+}
+
+// ── Active tests ────────────────────────────────────────────
+
+/**
+ * Registry of active A/B tests.
+ * When a test concludes, move it to CONCLUDED_TESTS with the winner.
+ */
+export const ACTIVE_TESTS = {
+  /** Dormancy re-engagement: trigger after 3 days (A) vs 7 days (B) of inactivity */
+  dormancy_timing: {
+    testName: 'dormancy_timing',
+    hypothesis: 'Shorter dormancy window (3 days) catches users before they churn',
+    variants: { A: '3 days', B: '7 days' },
+    dormancyDays: { A: 3, B: 7 } as Record<ABVariant, number>,
+  },
+  /** Post-upload step 1: instructional (A) vs curiosity/specificity (B) */
+  post_upload_subject: {
+    testName: 'post_upload_subject',
+    hypothesis: 'Curiosity + specificity drives higher opens than instructional framing',
+    variants: { A: 'Instructional (saved, what to do next)', B: 'Curiosity (4 engines decoded)' },
+  },
+} as const;
+
+// ── Subject line variants ───────────────────────────────────
+
+type SubjectVariants = Partial<
+  Record<SequenceName, Partial<Record<number, Record<ABVariant, string>>>>
+>;
+
+/**
+ * Subject line overrides per sequence/step/variant.
+ * If a sequence+step has an entry here, the variant subject is used
+ * instead of the template default.
+ *
+ * Only entries where A !== B are active (tested in getVariantSubject).
+ */
+export const SUBJECT_VARIANTS: SubjectVariants = {
+  post_upload: {
+    1: {
+      A: "Your first analysis is saved -- here's what to do next",
+      B: '4 engines just decoded your breathing data',
+    },
+  },
+};
+
+/**
+ * Get the subject line for a given sequence/step/variant.
+ * Returns the variant-specific subject if configured, otherwise null
+ * (caller should fall back to the template default).
+ */
+export function getVariantSubject(
+  sequenceName: SequenceName,
+  step: number,
+  variant: ABVariant
+): string | null {
+  const stepVariants = SUBJECT_VARIANTS[sequenceName]?.[step];
+  if (!stepVariants) return null;
+  // Only use variant subject if B is actually different from A (test is active)
+  if (stepVariants.A === stepVariants.B) return null;
+  return stepVariants[variant] ?? null;
+}

--- a/lib/email/cron-handler.ts
+++ b/lib/email/cron-handler.ts
@@ -3,27 +3,44 @@
  *
  * Processes pending email sequences:
  * 1. Queries for due emails (scheduled_at <= now, status = pending)
- * 2. Sends each via Resend
- * 3. Updates status to 'sent'
+ * 2. Sends each via Resend (with AB variant subjects where applicable)
+ * 3. Updates status to 'sent' with Resend message ID
  * 4. Checks for newly dormant users and schedules dormancy sequences
+ * 5. Checks for users who signed up but never uploaded (activation)
+ * 6. Applies sunset policy for unengaged users
  *
  * Returns a summary for logging.
  */
 
 import { SupabaseClient } from '@supabase/supabase-js';
-import { getPendingEmails, markSent, scheduleDormancySequences } from './sequences';
+import {
+  getPendingEmails,
+  markSent,
+  scheduleDormancySequences,
+  scheduleActivationSequences,
+  applySunsetPolicy,
+} from './sequences';
 import { SEQUENCES } from './templates';
 import { getUnsubscribeUrl } from './unsubscribe-token';
 import { sendEmail } from './send';
+import { getABVariant, getVariantSubject, type ABVariant } from './ab';
 
 interface CronResult {
   sent: number;
   failed: number;
   dormancyScheduled: number;
+  activationScheduled: number;
+  sunsetted: number;
 }
 
 export async function processEmailDrips(supabase: SupabaseClient): Promise<CronResult> {
-  const result: CronResult = { sent: 0, failed: 0, dormancyScheduled: 0 };
+  const result: CronResult = {
+    sent: 0,
+    failed: 0,
+    dormancyScheduled: 0,
+    activationScheduled: 0,
+    sunsetted: 0,
+  };
 
   // 1. Send pending emails
   const pendingEmails = await getPendingEmails(supabase);
@@ -36,15 +53,21 @@ export async function processEmailDrips(supabase: SupabaseClient): Promise<CronR
     const template = config.getTemplate(email.step, unsubscribeUrl);
     if (!template) continue;
 
-    const success = await sendEmail({
+    // Use variant subject if this email has an AB variant and a subject override exists
+    const variant = (email.ab_variant as ABVariant | null)
+      ?? getABVariant(email.user_id, 'post_upload_subject');
+    const variantSubject = getVariantSubject(email.sequence_name, email.step, variant);
+    const subject = variantSubject ?? template.subject;
+
+    const resendId = await sendEmail({
       to: email.email,
-      subject: template.subject,
+      subject,
       html: template.html,
       unsubscribeUrl,
     });
 
-    if (success) {
-      await markSent(supabase, email.id);
+    if (resendId) {
+      await markSent(supabase, email.id, resendId);
       result.sent++;
     } else {
       result.failed++;
@@ -53,6 +76,12 @@ export async function processEmailDrips(supabase: SupabaseClient): Promise<CronR
 
   // 2. Check for dormant users and schedule re-engagement
   result.dormancyScheduled = await scheduleDormancySequences(supabase);
+
+  // 3. Check for users who signed up but never uploaded
+  result.activationScheduled = await scheduleActivationSequences(supabase);
+
+  // 4. Apply sunset policy for persistently unengaged users
+  result.sunsetted = await applySunsetPolicy(supabase);
 
   return result;
 }

--- a/lib/email/send.ts
+++ b/lib/email/send.ts
@@ -16,13 +16,14 @@ interface SendEmailParams {
 
 /**
  * Send a single email via Resend API.
- * Returns true on success, false on failure (logged, not thrown).
+ * Returns the Resend message ID on success, null on failure (logged, not thrown).
+ * The message ID is used to correlate webhook events (opens, clicks, delivery).
  */
-export async function sendEmail({ to, subject, html, unsubscribeUrl }: SendEmailParams): Promise<boolean> {
+export async function sendEmail({ to, subject, html, unsubscribeUrl }: SendEmailParams): Promise<string | null> {
   const apiKey = serverEnv.RESEND_API_KEY;
   if (!apiKey) {
     console.error('[email-send] RESEND_API_KEY not configured');
-    return false;
+    return null;
   }
 
   try {
@@ -50,12 +51,13 @@ export async function sendEmail({ to, subject, html, unsubscribeUrl }: SendEmail
     if (!res.ok) {
       const body = await res.text();
       console.error(`[email-send] Resend API error ${res.status}: ${body}`);
-      return false;
+      return null;
     }
 
-    return true;
+    const data = await res.json() as { id?: string };
+    return data.id ?? null;
   } catch (err) {
     console.error('[email-send] Failed to send email:', err);
-    return false;
+    return null;
   }
 }

--- a/lib/email/sequences.ts
+++ b/lib/email/sequences.ts
@@ -2,24 +2,28 @@
  * Email sequence management — scheduling, cancellation, and queries.
  *
  * Used by:
- * - Analysis page (trigger post-upload sequence)
- * - Auth callback (trigger feature-education sequence)
- * - Cron job (query pending emails, send, update status)
+ * - Analysis page (trigger post-upload + feature-education sequence)
+ * - Auth callback (opt-in toggle)
+ * - Cron job (query pending emails, send, schedule dormancy/activation, sunset)
  * - Unsubscribe route (cancel all pending)
  */
 
 import { SupabaseClient } from '@supabase/supabase-js';
 import { SEQUENCES, type SequenceName } from './templates';
+import { type ABVariant } from './ab';
 
 /**
  * Schedule a full email sequence for a user.
  * Creates one row per step with the appropriate scheduled_at time.
  * Skips if the user already has this sequence (idempotent).
+ *
+ * @param variant - A/B variant for this user's sequence (stored for analysis)
  */
 export async function scheduleSequence(
   supabase: SupabaseClient,
   userId: string,
-  sequenceName: SequenceName
+  sequenceName: SequenceName,
+  variant?: ABVariant
 ): Promise<void> {
   const config = SEQUENCES[sequenceName];
   if (!config) return;
@@ -31,6 +35,7 @@ export async function scheduleSequence(
     step: index + 1,
     status: 'pending' as const,
     scheduled_at: new Date(now.getTime() + delayDays * 24 * 60 * 60 * 1000).toISOString(),
+    ...(variant && { ab_variant: variant }),
   }));
 
   // upsert to make this idempotent — if sequence already exists, skip
@@ -93,6 +98,7 @@ export async function getPendingEmails(
   sequence_name: SequenceName;
   step: number;
   email: string;
+  ab_variant: string | null;
 }>> {
   const { data, error } = await supabase
     .from('email_sequences')
@@ -101,6 +107,7 @@ export async function getPendingEmails(
       user_id,
       sequence_name,
       step,
+      ab_variant,
       profiles!inner(email, email_opt_in)
     `)
     .eq('status', 'pending')
@@ -128,20 +135,26 @@ export async function getPendingEmails(
         sequence_name: row.sequence_name as SequenceName,
         step: row.step,
         email: profile.email,
+        ab_variant: (row as Record<string, unknown>).ab_variant as string | null,
       };
     });
 }
 
 /**
- * Mark an email as sent.
+ * Mark an email as sent and store the Resend message ID for webhook correlation.
  */
 export async function markSent(
   supabase: SupabaseClient,
-  emailId: string
+  emailId: string,
+  resendId?: string
 ): Promise<void> {
   const { error } = await supabase
     .from('email_sequences')
-    .update({ status: 'sent', sent_at: new Date().toISOString() })
+    .update({
+      status: 'sent',
+      sent_at: new Date().toISOString(),
+      ...(resendId && { resend_id: resendId }),
+    })
     .eq('id', emailId);
 
   if (error) {
@@ -151,15 +164,23 @@ export async function markSent(
 
 /**
  * Check for dormant users and schedule re-engagement sequences.
- * Called by the cron job. A user is dormant if:
- * - last_analysis_at is > 14 days ago
- * - email_opt_in is true
- * - they don't already have a dormancy sequence
+ * Called by the cron job.
+ *
+ * A/B test (dormancy_timing): variant A triggers at 3 days, variant B at 7 days.
+ * Each user's variant is computed deterministically from their ID.
+ *
+ * The query uses the shorter threshold (3 days) to find all candidates,
+ * then filters per-user based on their variant's threshold.
  */
 export async function scheduleDormancySequences(
   supabase: SupabaseClient
 ): Promise<number> {
-  const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+  const { getABVariant, ACTIVE_TESTS } = await import('./ab');
+  const thresholds = ACTIVE_TESTS.dormancy_timing.dormancyDays;
+
+  // Use the shortest threshold to find all potential candidates
+  const minDays = Math.min(thresholds.A, thresholds.B);
+  const cutoff = new Date(Date.now() - minDays * 24 * 60 * 60 * 1000).toISOString();
 
   // Find users who already have a dormancy sequence (to exclude them)
   const { data: existingDormancy } = await supabase
@@ -169,29 +190,140 @@ export async function scheduleDormancySequences(
 
   const excludeIds = existingDormancy?.map((r) => r.user_id) ?? [];
 
-  // Find users who are dormant, opted in, and don't have a dormancy sequence
+  // Find users who are potentially dormant, opted in, and don't have a dormancy sequence
   let query = supabase
     .from('profiles')
-    .select('id')
+    .select('id, last_analysis_at')
     .eq('email_opt_in', true)
-    .lt('last_analysis_at', fourteenDaysAgo);
+    .lt('last_analysis_at', cutoff);
 
   if (excludeIds.length > 0) {
     query = query.not('id', 'in', `(${excludeIds.join(',')})`);
   }
 
-  const { data: dormantUsers, error } = await query;
+  const { data: candidates, error } = await query;
 
-  if (error || !dormantUsers) {
+  if (error || !candidates) {
     console.error('[email-sequences] Failed to find dormant users:', error?.message);
     return 0;
   }
 
   let scheduled = 0;
-  for (const user of dormantUsers) {
-    await scheduleSequence(supabase, user.id, 'dormancy');
+  const now = Date.now();
+
+  for (const user of candidates) {
+    const variant = getABVariant(user.id, 'dormancy_timing');
+    const requiredDays = thresholds[variant];
+    const requiredCutoff = now - requiredDays * 24 * 60 * 60 * 1000;
+    const lastAnalysis = new Date(user.last_analysis_at).getTime();
+
+    // Only schedule if this user has been inactive long enough for their variant
+    if (lastAnalysis <= requiredCutoff) {
+      await scheduleSequence(supabase, user.id, 'dormancy', variant);
+      scheduled++;
+    }
+  }
+
+  return scheduled;
+}
+
+/**
+ * Check for users who signed up but never uploaded, and schedule activation emails.
+ * Called by the cron job.
+ *
+ * Triggers 48h after account creation if last_analysis_at is null.
+ */
+export async function scheduleActivationSequences(
+  supabase: SupabaseClient
+): Promise<number> {
+  const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+
+  // Find users who already have an activation sequence
+  const { data: existingActivation } = await supabase
+    .from('email_sequences')
+    .select('user_id')
+    .eq('sequence_name', 'activation');
+
+  const excludeIds = existingActivation?.map((r) => r.user_id) ?? [];
+
+  // Find users created 48h+ ago, opted in, never uploaded, no activation sequence
+  let query = supabase
+    .from('profiles')
+    .select('id')
+    .eq('email_opt_in', true)
+    .is('last_analysis_at', null)
+    .lt('created_at', twoDaysAgo);
+
+  if (excludeIds.length > 0) {
+    query = query.not('id', 'in', `(${excludeIds.join(',')})`);
+  }
+
+  const { data: inactiveUsers, error } = await query;
+
+  if (error || !inactiveUsers) {
+    console.error('[email-sequences] Failed to find inactive users:', error?.message);
+    return 0;
+  }
+
+  let scheduled = 0;
+  for (const user of inactiveUsers) {
+    await scheduleSequence(supabase, user.id, 'activation');
     scheduled++;
   }
 
   return scheduled;
+}
+
+/**
+ * Sunset policy: opt out users who haven't engaged with 3+ consecutive emails.
+ * Called by the cron job. Requires webhook tracking data (opened_at, clicked_at).
+ *
+ * A user is sunsetted if they have >= 3 sent emails where:
+ * - delivered_at is not null (email arrived)
+ * - opened_at is null AND clicked_at is null (no engagement)
+ *
+ * Sunsetted users get email_opt_in = false and all pending emails cancelled.
+ */
+export async function applySunsetPolicy(
+  supabase: SupabaseClient
+): Promise<number> {
+  // Find users with 3+ delivered-but-unengaged emails
+  const { data: candidates, error } = await supabase
+    .from('email_sequences')
+    .select('user_id')
+    .eq('status', 'sent')
+    .not('delivered_at', 'is', null)
+    .is('opened_at', null)
+    .is('clicked_at', null);
+
+  if (error || !candidates) {
+    console.error('[email-sequences] Sunset policy query failed:', error?.message);
+    return 0;
+  }
+
+  // Count unengaged emails per user
+  const countByUser = new Map<string, number>();
+  for (const row of candidates) {
+    countByUser.set(row.user_id, (countByUser.get(row.user_id) ?? 0) + 1);
+  }
+
+  let sunsetted = 0;
+  for (const [userId, count] of countByUser) {
+    if (count >= 3) {
+      // Opt out and cancel pending
+      await supabase
+        .from('profiles')
+        .update({ email_opt_in: false })
+        .eq('id', userId);
+
+      await cancelAllPending(supabase, userId);
+      sunsetted++;
+    }
+  }
+
+  if (sunsetted > 0) {
+    console.error(`[email-sequences] Sunset policy: opted out ${sunsetted} users with ${sunsetted} unengaged emails`);
+  }
+
+  return sunsetted;
 }

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -77,17 +77,12 @@ function bulletList(items: string[]): string {
 
 export function postUploadStep1(unsubscribeUrl: string): { subject: string; html: string } {
   return {
-    subject: 'Your first analysis is saved -- here\'s what to do next',
+    subject: "Your first analysis is saved -- here's what to do next",
     html: layout(`
-      ${heading('Your analysis is saved')}
-      ${paragraph('Your ResMed SD card data has been analysed by four research-grade engines. Here\'s what you can do next:')}
-      ${bulletList([
-        '<strong style="color:#fff;">Upload more nights</strong> -- trend tracking shows how your therapy changes over time. One night is a snapshot; seven nights is a picture.',
-        '<strong style="color:#fff;">Try AI insights</strong> -- get a plain-language explanation of what your metrics mean for your therapy. Free users get 3 per month.',
-        '<strong style="color:#fff;">Export your report</strong> -- download a PDF or CSV to bring to your next sleep clinic visit.',
-      ])}
+      ${heading('Your breathing data has been analysed')}
+      ${paragraph('Four research-grade engines just scored your flow limitation, breathing regularity, and airway resistance. Your results are saved in your browser -- no one sees them but you.')}
+      ${paragraph('One night is a snapshot. Upload a few more nights and you\'ll start to see how your therapy is actually trending -- whether pressure changes helped, which nights are worse, and what your clinician should know.')}
       ${ctaButton('Upload Your Next Night', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=post_upload_1`)}
-      ${paragraph('Your data stays in your browser unless you choose to share it. No one sees your results but you.')}
     `, unsubscribeUrl),
   };
 }
@@ -105,7 +100,7 @@ export function postUploadStep2(unsubscribeUrl: string): { subject: string; html
         'First-half vs second-half differences (H1/H2 split)',
         'The overall direction of your therapy',
       ])}
-      ${ctaButton('See Your Trends', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=post_upload_2`)}
+      ${ctaButton('Upload Your Next Night', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=post_upload_2`)}
     `, unsubscribeUrl),
   };
 }
@@ -127,34 +122,30 @@ export function postUploadStep3(unsubscribeUrl: string): { subject: string; html
 
 export function dormancyStep1(unsubscribeUrl: string): { subject: string; html: string } {
   return {
-    subject: 'Your PAP data is waiting -- new features since your last visit',
+    subject: 'Your therapy data is still here',
     html: layout(`
-      ${heading('We\'ve been busy')}
-      ${paragraph('It\'s been a couple of weeks since your last analysis. Here\'s what\'s new in AirwayLab:')}
+      ${heading('Ready when you are')}
+      ${paragraph('Your previous analysis results are saved. When you upload new SD card data, AirwayLab compares it against your earlier nights so you can see what\'s changed.')}
+      ${paragraph('Even one new night gives you:')}
       ${bulletList([
-        '<strong style="color:#fff;">Improved AI insights</strong> -- deeper, more specific therapy recommendations powered by your flow data',
-        '<strong style="color:#fff;">Community benchmarks</strong> -- see how your metrics compare to other PAP users (anonymised, opt-in only)',
-        '<strong style="color:#fff;">Better trend views</strong> -- clearer visualisations of how your therapy is evolving',
+        'A before-and-after comparison of your flow limitation scores',
+        'Whether your breathing patterns are improving or drifting',
+        'Updated trend data to bring to your next clinic visit',
       ])}
-      ${paragraph('Your previous results are still saved in your browser. Upload new data to see how things have changed.')}
-      ${ctaButton('Analyse New Data', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=dormancy_1`)}
+      ${ctaButton('Upload This Month\'s Data', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=dormancy_1`)}
     `, unsubscribeUrl),
   };
 }
 
 export function dormancyStep2(unsubscribeUrl: string): { subject: string; html: string } {
   return {
-    subject: 'Still tracking your therapy? Your previous results are saved',
+    subject: 'Last check-in: are you still tracking your therapy?',
     html: layout(`
-      ${heading('Pick up where you left off')}
-      ${paragraph('Your previous analysis results are still stored in your browser. Upload this month\'s SD card data to compare:')}
-      ${bulletList([
-        'Has your Glasgow Index improved or worsened?',
-        'Is your flow limitation percentage trending in the right direction?',
-        'Are RERAs more or less frequent than last time?',
-      ])}
-      ${paragraph('Even a single new night gives you a comparison point. Your clinician will appreciate the longitudinal data.')}
-      ${ctaButton('Compare Your Progress', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=dormancy_2`)}
+      ${heading('No pressure -- just checking in')}
+      ${paragraph('We send occasional emails to help you get the most out of AirwayLab. If you\'re no longer tracking your PAP therapy, no worries -- this is the last email we\'ll send unless you upload new data.')}
+      ${paragraph('If you are still on therapy, your previous results are waiting. Upload your latest SD card data and see how your metrics compare.')}
+      ${ctaButton('Upload New Data', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=dormancy_2`)}
+      ${paragraph('If you\'d rather not hear from us, <a href="${unsubscribeUrl}" style="color:#5eead4;text-decoration:underline;">unsubscribe here</a>. One click, no questions.')}
     `, unsubscribeUrl),
   };
 }
@@ -163,7 +154,7 @@ export function dormancyStep2(unsubscribeUrl: string): { subject: string; html: 
 
 export function featureEducationStep1(unsubscribeUrl: string): { subject: string; html: string } {
   return {
-    subject: 'Did you know? AI insights explain what your numbers mean',
+    subject: 'Your metrics, explained in plain language',
     html: layout(`
       ${heading('Numbers are useful. Explanations are better.')}
       ${paragraph('AirwayLab\'s four engines give you detailed metrics -- Glasgow Index, FL Score, NED, RERA counts. But what do they mean for <em>your</em> therapy?')}
@@ -197,9 +188,42 @@ export function featureEducationStep2(unsubscribeUrl: string): { subject: string
   };
 }
 
+// ── Sequence 4: Activation (signed up, never uploaded) ───────
+
+export function activationStep1(unsubscribeUrl: string): { subject: string; html: string } {
+  return {
+    subject: 'Need help uploading your SD card data?',
+    html: layout(`
+      ${heading('Getting started takes 60 seconds')}
+      ${paragraph('You created an AirwayLab account but haven\'t uploaded any data yet. Here\'s what you need:')}
+      ${bulletList([
+        '<strong style="color:#fff;">A ResMed SD card</strong> -- remove it from your CPAP/BiPAP machine (AirSense 10, AirSense 11, AirCurve, or similar)',
+        '<strong style="color:#fff;">An SD card reader</strong> -- plug it into your computer',
+        '<strong style="color:#fff;">Select the DATALOG folder</strong> -- AirwayLab will find and parse all the EDF files automatically',
+      ])}
+      ${paragraph('Everything runs in your browser. Your data never leaves your device unless you choose to share it.')}
+      ${ctaButton('Upload Your SD Card', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=activation_1`)}
+      ${paragraph('Having trouble? Reply to this email and we\'ll help you get started.')}
+    `, unsubscribeUrl),
+  };
+}
+
+export function activationStep2(unsubscribeUrl: string): { subject: string; html: string } {
+  return {
+    subject: 'Your CPAP data has insights waiting to be found',
+    html: layout(`
+      ${heading('What one upload reveals')}
+      ${paragraph('AirwayLab users who upload a week of SD card data typically discover patterns their AHI never showed -- subtle flow limitation, periodic breathing, and arousal patterns that explain why they still feel tired despite "normal" numbers.')}
+      ${paragraph('Your machine has been recording detailed flow waveforms every night. AirwayLab\'s four engines analyse those waveforms at the breath level -- something OSCAR and your machine\'s built-in reports can\'t do.')}
+      ${ctaButton('Start Your First Analysis', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=activation_2`)}
+      ${paragraph('This is the last activation email we\'ll send. If you\'re not ready yet, your account will be here when you are.')}
+    `, unsubscribeUrl),
+  };
+}
+
 // ── Template registry ────────────────────────────────────────
 
-export type SequenceName = 'post_upload' | 'dormancy' | 'feature_education';
+export type SequenceName = 'post_upload' | 'dormancy' | 'feature_education' | 'activation';
 
 interface SequenceConfig {
   totalSteps: number;
@@ -221,7 +245,7 @@ export const SEQUENCES: Record<SequenceName, SequenceConfig> = {
   },
   dormancy: {
     totalSteps: 2,
-    delays: [0, 16], // 14 days dormant + 0 = 14 days, + 16 = 30 days
+    delays: [0, 7], // step 1 at trigger (3d or 7d via AB test), step 2 at t+7
     getTemplate: (step, url) => {
       if (step === 1) return dormancyStep1(url);
       if (step === 2) return dormancyStep2(url);
@@ -230,10 +254,19 @@ export const SEQUENCES: Record<SequenceName, SequenceConfig> = {
   },
   feature_education: {
     totalSteps: 2,
-    delays: [0, 7], // step 1 sent inline at trigger, step 2 via cron
+    delays: [10, 17], // starts 10 days after first upload (after post_upload finishes)
     getTemplate: (step, url) => {
       if (step === 1) return featureEducationStep1(url);
       if (step === 2) return featureEducationStep2(url);
+      return null;
+    },
+  },
+  activation: {
+    totalSteps: 2,
+    delays: [0, 3], // step 1 at trigger (48h after signup), step 2 at t+3
+    getTemplate: (step, url) => {
+      if (step === 1) return activationStep1(url);
+      if (step === 2) return activationStep2(url);
       return null;
     },
   },

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -49,6 +49,9 @@ export const serverEnv = {
   /** Resend API key for transactional email */
   RESEND_API_KEY: process.env.RESEND_API_KEY ?? undefined,
 
+  /** Resend webhook secret (used as query param for webhook auth) */
+  RESEND_WEBHOOK_SECRET: process.env.RESEND_WEBHOOK_SECRET ?? undefined,
+
   /** Secret for authenticating Vercel Cron requests */
   CRON_SECRET: process.env.CRON_SECRET ?? undefined,
 

--- a/supabase/migrations/032_email_ab_testing.sql
+++ b/supabase/migrations/032_email_ab_testing.sql
@@ -1,0 +1,19 @@
+-- A/B testing columns for email sequences.
+-- Tracks which variant was sent and Resend delivery/engagement events.
+
+ALTER TABLE email_sequences ADD COLUMN ab_variant TEXT;
+ALTER TABLE email_sequences ADD COLUMN resend_id TEXT;
+ALTER TABLE email_sequences ADD COLUMN delivered_at TIMESTAMPTZ;
+ALTER TABLE email_sequences ADD COLUMN opened_at TIMESTAMPTZ;
+ALTER TABLE email_sequences ADD COLUMN clicked_at TIMESTAMPTZ;
+
+-- Fast lookup for webhook event matching
+CREATE INDEX idx_email_sequences_resend_id
+  ON email_sequences (resend_id)
+  WHERE resend_id IS NOT NULL;
+
+-- Composite index for A/B analysis queries
+-- e.g. SELECT ab_variant, COUNT(*), AVG(opened_at IS NOT NULL) FROM email_sequences WHERE sequence_name = 'dormancy' GROUP BY ab_variant
+CREATE INDEX idx_email_sequences_ab_analysis
+  ON email_sequences (sequence_name, ab_variant)
+  WHERE ab_variant IS NOT NULL;


### PR DESCRIPTION
## Summary

- **AB test 1**: Dormancy timing -- 3 days (A) vs 7 days (B) inactivity trigger, replacing fixed 14-day threshold
- **AB test 2**: Post-upload step 1 subject line -- instructional ("saved, here's what to do next") vs curiosity ("4 engines just decoded your breathing data")
- **New activation sequence**: 2 emails for users who sign up but never upload (48h cron trigger)
- **Resend webhook handler**: Tracks delivery, opens, clicks, bounces, complaints per email
- **Sunset policy**: Auto opts out users with 3+ delivered-but-unengaged emails
- **Email rewrites**: Dormancy emails now evergreen (no stale feature lists), step 2 has transparent last-chance framing, post_upload step 1 has single CTA, step 2 CTA fixed
- **Retimed feature_education**: Now triggers 10 days after first upload (was at opt-in, before user had data)
- **Simplified opt-in route**: Just toggles the flag; sequences trigger on user actions

## Pre-merge checklist

- [ ] Run migration `032_email_ab_testing.sql` on Supabase
- [ ] `RESEND_WEBHOOK_SECRET` env var set in Vercel (done)
- [ ] Resend webhook configured to send all events to `https://airwaylab.app/api/webhooks/resend?secret=<secret>` (done)
- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian

## Test plan

- [ ] Trigger post_upload via upload -- verify step 1 email arrives with correct subject (check variant in DB)
- [ ] Verify feature_education is scheduled for day 10 (check email_sequences table)
- [ ] Verify activation cron picks up users with no upload after 48h
- [ ] Send test webhook event to `/api/webhooks/resend?secret=<secret>` -- verify opened_at updates
- [ ] Verify sunset policy doesn't trigger yet (no webhook data flowing)
- [ ] AB analysis query returns results: `SELECT ab_variant, COUNT(*) FROM email_sequences WHERE ab_variant IS NOT NULL GROUP BY ab_variant`

🤖 Generated with [Claude Code](https://claude.com/claude-code)