### PR TITLE
fix: tiered rate limits and 429 backoff for power users

### DIFF
--- a/__tests__/ai-insights-error-handling.test.ts
+++ b/__tests__/ai-insights-error-handling.test.ts
@@ -20,7 +20,9 @@ vi.mock('@/lib/csrf', () => ({
 const mockIsLimited = vi.fn(() => false);
 vi.mock('@/lib/rate-limit', () => ({
   aiRateLimiter: { isLimited: (...args: Parameters<typeof mockIsLimited>) => mockIsLimited(...args) },
+  aiPremiumRateLimiter: { isLimited: (...args: Parameters<typeof mockIsLimited>) => mockIsLimited(...args) },
   getRateLimitKey: vi.fn(() => '127.0.0.1'),
+  getUserRateLimitKey: vi.fn((id: string) => `user:${id}`),
 }));
 
 const mockCaptureException = vi.fn();

--- a/__tests__/api-routes.test.ts
+++ b/__tests__/api-routes.test.ts
@@ -16,7 +16,9 @@ vi.mock('@/lib/rate-limit', () => {
   return {
     stripeRateLimiter: mockLimiter,
     aiRateLimiter: mockLimiter,
+    aiPremiumRateLimiter: mockLimiter,
     getRateLimitKey: vi.fn(() => '127.0.0.1'),
+    getUserRateLimitKey: vi.fn((id: string) => `user:${id}`),
     RateLimiter: class {
       isLimited(...args: Parameters<typeof mockIsLimited>) { return mockIsLimited(...args); }
     },

--- a/__tests__/files-api-routes.test.ts
+++ b/__tests__/files-api-routes.test.ts
@@ -16,7 +16,9 @@ vi.mock('@/lib/rate-limit', () => {
   return {
     stripeRateLimiter: mockLimiter,
     aiRateLimiter: mockLimiter,
+    aiPremiumRateLimiter: mockLimiter,
     getRateLimitKey: vi.fn(() => '127.0.0.1'),
+    getUserRateLimitKey: vi.fn((id: string) => `user:${id}`),
     RateLimiter: class {
       isLimited(...args: Parameters<typeof mockIsLimited>) { return mockIsLimited(...args); }
     },
@@ -208,7 +210,8 @@ describe('POST /api/files/presign', () => {
   });
 
   it('returns 429 when rate limited', async () => {
-    mockValidateOrigin.mockReturnValue(true);
+    // Rate limit check happens after auth, so we need an authenticated user
+    setupAuthenticatedUser();
     mockIsLimited.mockReturnValue(true);
     const res = await callPresign(makePostRequest('/api/files/presign', validBody));
     expect(res.status).toBe(429);

--- a/__tests__/premium-ai-quality.test.ts
+++ b/__tests__/premium-ai-quality.test.ts
@@ -10,7 +10,9 @@ vi.mock('@/lib/csrf', () => ({
 const mockIsLimited = vi.fn(() => false);
 vi.mock('@/lib/rate-limit', () => ({
   aiRateLimiter: { isLimited: (...args: Parameters<typeof mockIsLimited>) => mockIsLimited(...args) },
+  aiPremiumRateLimiter: { isLimited: (...args: Parameters<typeof mockIsLimited>) => mockIsLimited(...args) },
   getRateLimitKey: vi.fn(() => '127.0.0.1'),
+  getUserRateLimitKey: vi.fn((id: string) => `user:${id}`),
 }));
 
 vi.mock('@sentry/nextjs', () => ({

--- a/__tests__/waveform-api-route.test.ts
+++ b/__tests__/waveform-api-route.test.ts
@@ -37,6 +37,7 @@ vi.mock('@/lib/rate-limit', () => {
   return {
     RateLimiter: MockRateLimiter,
     getRateLimitKey: vi.fn(() => '127.0.0.1'),
+    getUserRateLimitKey: vi.fn((id: string) => `user:${id}`),
   };
 });
 

--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/nextjs';
 import { z } from 'zod';
 import type { Insight } from '@/lib/insights';
 import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server';
-import { aiRateLimiter, getRateLimitKey } from '@/lib/rate-limit';
+import { aiRateLimiter, aiPremiumRateLimiter, getUserRateLimitKey } from '@/lib/rate-limit';
 import { validateOrigin } from '@/lib/csrf';
 import { salvageTruncatedJSON } from './salvage';
 import { sanitizePromptInput } from '@/lib/prompt-sanitize';
@@ -217,12 +217,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
   }
 
-  // Rate limiting (C3)
-  const ip = getRateLimitKey(request);
-  if (await aiRateLimiter.isLimited(ip)) {
-    return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
-  }
-
   // Auth check — require signed-in user
   const supabase = await getSupabaseServer();
   if (!supabase) {
@@ -243,6 +237,13 @@ export async function POST(request: NextRequest) {
     .single();
 
   const userTier = profile?.tier ?? 'community';
+
+  // Rate limiting by user ID — paid users get 3x the limit (C3)
+  const isPaidTierForRateLimit = userTier === 'supporter' || userTier === 'champion';
+  const rateLimiter = isPaidTierForRateLimit ? aiPremiumRateLimiter : aiRateLimiter;
+  if (await rateLimiter.isLimited(getUserRateLimitKey(user.id))) {
+    return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
+  }
 
   if (userTier === 'community') {
     const adminClient = getSupabaseServiceRole();

--- a/app/api/contribute-data/route.ts
+++ b/app/api/contribute-data/route.ts
@@ -7,7 +7,7 @@ import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import { exceedsPayloadLimit } from '@/lib/api/payload-guard';
 import type { NightResult } from '@/lib/types';
 
-const limiter = new RateLimiter({ windowMs: 3_600_000, max: 10 });
+const limiter = new RateLimiter({ windowMs: 3_600_000, max: 30 });
 
 // ── Validation ───────────────────────────────────────────────
 const MAX_NIGHTS_PER_CHUNK = 1000; // max nights per request (client chunks larger datasets)

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -7,7 +7,7 @@ import { exceedsPayloadLimit } from '@/lib/api/payload-guard'
 import { resultToResponse } from '@/lib/errors'
 import { submitFeedback } from '@/lib/services/feedback-service'
 
-const limiter = new RateLimiter({ windowMs: 3_600_000, max: 5 })
+const limiter = new RateLimiter({ windowMs: 3_600_000, max: 10 })
 
 const FeedbackSchema = z.object({
   message: z.string()

--- a/app/api/files/presign/route.ts
+++ b/app/api/files/presign/route.ts
@@ -2,12 +2,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { captureApiError } from '@/lib/sentry-utils';
 import { z } from 'zod';
 import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server';
-import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
+import { RateLimiter, getUserRateLimitKey } from '@/lib/rate-limit';
 import { validateOrigin } from '@/lib/csrf';
 import { hasStorageConsent } from '@/lib/storage/quota';
 import { STORAGE_BUCKET, MAX_FILE_SIZE, SUPPORTED_EXTENSIONS } from '@/lib/storage/types';
 
-const rateLimiter = new RateLimiter({ windowMs: 3_600_000, max: 2000 });
+const rateLimiter = new RateLimiter({ windowMs: 3_600_000, max: 5000 });
 
 const presignSchema = z.object({
   filePath: z.string().min(1).max(500),
@@ -23,11 +23,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
   }
 
-  const ip = getRateLimitKey(request);
-  if (await rateLimiter.isLimited(ip)) {
-    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
-  }
-
   const supabase = await getSupabaseServer();
   if (!supabase) {
     return NextResponse.json({ error: 'Auth not configured' }, { status: 503 });
@@ -36,6 +31,14 @@ export async function POST(request: NextRequest) {
   const { data: { user }, error: authError } = await supabase.auth.getUser();
   if (authError || !user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Rate limit by user ID (not IP) so shared-IP users get their own bucket
+  if (await rateLimiter.isLimited(getUserRateLimitKey(user.id))) {
+    return NextResponse.json(
+      { error: 'Too many upload requests. Please wait a few minutes and try again.' },
+      { status: 429 }
+    );
   }
 
   const serviceRole = getSupabaseServiceRole();

--- a/lib/contribute.ts
+++ b/lib/contribute.ts
@@ -7,6 +7,8 @@
 import type { NightResult } from './types';
 
 const CHUNK_SIZE = 1000;
+const RATE_LIMIT_MAX_RETRIES = 3;
+const RATE_LIMIT_BASE_DELAY_MS = 5000;
 
 interface ContributionResult {
   ok: boolean;
@@ -29,17 +31,36 @@ export async function contributeNights(
 
   for (let i = 0; i < nights.length; i += CHUNK_SIZE) {
     const chunk = nights.slice(i, i + CHUNK_SIZE);
-    const res = await fetch('/api/contribute-data', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ nights: chunk, contributionId }),
-    });
+    const batchNum = Math.floor(i / CHUNK_SIZE) + 1;
+    let success = false;
 
-    if (!res.ok) {
+    for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+      const res = await fetch('/api/contribute-data', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nights: chunk, contributionId }),
+      });
+
+      if (res.ok) {
+        success = true;
+        break;
+      }
+
+      // Retry with exponential backoff on rate limit
+      if (res.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
+        const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
+        await new Promise(r => setTimeout(r, delay));
+        continue;
+      }
+
       const body = await res.json().catch(() => ({ error: 'Unknown error' }));
       throw new Error(
-        `Contribution failed (batch ${Math.floor(i / CHUNK_SIZE) + 1}): ${body.error || res.status}`
+        `Contribution failed (batch ${batchNum}): ${body.error || res.status}`
       );
+    }
+
+    if (!success) {
+      throw new Error(`Contribution failed (batch ${batchNum}): Rate limited after retries`);
     }
 
     totalSent += chunk.length;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -144,12 +144,29 @@ export function getRateLimitKey(request: Request): string {
   return `anon_${(hash >>> 0).toString(36)}`;
 }
 
+// ─── Rate limit key helpers ──────────────────────────────────
+
+/**
+ * Build a rate-limit key scoped to a specific user.
+ * Authenticated routes should use this instead of IP-based keys
+ * so users behind shared IPs (NAT, VPN) get their own bucket.
+ */
+export function getUserRateLimitKey(userId: string): string {
+  return `user:${userId}`;
+}
+
 // ─── Pre-configured limiters ─────────────────────────────────
 
-/** AI insights: 20 requests per hour per IP */
+/** AI insights — community tier: 20 requests per hour per user */
 export const aiRateLimiter = new RateLimiter({
   windowMs: 3_600_000,
   max: 20,
+});
+
+/** AI insights — paid tiers: 60 requests per hour per user */
+export const aiPremiumRateLimiter = new RateLimiter({
+  windowMs: 3_600_000,
+  max: 60,
 });
 
 /** Checkout/portal: 10 requests per 15 minutes per IP */

--- a/lib/storage/upload-orchestrator.ts
+++ b/lib/storage/upload-orchestrator.ts
@@ -20,6 +20,10 @@ type UploadListener = (state: UploadState) => void;
 
 const CONCURRENCY = 10;
 const RETRY_DELAY_MS = 2000;
+/** Base delay for rate limit backoff (doubles each time) */
+const RATE_LIMIT_BASE_DELAY_MS = 5000;
+/** Maximum rate limit retries before giving up on a file */
+const RATE_LIMIT_MAX_RETRIES = 4;
 /** Abort after this many consecutive failures with the same error */
 const FAIL_FAST_THRESHOLD = 3;
 
@@ -432,36 +436,71 @@ class UploadOrchestrator {
         // Reset consecutive error counter on success
         consecutiveErrors = 0;
         lastErrorMessage = '';
-      } catch {
-        // Retry once
-        try {
-          await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
-          if (signal.aborted) throw new Error('Cancelled');
-          const uploaded = await this.uploadSingleFile(file, filePath, fileName, hash, nightDate, signal);
-          if (uploaded) result.uploaded++;
-          else result.skipped++;
-          consecutiveErrors = 0;
-          lastErrorMessage = '';
-        } catch (retryErr) {
-          const errMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
-          result.failed++;
-          result.errors.push(`${fileName}: ${errMsg}`);
-
-          // Fail-fast: only count systemic errors (auth, network, server),
-          // not per-file validation errors (400) which are expected for some files
-          const isValidation = retryErr instanceof Error && (retryErr as Error & { isValidation?: boolean }).isValidation === true;
-          if (!isValidation) {
-            const normalized = errMsg.replace(/^[^:]+:\s*/, '');
-            if (normalized === lastErrorMessage) {
-              consecutiveErrors++;
-            } else {
-              consecutiveErrors = 1;
-              lastErrorMessage = normalized;
+      } catch (firstErr) {
+        // Rate limit: exponential backoff with multiple retries
+        const isRateLimit = firstErr instanceof Error && (firstErr as Error & { isRateLimit?: boolean }).isRateLimit === true;
+        if (isRateLimit) {
+          let uploaded = false;
+          for (let attempt = 0; attempt < RATE_LIMIT_MAX_RETRIES; attempt++) {
+            const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
+            await new Promise(r => setTimeout(r, delay));
+            if (signal.aborted) break;
+            try {
+              const ok = await this.uploadSingleFile(file, filePath, fileName, hash, nightDate, signal);
+              if (ok) result.uploaded++;
+              else result.skipped++;
+              uploaded = true;
+              consecutiveErrors = 0;
+              lastErrorMessage = '';
+              break;
+            } catch (retryErr) {
+              const stillRateLimited = retryErr instanceof Error && (retryErr as Error & { isRateLimit?: boolean }).isRateLimit === true;
+              if (!stillRateLimited) {
+                // Different error — record and stop retrying this file
+                const errMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+                result.failed++;
+                result.errors.push(`${fileName}: ${errMsg}`);
+                uploaded = true; // prevent double-counting
+                break;
+              }
+              // Still rate limited — continue backoff
             }
+          }
+          if (!uploaded) {
+            result.failed++;
+            result.errors.push(`${fileName}: Rate limited after retries`);
+          }
+        } else {
+          // Non-rate-limit error: retry once with flat delay
+          try {
+            await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+            if (signal.aborted) throw new Error('Cancelled');
+            const uploaded = await this.uploadSingleFile(file, filePath, fileName, hash, nightDate, signal);
+            if (uploaded) result.uploaded++;
+            else result.skipped++;
+            consecutiveErrors = 0;
+            lastErrorMessage = '';
+          } catch (retryErr) {
+            const errMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+            result.failed++;
+            result.errors.push(`${fileName}: ${errMsg}`);
 
-            // Abort if we've seen the same systemic error too many times in a row
-            if (consecutiveErrors >= FAIL_FAST_THRESHOLD) {
-              this.abortController?.abort();
+            // Fail-fast: only count systemic errors (auth, network, server),
+            // not per-file validation errors (400) which are expected for some files
+            const isValidation = retryErr instanceof Error && (retryErr as Error & { isValidation?: boolean }).isValidation === true;
+            if (!isValidation) {
+              const normalized = errMsg.replace(/^[^:]+:\s*/, '');
+              if (normalized === lastErrorMessage) {
+                consecutiveErrors++;
+              } else {
+                consecutiveErrors = 1;
+                lastErrorMessage = normalized;
+              }
+
+              // Abort if we've seen the same systemic error too many times in a row
+              if (consecutiveErrors >= FAIL_FAST_THRESHOLD) {
+                this.abortController?.abort();
+              }
             }
           }
         }
@@ -525,6 +564,8 @@ class UploadOrchestrator {
         throw new Error(err.error || 'Cloud sync requires an active session. Please sign in again.');
       }
       const error = new Error(err.error || `Presign failed: ${presignRes.status}`);
+      // Tag rate limit errors so retry logic uses exponential backoff
+      (error as Error & { isRateLimit?: boolean }).isRateLimit = presignRes.status === 429;
       // Tag validation errors (400) so fail-fast can distinguish them from systemic failures
       (error as Error & { isValidation?: boolean }).isValidation = presignRes.status === 400;
       throw error;


### PR DESCRIPTION
## Summary

- **Switches authenticated routes to user ID-based rate limiting** instead of IP-based, so users behind shared IPs (NAT, VPN, offices) get their own bucket
- **Adds exponential backoff with jitter** for 429 responses in the upload orchestrator and contribute client — rate-limited uploads now pause and retry instead of failing
- **Increases rate limits** across the board for power users with large datasets:

| Endpoint | Before | After | Key |
|----------|--------|-------|-----|
| Presign (cloud sync) | 2000/hr per IP | 5000/hr per user | User ID |
| AI insights (community) | 20/hr per IP | 20/hr per user | User ID |
| AI insights (paid) | 20/hr per IP | **60/hr per user** | User ID |
| Contribute data | 10/hr per IP | 30/hr per IP | IP |
| Feedback | 5/hr per IP | 10/hr per IP | IP |

Closes #207, closes #208, closes #210

## Test plan

- [x] All 1313 tests pass
- [x] TypeScript compiles clean
- [x] Production build succeeds
- [ ] Verify Vercel preview: upload SD card data, check all dashboard tabs
- [ ] Verify AI insights work for paid user
- [ ] Verify feedback submission works
- [ ] Check Sentry for new errors after deploy


🤖 Generated with [Claude Code](https://claude.com/claude-code)