### PR TITLE
fix: date validation, hydration mismatch, and Sentry noise reduction

### DIFF
--- a/app/api/files/presign/route.ts
+++ b/app/api/files/presign/route.ts
@@ -14,7 +14,10 @@ const presignSchema = z.object({
   fileName: z.string().min(1).max(255),
   fileSize: z.number().int().positive().max(MAX_FILE_SIZE),
   fileHash: z.string().length(64),
-  nightDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable(),
+  nightDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).refine(
+    (d) => { const t = new Date(d); return !isNaN(t.getTime()) && t.toISOString().startsWith(d); },
+    { message: 'Invalid date' }
+  ).nullable(),
   mimeType: z.string().max(100).nullable().optional(),
 });
 

--- a/components/share/shared-view-client.tsx
+++ b/components/share/shared-view-client.tsx
@@ -80,11 +80,13 @@ export function SharedViewClient({
     }
   }, [shareUrl]);
 
-  const expiresDate = new Date(expiresAt).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  });
+  // Format date deterministically to avoid SSR/client hydration mismatch
+  // (toLocaleDateString output varies by runtime environment)
+  const expiresDate = (() => {
+    const d = new Date(expiresAt);
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    return `${d.getUTCDate()} ${months[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+  })();
 
   return (
     <ThresholdsProvider>

--- a/lib/contribute-waveforms.ts
+++ b/lib/contribute-waveforms.ts
@@ -393,10 +393,13 @@ export async function contributeWaveformsBackground(
         trackContributedWaveformDate(night.dateStr);
       } else {
         trackFailedWaveformDate(night.dateStr);
+        // Rate-limited (429) uploads are expected under heavy use -- log as info to reduce noise.
+        // Actual failures (4xx/5xx) remain warnings.
+        const isRateLimited = result.status === 429;
         Sentry.captureMessage(
           `Waveform upload failed for ${night.dateStr}`,
           {
-            level: 'warning',
+            level: isRateLimited ? 'info' : 'warning',
             tags: { feature: 'waveform-contribution', status: String(result.status ?? 'unknown') },
             extra: { detail: result.detail },
           }


### PR DESCRIPTION
## Summary

Three Sentry issues fixed in one batch:

| Sentry Issue | Problem | Fix |
|-------------|---------|-----|
| **JAVASCRIPT-NEXTJS-26** (18 events) | `/api/files/presign` accepted dates like `7404-44-26` -- regex matched but Supabase crashed | Added `.refine()` to Zod schema validating date actually parses |
| **JAVASCRIPT-NEXTJS-A** (10 events) | Shared analysis page hydration mismatch from `toLocaleDateString()` producing different output on server vs client | Replaced with deterministic UTC formatting |
| **JAVASCRIPT-NEXTJS-11** (482 events) | Waveform upload 429s logged as `warning`, one user retrying created noise flood | Downgraded rate-limited (429) failures to `info`; real errors stay `warning` |

Also bulk-closed 21 noise issues: 20 truncated EDF files (one user, incomplete SD card copy) + 2 Supabase Storage transient errors.

## Test plan

- [x] Type check passes
- [x] Build passes
- [ ] Verify presign rejects `{"nightDate": "9999-13-45"}` with 400
- [ ] Verify shared analysis page loads without hydration error
- [ ] Verify Sentry noise reduction after deploy (429s should appear as info, not warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)