### PR TITLE
feat: metrics comprehension and contextual framing

### DIFF
--- a/__tests__/insights.test.ts
+++ b/__tests__/insights.test.ts
@@ -25,7 +25,7 @@ describe('generateInsights', () => {
       expect(['positive', 'warning', 'actionable', 'info']).toContain(insight.type);
       expect(insight.title.length).toBeGreaterThan(0);
       expect(insight.body.length).toBeGreaterThan(0);
-      expect(['glasgow', 'wat', 'ned', 'oximetry', 'therapy', 'trend', 'settings']).toContain(insight.category);
+      expect(['glasgow', 'wat', 'ned', 'oximetry', 'therapy', 'trend', 'settings', 'correlation', 'temporal']).toContain(insight.category);
     }
   });
 

--- a/components/common/metric-card.tsx
+++ b/components/common/metric-card.tsx
@@ -16,6 +16,8 @@ interface MetricCardProps {
   tooltip?: string;
   methodology?: string;
   onClick?: () => void;
+  /** Short context hint shown below value for amber/red metrics */
+  contextHint?: string;
 }
 
 function formatValue(value: number, format?: string): string {
@@ -117,6 +119,7 @@ export const MetricCard = memo(function MetricCard({
   tooltip,
   methodology,
   onClick,
+  contextHint,
 }: MetricCardProps) {
   const light = threshold ? getTrafficLight(value, threshold) : null;
   const dotColor = light ? getTrafficDotColor(light) : '';
@@ -177,6 +180,9 @@ export const MetricCard = memo(function MetricCard({
           </span>
         )}
       </div>
+      {contextHint && light && light !== 'good' && (
+        <p className="mt-0.5 text-[10px] text-muted-foreground">{contextHint}</p>
+      )}
     </div>
   );
 });

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -10,7 +10,7 @@ import type { NightResult } from '@/lib/types';
 import { generateInsights } from '@/lib/insights';
 import { NightSummaryHero } from '@/components/dashboard/night-summary-hero';
 import { AIInsightsGate } from '@/components/dashboard/ai-insights-gate';
-import { HeartPulse, TrendingDown, TrendingUp, ChevronRight, Upload, Info, Settings2, Share2 } from 'lucide-react';
+import { HeartPulse, TrendingDown, TrendingUp, ChevronRight, Upload, Info, Settings2, Share2, ShieldCheck, AlertTriangle, AlertCircle } from 'lucide-react';
 import { UpgradePrompt } from '@/components/auth/upgrade-prompt';
 import { useAuth } from '@/lib/auth/auth-context';
 import { SharePrompts } from '@/components/dashboard/share-prompts';
@@ -100,6 +100,39 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
       <div data-walkthrough="summary-hero">
         <NightSummaryHero night={n} />
       </div>
+
+      {/* Treatment Success Banner — contextualises metrics based on RERA control */}
+      {(() => {
+        const reraLight = getTrafficLight(n.ned.reraIndex, THRESHOLDS.reraIndex!);
+        if (reraLight === 'good') {
+          return (
+            <div className="flex items-start gap-2.5 rounded-lg border border-emerald-500/20 bg-emerald-500/[0.05] px-4 py-3">
+              <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500/70" />
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Your therapy is controlling respiratory events effectively. The metrics below show areas where further optimisation may improve sleep quality.
+              </p>
+            </div>
+          );
+        }
+        if (reraLight === 'warn') {
+          return (
+            <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/20 bg-amber-500/[0.05] px-4 py-3">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500/70" />
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Your respiratory event index suggests room for therapy adjustment. Discuss these findings with your clinician.
+              </p>
+            </div>
+          );
+        }
+        return (
+          <div className="flex items-start gap-2.5 rounded-lg border border-red-500/20 bg-red-500/[0.05] px-4 py-3">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-500/70" />
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              Your respiratory disruption index is elevated. These findings are worth discussing with your clinician.
+            </p>
+          </div>
+        );
+      })()}
 
       {/* Symptom Rating — how did you sleep? */}
       <SymptomRating
@@ -191,6 +224,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           threshold={THRESHOLDS.iflRisk}
           previousValue={p ? computeIFLRisk(p) : undefined}
           tooltip="Combines FL Score, NED, Flatness Index, and Glasgow Index to estimate how much flow limitation may be driving symptoms. Higher values suggest greater symptom risk from flow limitation."
+          contextHint={getTrafficLight(computeIFLRisk(n), THRESHOLDS.iflRisk!) === 'bad' ? 'Room to optimise' : getTrafficLight(computeIFLRisk(n), THRESHOLDS.iflRisk!) === 'warn' ? 'May benefit from optimisation' : undefined}
           onClick={() => openMetric('IFL Symptom Risk', (x) => computeIFLRisk(x), { unit: '%', threshold: THRESHOLDS.iflRisk, description: 'Composite flow limitation symptom risk across all nights' })}
         />
         <MetricCard
@@ -200,6 +234,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           previousValue={p?.glasgow.overall}
           tooltip="A composite score measuring how abnormal your breathing waveform looks. Lower is better. Based on 9 breath shape components."
           methodology={METRIC_METHODOLOGIES.glasgowIndex}
+          contextHint={getTrafficLight(n.glasgow.overall, THRESHOLDS.glasgowOverall!) === 'bad' ? 'Room to optimise' : getTrafficLight(n.glasgow.overall, THRESHOLDS.glasgowOverall!) === 'warn' ? 'May benefit from optimisation' : undefined}
           onClick={() => openMetric('Glasgow Index', (x) => x.glasgow.overall, { threshold: THRESHOLDS.glasgowOverall, description: 'Composite breath-shape abnormality score across all nights' })}
         />
         <MetricCard
@@ -211,6 +246,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           previousValue={p?.wat.flScore}
           tooltip="Percentage of breaths showing flow limitation — when your airway partially collapses during inhalation. Lower is better."
           methodology={METRIC_METHODOLOGIES.flScore}
+          contextHint={getTrafficLight(n.wat.flScore, THRESHOLDS.watFL!) === 'bad' ? 'Room to optimise' : getTrafficLight(n.wat.flScore, THRESHOLDS.watFL!) === 'warn' ? 'May benefit from optimisation' : undefined}
           onClick={() => openMetric('FL Score', (x) => x.wat.flScore, { unit: '%', threshold: THRESHOLDS.watFL, description: 'Percentage of flow-limited breaths per night' })}
         />
         <MetricCard
@@ -222,6 +258,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           previousValue={p?.ned.nedMean}
           tooltip="Negative Effort Dependence — measures how much your breathing effort is wasted due to airway obstruction. Lower is better."
           methodology={METRIC_METHODOLOGIES.nedMean}
+          contextHint={getTrafficLight(n.ned.nedMean, THRESHOLDS.nedMean!) === 'bad' ? 'Room to optimise' : getTrafficLight(n.ned.nedMean, THRESHOLDS.nedMean!) === 'warn' ? 'May benefit from optimisation' : undefined}
           onClick={() => openMetric('NED Mean', (x) => x.ned.nedMean, { unit: '%', threshold: THRESHOLDS.nedMean, description: 'Average wasted breathing effort due to obstruction' })}
         />
         <MetricCard
@@ -232,6 +269,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           previousValue={p?.ned.reraIndex}
           tooltip="Respiratory Effort-Related Arousals per hour. These are brief awakenings caused by breathing effort. Lower is better."
           methodology={METRIC_METHODOLOGIES.reraIndex}
+          contextHint={getTrafficLight(n.ned.reraIndex, THRESHOLDS.reraIndex!) === 'bad' ? 'Discuss with clinician' : undefined}
           onClick={() => openMetric('RERA Index', (x) => x.ned.reraIndex, { unit: '/hr', threshold: THRESHOLDS.reraIndex, description: 'Respiratory effort-related arousals per hour' })}
         />
       </div>
@@ -240,6 +278,31 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         text={getIFLRiskExplanation(computeIFLRisk(n), THRESHOLDS.iflRisk!)}
         defaultExpanded={isNewUser}
       />
+
+      {/* Understanding Your Results — collapsible guide to interpreting metrics */}
+      <details className="group rounded-xl border border-border/50 bg-card/30">
+        <summary className="flex cursor-pointer items-center gap-2 px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground [&::-webkit-details-marker]:hidden">
+          <ChevronRight className="h-4 w-4 transition-transform group-open:rotate-90" />
+          Understanding Your Results
+        </summary>
+        <div className="border-t border-border/30 px-4 pb-4 pt-3 space-y-2.5">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Green, amber, and red indicators show where each metric falls relative to research-based thresholds.
+          </p>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Flow limitation metrics (Glasgow Index, FL Score, NED) measure a different dimension than event-based metrics like RERA. Red flow limitation scores mean room to optimise, not that treatment is failing.
+          </p>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Always discuss findings with your clinician before making therapy changes.
+          </p>
+          <Link
+            href="/glossary"
+            className="inline-block text-xs text-primary/70 underline underline-offset-2 hover:text-primary"
+          >
+            Read the full glossary for detailed metric definitions
+          </Link>
+        </div>
+      </details>
 
       {/* Community Benchmarks — ungated, shows metric position bars */}
       <CommunityBenchmarks night={n} isDemo={isDemo} />
@@ -457,6 +520,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           compact
           tooltip="Respiratory disruptions per hour — recovery breaths following flow-limited breathing. This flow-based estimate typically reads higher than in-lab arousal index. Lower is better."
           methodology={METRIC_METHODOLOGIES.eai}
+          contextHint={getTrafficLight(n.ned.estimatedArousalIndex, THRESHOLDS.eai!) === 'bad' ? 'Discuss with clinician' : undefined}
           onClick={() => openMetric('Resp. Disruption Index', (x) => x.ned.estimatedArousalIndex, { unit: '/hr', threshold: THRESHOLDS.eai })}
         />
       </div>
@@ -487,6 +551,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
                 compact
                 tooltip="Oxygen Desaturation Index — number of times per hour your blood oxygen drops by 3% or more. Lower is better."
                 methodology={METRIC_METHODOLOGIES.odi3}
+                contextHint={getTrafficLight(n.oximetry.odi3, THRESHOLDS.odi3!) === 'bad' ? 'Discuss with clinician' : undefined}
                 onClick={() => openMetric('ODI-3', (x) => x.oximetry?.odi3, { unit: '/hr', threshold: THRESHOLDS.odi3 })}
               />
               <MetricCard

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -239,6 +239,20 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
     });
   }
 
