### PR TITLE
chore: run discord-sync cron every 15min

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -14,7 +14,8 @@
     },
     {
       "path": "/api/cron/discord-sync",
-      "schedule": "0 */6 * * *"
+      "schedule": "*/15 * * * *"
     }
   ]
 }
+


### PR DESCRIPTION
## Summary

- Change discord-sync cron from every 6 hours to every 15 minutes
- Users who join Discord via invite link get roles within 15 min instead of 6 hours
- No code changes, just schedule update in vercel.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)