### PR TITLE
fix: stop sending rate-limited waveform uploads to Sentry

### DIFF
--- a/lib/contribute-waveforms.ts
+++ b/lib/contribute-waveforms.ts
@@ -393,17 +393,22 @@ export async function contributeWaveformsBackground(
         trackContributedWaveformDate(night.dateStr);
       } else {
         trackFailedWaveformDate(night.dateStr);
-        // Rate-limited (429) uploads are expected under heavy use -- log as info to reduce noise.
-        // Actual failures (4xx/5xx) remain warnings.
-        const isRateLimited = result.status === 429;
-        Sentry.captureMessage(
-          `Waveform upload failed for ${night.dateStr}`,
-          {
-            level: isRateLimited ? 'info' : 'warning',
-            tags: { feature: 'waveform-contribution', status: String(result.status ?? 'unknown') },
-            extra: { detail: result.detail },
-          }
-        );
+        // Rate-limited (429) is expected behavior -- log locally only, never to Sentry.
+        // Actual failures (4xx/5xx) are reported to Sentry as warnings.
+        if (result.status === 429) {
+          console.warn(
+            `Waveform upload rate-limited for ${night.dateStr} (429)`
+          );
+        } else {
+          Sentry.captureMessage(
+            `Waveform upload failed for ${night.dateStr}`,
+            {
+              level: 'warning',
+              tags: { feature: 'waveform-contribution', status: String(result.status ?? 'unknown') },
+              extra: { detail: result.detail },
+            }
+          );
+        }
       }
     } catch (err) {
       trackFailedWaveformDate(night.dateStr);


### PR DESCRIPTION
## Summary

- Rate-limited (429) waveform uploads were being sent to Sentry as info-level messages, generating **748 events in 6 days** and polluting the error stream
- Now: 429 responses log to `console.warn` only (local Vercel logs), not Sentry
- Actual failures (500s, network errors) still go to Sentry as warnings

Fixes JAVASCRIPT-NEXTJS-11 noise.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 89 files, 1356 tests passing
- [ ] Verify Vercel preview deploy
- [ ] Monitor Sentry for 24h — waveform upload events should drop to near-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)