### PR TITLE
fix: resolve hydration mismatch on shared analysis pages

### DIFF
--- a/components/dashboard/ai-insights-gate.tsx
+++ b/components/dashboard/ai-insights-gate.tsx
@@ -74,10 +74,15 @@ export function AIInsightsGate({
   const aiRemaining = user ? (isPaid ? Infinity : getAIRemaining(tier)) : 0;
   const isExhausted = !isPaid && aiRemaining <= 0 && !!user;
 
-  // Check localStorage results for returning user detection
-  const isReturning = typeof window !== 'undefined' && (() => {
-    try { return !!localStorage.getItem('airwaylab_results'); } catch { return false; }
-  })();
+  // Check localStorage results for returning user detection.
+  // Deferred to useEffect to avoid SSR/client hydration mismatch
+  // (localStorage is unavailable during server rendering).
+  const [isReturning, setIsReturning] = useState(false);
+  useEffect(() => {
+    try {
+      if (localStorage.getItem('airwaylab_results')) setIsReturning(true);
+    } catch { /* noop */ }
+  }, []);
 
   const handleGenerate = useCallback(() => {
     abortRef.current?.abort();

--- a/components/dashboard/data-contribution.tsx
+++ b/components/dashboard/data-contribution.tsx
@@ -36,31 +36,27 @@ export function DataContribution({
   autoSubmitStatus = 'idle',
   autoSubmitCount = 0,
 }: Props) {
-  const [dismissed, setDismissed] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    try {
-      return sessionStorage.getItem(DISMISS_KEY) === '1';
-    } catch {
-      return false;
-    }
-  });
-
-  // Check persistent consent state
-  const [isOptedIn] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    return getConsentState();
-  });
-
-  // Track which nights were previously contributed (date-based dedup)
-  const [contributedDates] = useState<string[]>(() => {
-    if (typeof window === 'undefined') return [];
-    try {
-      return JSON.parse(localStorage.getItem('airwaylab_contributed_dates') || '[]');
-    } catch {
-      return [];
-    }
-  });
+  // Initialize all browser-dependent state to safe defaults to match SSR.
+  // Actual values are loaded in the useEffect below to avoid hydration mismatches.
+  const [dismissed, setDismissed] = useState(false);
+  const [isOptedIn, setIsOptedIn] = useState(false);
+  const [contributedDates, setContributedDates] = useState<string[]>([]);
   const contributedNightCount = contributedDates.length;
+
+  // Load browser-dependent state after mount
+  useEffect(() => {
+    try {
+      if (sessionStorage.getItem(DISMISS_KEY) === '1') setDismissed(true);
+    } catch { /* noop */ }
+    setIsOptedIn(getConsentState());
+    try {
+      const raw = localStorage.getItem('airwaylab_contributed_dates');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) setContributedDates(parsed);
+      }
+    } catch { /* noop */ }
+  }, []);
 
   const [status, setStatus] = useState<'idle' | 'sending' | 'success' | 'error'>('idle');
   const [expanded, setExpanded] = useState(false);

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -59,9 +59,11 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
   const p = previousNight;
 
   const [symptomRating, setSymptomRating] = useState<number | null>(null);
-  const [isContributeConsented, setIsContributeConsented] = useState(() => getConsentState());
+  // Initialize to false to match SSR (localStorage is unavailable during
+  // server rendering). Actual consent state is loaded in the useEffect below.
+  const [isContributeConsented, setIsContributeConsented] = useState(false);
 
-  // Reload symptom rating when night changes
+  // Load symptom rating and consent state after mount (and when night changes)
   useEffect(() => {
     const notes = loadNightNotes(n.dateStr);
     setSymptomRating(notes.symptomRating);


### PR DESCRIPTION
## Summary

Fixes React hydration errors on `/shared/[id]` pages (Sentry JAVASCRIPT-NEXTJS-A, 11 events, regressed).

**Root cause:** Three dashboard components read `localStorage`/`sessionStorage` during initial render (in `useState` initializers or computed values). During SSR these APIs are unavailable, producing default values. During client hydration, the browser returns actual stored values, causing a state mismatch.

**Fix:** Defer all browser storage reads to `useEffect`, initializing with SSR-safe defaults:

- `ai-insights-gate.tsx` — `isReturning` now deferred to useEffect
- `data-contribution.tsx` — `dismissed`, `isOptedIn`, `contributedDates` all deferred
- `overview-tab.tsx` — `isContributeConsented` deferred (existing useEffect already handled reload)

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 89 files, 1356 tests passing
- [x] `npm run build` — clean production build
- [ ] Verify Vercel preview deploy — check /shared/ pages render without console hydration warnings
- [ ] Monitor Sentry for 48h — JAVASCRIPT-NEXTJS-A should not recur

🤖 Generated with [Claude Code](https://claude.com/claude-code)