### PR TITLE
feat: broadcast email system + March 2026 update

### DIFF
--- a/app/api/admin/broadcast/route.ts
+++ b/app/api/admin/broadcast/route.ts
@@ -1,0 +1,179 @@
+/**
+ * Admin endpoint to send broadcast emails to all opted-in users.
+ *
+ * Protected by X-Admin-Secret header (ADMIN_API_KEY env var).
+ * Idempotent: checks email_log for existing broadcasts of the same template.
+ * Supports dry-run mode (default) and A/B subject testing.
+ *
+ * Usage:
+ *   # Dry run (returns count + sample, sends nothing)
+ *   curl -X POST https://airwaylab.app/api/admin/broadcast \
+ *     -H "x-admin-secret: $ADMIN_API_KEY" \
+ *     -H "Content-Type: application/json" \
+ *     -d '{"templateId": "march_2026_update"}'
+ *
+ *   # Live send
+ *   curl -X POST https://airwaylab.app/api/admin/broadcast \
+ *     -H "x-admin-secret: $ADMIN_API_KEY" \
+ *     -H "Content-Type: application/json" \
+ *     -d '{"templateId": "march_2026_update", "dryRun": false}'
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import * as Sentry from '@sentry/nextjs'
+import { getSupabaseServiceRole } from '@/lib/supabase/server'
+import { sendEmail } from '@/lib/email/send'
+import { getUnsubscribeUrl } from '@/lib/email/unsubscribe-token'
+import { BROADCAST_TEMPLATES, type BroadcastSubjectVariant } from '@/lib/email/broadcast'
+
+const ADMIN_SECRET = process.env.ADMIN_API_KEY
+const BATCH_SIZE = 10
+const BATCH_DELAY_MS = 1000
+
+function sleep(ms: number) {
+  return new Promise(r => setTimeout(r, ms))
+}
+
+export async function POST(request: NextRequest) {
+  const secret = request.headers.get('x-admin-secret')
+  if (!ADMIN_SECRET || secret !== ADMIN_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: { templateId?: string; dryRun?: boolean }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { templateId, dryRun = true } = body
+  if (!templateId) {
+    return NextResponse.json(
+      { error: 'templateId required', available: Object.keys(BROADCAST_TEMPLATES) },
+      { status: 400 }
+    )
+  }
+
+  const template = BROADCAST_TEMPLATES[templateId]
+  if (!template) {
+    return NextResponse.json(
+      { error: `Unknown template: ${templateId}`, available: Object.keys(BROADCAST_TEMPLATES) },
+      { status: 400 }
+    )
+  }
+
+  const supabase = getSupabaseServiceRole()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 503 })
+  }
+
+  try {
+    // Fetch all opted-in users with email
+    const { data: users, error: fetchError } = await supabase
+      .from('profiles')
+      .select('id, email')
+      .eq('email_opt_in', true)
+      .not('email', 'is', null)
+
+    if (fetchError) {
+      console.error('[broadcast] Failed to fetch users:', fetchError)
+      return NextResponse.json({ error: 'Database query failed' }, { status: 500 })
+    }
+
+    if (!users || users.length === 0) {
+      return NextResponse.json({ sent: 0, skipped: 0, message: 'No opted-in users found' })
+    }
+
+    // Idempotency: skip users who already received this broadcast
+    const emailType = `broadcast_${templateId}`
+    const { data: alreadySent } = await supabase
+      .from('email_log')
+      .select('to_email')
+      .eq('email_type', emailType)
+
+    const alreadySentEmails = new Set(
+      (alreadySent ?? []).map(r => r.to_email)
+    )
+
+    const toSend = users.filter(u => !alreadySentEmails.has(u.email))
+    const skipped = users.length - toSend.length
+
+    // Dry run: return count + sample email, send nothing
+    if (dryRun) {
+      const sampleUnsubscribeUrl = 'https://airwaylab.app/api/email/unsubscribe?token=SAMPLE'
+      const sampleA = template.getTemplate(sampleUnsubscribeUrl, 'A')
+      const sampleB = template.getTemplate(sampleUnsubscribeUrl, 'B')
+
+      return NextResponse.json({
+        dryRun: true,
+        templateId,
+        total_opted_in: users.length,
+        already_sent: skipped,
+        would_send: toSend.length,
+        subject_A: sampleA.subject,
+        subject_B: sampleB.subject,
+        sample_html_A: sampleA.html,
+      })
+    }
+
+    // Live send: A/B split on subject line (50/50)
+    let sent = 0
+    const errors: string[] = []
+
+    for (let i = 0; i < toSend.length; i += BATCH_SIZE) {
+      const batch = toSend.slice(i, i + BATCH_SIZE)
+
+      await Promise.all(
+        batch.map(async (user) => {
+          try {
+            const variant: BroadcastSubjectVariant = (i + batch.indexOf(user)) % 2 === 0 ? 'A' : 'B'
+            const unsubscribeUrl = getUnsubscribeUrl(user.id)
+            const { subject, html } = template.getTemplate(unsubscribeUrl, variant)
+
+            await sendEmail({
+              to: user.email,
+              subject,
+              html,
+              replyTo: 'dev@airwaylab.app',
+              unsubscribeUrl,
+              metadata: {
+                emailType: emailType,
+                userId: user.id,
+              },
+            })
+            sent++
+          } catch (err) {
+            const msg = `Failed to send to ${user.email}: ${err}`
+            console.error(`[broadcast] ${msg}`)
+            errors.push(msg)
+          }
+        })
+      )
+
+      if (i + BATCH_SIZE < toSend.length) {
+        await sleep(BATCH_DELAY_MS)
+      }
+    }
+
+    if (errors.length > 0) {
+      Sentry.captureMessage(`Broadcast ${templateId}: some emails failed`, {
+        level: 'warning',
+        extra: { errors, sent, skipped },
+      })
+    }
+
+    return NextResponse.json({
+      dryRun: false,
+      templateId,
+      sent,
+      skipped,
+      errors: errors.length,
+      total_opted_in: users.length,
+    })
+  } catch (err) {
+    console.error('[broadcast] Unexpected error:', err)
+    Sentry.captureException(err, { tags: { action: 'broadcast', templateId } })
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+  }
+}

--- a/lib/email/broadcast.ts
+++ b/lib/email/broadcast.ts
@@ -1,0 +1,106 @@
+/**
+ * Broadcast email templates for AirwayLab.
+ *
+ * One-off emails to all opted-in users. Each broadcast is a named function
+ * returning { subject, html }. The broadcast API route looks up templates
+ * by ID from the BROADCAST_TEMPLATES registry at the bottom.
+ */
+
+import { BASE_URL, ctaButton, paragraph, emailShell } from './helpers'
+
+// ── Broadcast layout (with unsubscribe) ──────────────────────
+
+function broadcastLayout(content: string, unsubscribeUrl: string): string {
+  return emailShell(`
+    ${content}
+
+    <!-- Footer -->
+    <div style="margin-top:40px;padding-top:24px;border-top:1px solid #1e1e21;">
+      <p style="font-size:11px;color:#52525b;line-height:1.6;margin:0;">
+        You're receiving this because you opted in to email updates on
+        <a href="${BASE_URL}" style="color:#5eead4;text-decoration:none;">airwaylab.app</a>.
+      </p>
+      <p style="font-size:11px;color:#52525b;margin:8px 0 0 0;">
+        <a href="${unsubscribeUrl}" style="color:#5eead4;text-decoration:underline;">Unsubscribe</a>
+        from these emails.
+      </p>
+    </div>
+  `)
+}
+
+function smallText(text: string): string {
+  return `<p style="font-size:12px;color:#71717a;line-height:1.6;margin:16px 0 0 0;">${text}</p>`
+}
+
+function subheading(text: string): string {
+  return `<h3 style="font-size:16px;color:#ffffff;font-weight:600;margin:24px 0 8px 0;">${text}</h3>`
+}
+
+// ── March 2026 update broadcast ──────────────────────────────
+
+export type BroadcastSubjectVariant = 'A' | 'B'
+
+function march2026Update(unsubscribeUrl: string, subjectVariant: BroadcastSubjectVariant): { subject: string; html: string } {
+  const subjects: Record<BroadcastSubjectVariant, string> = {
+    A: '130 updates in 2 weeks. Here\'s what changed.',
+    B: 'Your AHI says you\'re fine. Your data says otherwise.',
+  }
+
+  const ANALYZE_URL = `${BASE_URL}/analyze?utm_source=email&utm_medium=broadcast&utm_campaign=march_2026`
+  const PRICING_URL = `${BASE_URL}/pricing?utm_source=email&utm_medium=broadcast&utm_campaign=march_2026`
+  const DISCORD_URL = 'https://discord.gg/DK7aN847Mn'
+  const GETTING_STARTED_URL = `${BASE_URL}/getting-started?utm_source=email&utm_medium=broadcast&utm_campaign=march_2026`
+  const CHANGELOG_URL = `${BASE_URL}/changelog?utm_source=email&utm_medium=broadcast&utm_campaign=march_2026`
+
+  return {
+    subject: subjects[subjectVariant],
+    html: broadcastLayout(`
+      ${paragraph('AirwayLab launched two weeks ago. In that time we\'ve shipped over 130 updates. Here\'s what matters most.')}
+
+      ${subheading('Not just ResMed anymore')}
+      ${paragraph('<strong>BMC Luna 2 and RESmart G2 are now fully supported.</strong> Same analysis engines, same dashboard, same insights. If you\'re on an AirSense 10, AirSense 11, or AirCurve 10, nothing changes for you. But if you know someone on a BMC device who\'s been locked out of tools like this, send them our way.')}
+      ${paragraph('Using a different device? Reply to this email or upload your data and we\'ll capture the file structure automatically. We want to make this accessible for every PAP user, not just ResMed and BMC. More devices are on the roadmap.')}
+
+      ${subheading('New: IFL Symptom Risk')}
+      ${paragraph('A single 0-100% score that answers: <strong>how much is flow limitation actually driving your symptoms?</strong> It combines FL Score, NED, Flatness Index, and Glasgow into one number. Based on research showing flow limitation causes fatigue independently of arousals. If you\'ve had a "normal" AHI for years and still feel terrible, this is the metric to watch.')}
+
+      ${subheading('Community benchmarks')}
+      ${paragraph('After you upload, you\'ll see where your IFL Risk, Glasgow, FL Score, and RERA Index fall compared to other AirwayLab users. Anonymised, no data contribution required. It\'s one thing to see a number. It\'s another to know what that number means relative to everyone else.')}
+
+      ${ctaButton('Upload Your Latest Data', ANALYZE_URL)}
+
+      ${subheading('Where this is going')}
+      ${paragraph('Every night of data that users contribute is building something I\'ve wanted to exist for a long time: <strong>therapy algorithms that learn and adapt to individual breathing patterns.</strong> Not the static pressure responses in today\'s machines, but a system that improves based on what thousands of real nights reveal.')}
+      ${paragraph('The analysis tool you use today is the data foundation for that. More devices, more users, more nights contributed means better algorithms for everyone. That\'s the long game.')}
+
+      ${paragraph('If the free analysis has been useful, <a href="' + PRICING_URL + '" style="color:#5eead4;text-decoration:underline;">Supporter and Champion tiers</a> fund this work. You also get AI insights that explain your specific patterns, cloud backup, PDF clinician reports, and a voice in what gets built next.')}
+
+      ${subheading('Join the premium community')}
+      ${paragraph('Building and maintaining clinical-grade analysis software takes time, and to keep improving AirwayLab we need more supporters. As a way to say thank you and build something great together, we\'ve launched a <a href="' + DISCORD_URL + '" style="color:#5eead4;text-decoration:underline;">premium Discord community</a> for supporters to discuss anything PAP related, share what they\'re seeing in their data, and help shape the roadmap. Champions vote on what gets built next.')}
+
+      ${paragraph('Or just reply to this email. I read everything and I want to know: <strong>what\'s the one thing that would make AirwayLab more useful for your therapy?</strong>')}
+
+      ${paragraph('<span style="color:#a1a1aa;">-- Demian</span>')}
+
+      ${smallText('P.S. New to AirwayLab or tried it once and got lost? There\'s now a <a href="' + GETTING_STARTED_URL + '" style="color:#5eead4;text-decoration:underline;">Getting Started guide</a> and a guided walkthrough that walks you through every tab. And you can see everything we\'ve shipped on the <a href="' + CHANGELOG_URL + '" style="color:#5eead4;text-decoration:underline;">changelog</a>.')}
+
+      ${smallText('AirwayLab is not a medical device. Always discuss therapy changes with your clinician.')}
+    `, unsubscribeUrl),
+  }
+}
+
+// ── Template registry ────────────────────────────────────────
+
+export interface BroadcastTemplate {
+  id: string
+  description: string
+  getTemplate: (unsubscribeUrl: string, subjectVariant: BroadcastSubjectVariant) => { subject: string; html: string }
+}
+
+export const BROADCAST_TEMPLATES: Record<string, BroadcastTemplate> = {
+  march_2026_update: {
+    id: 'march_2026_update',
+    description: 'March 2026 founder letter: IFL Risk, multi-device support, vision, Discord community',
+    getTemplate: march2026Update,
+  },
+}


### PR DESCRIPTION
## Summary
- Broadcast email template (`lib/email/broadcast.ts`) with A/B subject testing
- Admin endpoint (`/api/admin/broadcast`) with dry-run mode, idempotent sends, batched delivery
- March 2026 founder letter: BMC Luna support, IFL Symptom Risk, community benchmarks, vision, premium Discord

## How to send
```bash
# Dry run
curl -X POST https://airwaylab.app/api/admin/broadcast \
  -H "x-admin-secret: $ADMIN_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"templateId": "march_2026_update"}'

# Live send
curl -X POST https://airwaylab.app/api/admin/broadcast \
  -H "x-admin-secret: $ADMIN_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"templateId": "march_2026_update", "dryRun": false}'
```

## Pre-merge checklist
- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] Bundle size impact: negligible (server-only code)
- [ ] Vercel preview deploy verified by Demian
- [x] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)