### PR TITLE
fix: enable Sentry structured logging and clean stale files

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -11,4 +11,7 @@ Sentry.init({
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
+
+  // Enable Sentry structured logging (Sentry.logger.info/warn/etc.)
+  _experiments: { enableLogs: true },
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -12,6 +12,9 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 
+  // Enable Sentry structured logging (Sentry.logger.info/warn/etc.)
+  _experiments: { enableLogs: true },
+
   beforeSend(event) {
     // Supabase storage rejects internally for duplicate uploads before our code handles it.
     // The contribute-waveforms endpoint treats duplicates as idempotent success (upsert: false by design).


### PR DESCRIPTION
## Summary

- Enable `_experiments: { enableLogs: true }` in `sentry.server.config.ts` and `sentry.edge.config.ts` so `Sentry.logger.*` calls from Phase 2 (#245) actually appear in the Sentry Logs tab
- Deleted stale untracked files from disk: `HANDOFF-tier2-remaining.md`, `.prettierrc`, macOS duplicates

## Test plan

- [x] `npm run check` — all passing (86 files, 1313 tests)
- [ ] Verify Sentry Logs tab shows structured logs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)