+  // Strong event control with residual flow limitation
+  if (
+    n.ned.reraIndex < 5 &&
+    (n.wat.flScore > 50 || n.glasgow.overall > 2.0 || n.ned.nedMean > 25)
+  ) {
+    insights.push({
+      id: 'event-control-residual-fl',
+      type: 'info',
+      title: 'Strong event control with residual flow limitation',
+      body: 'Your therapy effectively controls respiratory events. Red flow limitation metrics show room for further optimisation, not treatment failure. Discuss with your clinician.',
+      category: 'therapy',
+    });
+  }
+
   // NED RERA
   if (n.ned.reraIndex >= 10) {
     insights.push({

--- a/lib/metric-explanations.ts
+++ b/lib/metric-explanations.ts
@@ -3,6 +3,48 @@ import { getTrafficLight } from './thresholds';
 import { fmt } from './format-utils';
 
 /* ------------------------------------------------------------------ */
+/*  Plain-language metric summaries                                    */
+/*  One-sentence descriptions for users who want the "what" not "how" */
+/* ------------------------------------------------------------------ */
+
+export const METRIC_PLAIN_LANGUAGE: Record<string, string> = {
+  iflRisk:
+    'A composite score estimating how much flow limitation may be affecting your sleep quality. Higher values suggest greater symptom risk.',
+  glasgowIndex:
+    'A breath-shape score measuring how far your breathing deviates from normal flow patterns.',
+  flScore:
+    'How much of your breathing shows restricted airflow. Higher values mean your airway narrows during sleep.',
+  nedMean:
+    'Average negative effort dependence -- how much your airway resists airflow during inspiration.',
+  reraIndex:
+    'How often your breathing effort increases enough to briefly disrupt sleep, even without a full apnoea.',
+  eai:
+    'An estimate of how often your breathing disruptions cause brief recovery responses, based on flow patterns.',
+  regularity:
+    'How repetitive your breathing rhythm is. On PAP therapy, high regularity can signal persistently restricted airflow.',
+  periodicity:
+    'Detects repeating breathing cycles that may indicate periodic breathing or central events.',
+  combinedFL:
+    'The percentage of breaths where your airway was partially restricted, combining two independent detection methods.',
+  odi3:
+    'How many times per hour your blood oxygen drops by 3% or more from a recent baseline.',
+  tBelow90:
+    'Total time your blood oxygen spent below 90%, a level where your body may start to experience stress.',
+  spo2Mean:
+    'Your average blood oxygen level throughout the night. Normal range is 94-98%.',
+  hrClin10:
+    'How often your heart rate surges by 10+ beats per minute, which can indicate breathing-related arousals.',
+  briefObstructionIndex:
+    'How often your airway briefly collapses for just one or two breaths -- too short for standard detection methods.',
+  hypopneaIndex:
+    'How often your airflow drops significantly for 10 or more seconds, indicating partial airway collapse.',
+  amplitudeCv:
+    'How much your breath size varies within each 5-minute window. Higher values suggest intermittent airway compromise.',
+  estimatedRdi:
+    'An estimated count of all respiratory disruptions per hour, combining RERAs and hypopnoeas detected from flow data.',
+};
+
+/* ------------------------------------------------------------------ */
 /*  Plain-language methodology descriptions                           */
 /*  Used in MetricCard info popovers and the About page               */
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary

- **Treatment Success Banner** at the top of the overview tab, colour-coded by RERA control (green < 5, amber 5-10, red >= 10) to immediately frame whether therapy is working before the user sees individual metrics
- **"Understanding Your Results" collapsible section** below the primary metrics grid explaining the traffic light system, the distinction between flow limitation metrics and event-based metrics, and a link to the glossary
- **MetricCard `contextHint` prop** that shows a short guidance line ("Room to optimise" / "Discuss with clinician") below the value for amber/red metrics, varying by metric category (FL vs event)
- **`METRIC_PLAIN_LANGUAGE` dictionary** in `lib/metric-explanations.ts` with one-sentence plain-language descriptions for all 17 metrics
- **New insight rule** "Strong event control with residual flow limitation" fires when RERA < 5 but FL metrics are elevated (FL Score > 50 OR Glasgow > 2.0 OR NED Mean > 25), categorised as `therapy`/`info`

## Test plan

- [x] `npx tsc --noEmit` passes (zero errors)
- [x] `npm test` passes (89 test files, 1356 tests)
- [x] `npm run build` passes (production build)
- [ ] Verify Treatment Success Banner renders correctly for green/amber/red RERA values on Vercel preview
- [ ] Verify "Understanding Your Results" section expands/collapses and glossary link works
- [ ] Verify contextHint text appears below amber/red metric values and is absent for green
- [ ] Verify new insight fires when RERA < 5 with elevated FL metrics on real SD card data
- [ ] Mobile viewport check on all new elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)