### PR TITLE
fix: sunset policy uses clicks instead of opens for engagement

### DIFF
--- a/__tests__/email-infrastructure.test.ts
+++ b/__tests__/email-infrastructure.test.ts
@@ -24,7 +24,7 @@ describe('applySunsetPolicy circuit breaker', () => {
     return proxy;
   }
 
-  it('skips sunset when zero opens are tracked system-wide', async () => {
+  it('skips sunset when zero clicks are tracked system-wide', async () => {
     const { applySunsetPolicy } = await import('@/lib/email/sequences');
 
     const mockSupabase = {
@@ -48,7 +48,7 @@ describe('applySunsetPolicy circuit breaker', () => {
     expect(result).toBe(0);
   });
 
-  it('proceeds with sunset when opens are tracked', async () => {
+  it('proceeds with sunset when clicks are tracked', async () => {
     const { applySunsetPolicy } = await import('@/lib/email/sequences');
 
     const mockSupabase = {
@@ -56,13 +56,13 @@ describe('applySunsetPolicy circuit breaker', () => {
         if (table === 'email_sequences') {
           return {
             select: vi.fn().mockImplementation((_cols: string, opts?: { count?: string; head?: boolean }) => {
-              // Circuit breaker query: return 5 opens
+              // Circuit breaker query: return 5 clicks
               if (opts?.count === 'exact' && opts?.head) {
                 return {
                   not: vi.fn().mockReturnValue({ count: 5 }),
                 };
               }
-              // Unengaged users query: chain .eq().not().is().is()
+              // Unengaged users query: chain .eq().not().is()
               const terminalValue = Promise.resolve({
                 data: [
                   { user_id: 'user-1' },
@@ -71,8 +71,7 @@ describe('applySunsetPolicy circuit breaker', () => {
                 ],
                 error: null,
               });
-              const isChain = { is: vi.fn().mockReturnValue(terminalValue) };
-              const notChain = { is: vi.fn().mockReturnValue(isChain) };
+              const notChain = { is: vi.fn().mockReturnValue(terminalValue) };
               const eqChain = { not: vi.fn().mockReturnValue(notChain) };
               return { eq: vi.fn().mockReturnValue(eqChain) };
             }),

--- a/lib/email/sequences.ts
+++ b/lib/email/sequences.ts
@@ -255,32 +255,32 @@ export async function scheduleActivationSequences(
  *
  * A user is sunsetted if they have >= 3 sent emails where:
  * - delivered_at is not null (email arrived)
- * - opened_at is null AND clicked_at is null (no engagement)
+ * - clicked_at is null (no engagement -- clicks are the primary signal
+ *   since open tracking is disabled for deliverability reasons)
  *
  * Sunsetted users get email_opt_in = false and all pending emails cancelled.
  */
 export async function applySunsetPolicy(
   supabase: SupabaseClient
 ): Promise<number> {
-  // Circuit breaker: if zero opens are tracked system-wide, open tracking
-  // is likely broken. Skip sunset to avoid mass-unsubscribing engaged users.
-  const { count: totalOpens } = await supabase
+  // Circuit breaker: if zero clicks are tracked system-wide, click tracking
+  // may be misconfigured. Skip sunset to avoid mass-unsubscribing engaged users.
+  const { count: totalClicks } = await supabase
     .from('email_sequences')
     .select('*', { count: 'exact', head: true })
-    .not('opened_at', 'is', null);
+    .not('clicked_at', 'is', null);
 
-  if (!totalOpens || totalOpens === 0) {
-    console.error('[email-sequences] Sunset skipped: zero opens tracked system-wide (open tracking may be misconfigured)');
+  if (!totalClicks || totalClicks === 0) {
+    console.error('[email-sequences] Sunset skipped: zero clicks tracked system-wide (click tracking may be misconfigured)');
     return 0;
   }
 
-  // Find users with 3+ delivered-but-unengaged emails
+  // Find users with 3+ delivered-but-unengaged emails (no clicks)
   const { data: candidates, error } = await supabase
     .from('email_sequences')
     .select('user_id')
     .eq('status', 'sent')
     .not('delivered_at', 'is', null)
-    .is('opened_at', null)
     .is('clicked_at', null);
 
   if (error || !candidates) {


### PR DESCRIPTION
## Summary

Open tracking disabled in Resend per their recommendation (tracking pixel hurts inbox placement and produces inaccurate data). Click tracking enabled instead -- more reliable engagement signal.

- Circuit breaker now checks `clicked_at` instead of `opened_at`
- Unengaged = 3+ delivered emails with no clicks
- Test mocks updated to match new query chain

## Test plan

- [x] Type check + build pass
- [x] 3 email-infrastructure tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)