### PR TITLE
fix: storage upload retry for transient 5xx errors

### DIFF
--- a/__tests__/upload-orchestrator.test.ts
+++ b/__tests__/upload-orchestrator.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { isTransientServerError } from '@/lib/storage/upload-orchestrator';
+
+describe('isTransientServerError', () => {
+  it('identifies 502 Bad Gateway as transient', () => {
+    expect(isTransientServerError('Upload failed: 502')).toBe(true);
+  });
+
+  it('identifies 503 Service Unavailable as transient', () => {
+    expect(isTransientServerError('Upload failed: 503')).toBe(true);
+  });
+
+  it('identifies 504 Gateway Timeout as transient', () => {
+    expect(isTransientServerError('Presign failed: 504')).toBe(true);
+  });
+
+  it('identifies 520 (Cloudflare) as transient', () => {
+    expect(isTransientServerError('Upload failed: 520')).toBe(true);
+  });
+
+  it('identifies transient errors embedded in longer messages', () => {
+    expect(isTransientServerError('server returned 503 temporarily')).toBe(true);
+    expect(isTransientServerError('error code: 502 bad gateway')).toBe(true);
+  });
+
+  it('does not flag 200 OK as transient', () => {
+    expect(isTransientServerError('Upload succeeded: 200')).toBe(false);
+  });
+
+  it('does not flag 400 Bad Request as transient', () => {
+    expect(isTransientServerError('Presign failed: 400')).toBe(false);
+  });
+
+  it('does not flag 401 Unauthorized as transient', () => {
+    expect(isTransientServerError('Unauthorized: 401')).toBe(false);
+  });
+
+  it('does not flag 403 Forbidden as transient', () => {
+    expect(isTransientServerError('Forbidden: 403')).toBe(false);
+  });
+
+  it('does not flag 404 Not Found as transient', () => {
+    expect(isTransientServerError('Not found: 404')).toBe(false);
+  });
+
+  it('does not flag 429 Rate Limited as transient', () => {
+    expect(isTransientServerError('Too many requests: 429')).toBe(false);
+  });
+
+  it('does not flag 500 Internal Server Error as transient', () => {
+    expect(isTransientServerError('Internal server error: 500')).toBe(false);
+  });
+
+  it('does not flag generic error messages without status codes', () => {
+    expect(isTransientServerError('Network timeout')).toBe(false);
+    expect(isTransientServerError('Failed to fetch')).toBe(false);
+    expect(isTransientServerError('')).toBe(false);
+  });
+
+  it('does not match partial number sequences', () => {
+    // 5020 should not match 502
+    expect(isTransientServerError('error code 5020')).toBe(false);
+    // 1503 should not match 503
+    expect(isTransientServerError('request id 1503')).toBe(false);
+  });
+});

--- a/app/api/files/presign/route.ts
+++ b/app/api/files/presign/route.ts
@@ -86,10 +86,10 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
 
     if (existing) {
-      // Unconfirmed rows older than 1 hour are definitively orphaned —
+      // Unconfirmed rows older than 10 minutes are definitively orphaned —
       // delete without checking storage (the PUT never completed)
       const ageMs = Date.now() - new Date(existing.uploaded_at).getTime();
-      const isStaleOrphan = !existing.upload_confirmed && ageMs > 60 * 60 * 1000;
+      const isStaleOrphan = !existing.upload_confirmed && ageMs > 10 * 60 * 1000;
 
       if (isStaleOrphan) {
         await serviceRole.from('user_files').delete().eq('id', existing.id);
@@ -111,7 +111,7 @@ export async function POST(request: NextRequest) {
         // Storage file missing despite confirmed — delete orphaned row
         await serviceRole.from('user_files').delete().eq('id', existing.id);
       } else {
-        // Unconfirmed but recent (< 1 hour) — another upload may be in progress.
+        // Unconfirmed but recent (< 10 min) — another upload may be in progress.
         // Delete and re-create to avoid blocking this upload attempt.
         // Also remove any partial storage object to avoid signed URL conflicts.
         await serviceRole.from('user_files').delete().eq('id', existing.id);

--- a/lib/storage/upload-orchestrator.ts
+++ b/lib/storage/upload-orchestrator.ts
@@ -24,8 +24,18 @@ const RETRY_DELAY_MS = 2000;
 const RATE_LIMIT_BASE_DELAY_MS = 5000;
 /** Maximum rate limit retries before giving up on a file */
 const RATE_LIMIT_MAX_RETRIES = 4;
+/** Maximum retries for transient 5xx errors (less aggressive than rate limits) */
+const TRANSIENT_MAX_RETRIES = 3;
 /** Abort after this many consecutive failures with the same error */
 const FAIL_FAST_THRESHOLD = 3;
+
+/**
+ * Check if an error message indicates a transient server error.
+ * These are typically CDN/proxy-level failures that resolve on retry.
+ */
+export function isTransientServerError(errorMessage: string): boolean {
+  return /\b(502|503|504|520)\b/.test(errorMessage);
+}
 
 function getFilePath(file: File): string {
   return (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || file.name;
@@ -237,11 +247,17 @@ class UploadOrchestrator {
       .sort((a, b) => b[1] - a[1])
       .slice(0, 5);
 
+    // Tag as transient if ALL failures were 5xx server errors
+    const allTransient = result.errors.length > 0 && result.errors.every(
+      (err) => /\b(500|502|503|504|520)\b/.test(err)
+    );
+
     Sentry.captureMessage('cloud_upload_partial_failure', {
       level: result.uploaded === 0 ? 'error' : 'warning',
       tags: {
         allFailed: String(result.uploaded === 0),
         failedCount: String(result.failed),
+        transient: String(allTransient),
       },
       extra: {
         uploaded: result.uploaded,
@@ -439,9 +455,14 @@ class UploadOrchestrator {
       } catch (firstErr) {
         // Rate limit: exponential backoff with multiple retries
         const isRateLimit = firstErr instanceof Error && (firstErr as Error & { isRateLimit?: boolean }).isRateLimit === true;
-        if (isRateLimit) {
+        // Transient 5xx (502, 503, 504, 520): same exponential backoff but capped at fewer retries
+        const firstErrMsg = firstErr instanceof Error ? firstErr.message : String(firstErr);
+        const isTransient = !isRateLimit && isTransientServerError(firstErrMsg);
+        if (isRateLimit || isTransient) {
+          const maxRetries = isRateLimit ? RATE_LIMIT_MAX_RETRIES : TRANSIENT_MAX_RETRIES;
+          const retryLabel = isRateLimit ? 'Rate limited' : 'Transient server error';
           let uploaded = false;
-          for (let attempt = 0; attempt < RATE_LIMIT_MAX_RETRIES; attempt++) {
+          for (let attempt = 0; attempt < maxRetries; attempt++) {
             const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
             await new Promise(r => setTimeout(r, delay));
             if (signal.aborted) break;
@@ -454,26 +475,30 @@ class UploadOrchestrator {
               lastErrorMessage = '';
               break;
             } catch (retryErr) {
-              const stillRateLimited = retryErr instanceof Error && (retryErr as Error & { isRateLimit?: boolean }).isRateLimit === true;
-              if (!stillRateLimited) {
+              const retryErrMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+              const stillRetryable = isRateLimit
+                ? retryErr instanceof Error && (retryErr as Error & { isRateLimit?: boolean }).isRateLimit === true
+                : isTransientServerError(retryErrMsg);
+              if (!stillRetryable) {
                 // Different error — record and stop retrying this file
-                const errMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
                 result.failed++;
-                result.errors.push(`${fileName}: ${errMsg}`);
+                result.errors.push(`${fileName}: ${retryErrMsg}`);
                 uploaded = true; // prevent double-counting
                 break;
               }
-              // Still rate limited — continue backoff
+              // Still retryable — continue backoff
             }
           }
           if (!uploaded) {
             result.failed++;
-            result.errors.push(`${fileName}: Rate limited after retries`);
+            result.errors.push(`${fileName}: ${retryLabel} after retries`);
           }
+          // Transient 5xx errors do NOT count toward consecutiveErrors —
+          // they are infrastructure-level and typically self-heal
         } else {
-          // Non-rate-limit error: retry once with flat delay
+          // Non-rate-limit, non-transient error: retry once with flat delay + jitter
           try {
-            await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+            await new Promise(r => setTimeout(r, RETRY_DELAY_MS + Math.random() * 500));
             if (signal.aborted) throw new Error('Cancelled');
             const uploaded = await this.uploadSingleFile(file, filePath, fileName, hash, nightDate, signal);
             if (uploaded) result.uploaded++;


### PR DESCRIPTION
## Summary
- Add `isTransientServerError()` helper that identifies 502, 503, 504, 520 status codes in error messages
- Route transient 5xx errors through exponential backoff (same as rate limits) capped at 3 retries instead of 4
- Transient 5xx errors do NOT count toward the `consecutiveErrors` fail-fast counter, preventing premature upload aborts during CDN/proxy flaps
- Add jitter (`Math.random() * 500`) to the flat 2s retry delay for non-rate-limit, non-transient errors to reduce thundering herd
- Add `transient` tag to Sentry failure reports (true when ALL failures contain 5xx status codes) for easier triage
- Reduce orphan timeout in presign route from 1 hour to 10 minutes to speed up recovery from failed uploads

## Test plan
- [x] `isTransientServerError` correctly identifies 502, 503, 504, 520 (14 test cases)
- [x] Non-5xx errors (400, 401, 403, 404, 429, 500) are not identified as transient
- [x] Partial number sequences (e.g. 5020, 1503) do not false-positive
- [x] Generic error messages without status codes return false
- [x] Full test suite passes (90 files, 1370 tests)
- [x] TypeScript strict check passes
- [x] Production build succeeds
- [ ] Manual: verify upload retry behavior on Vercel preview with network throttling

🤖 Generated with [Claude Code](https://claude.com/claude-code)