### PR TITLE
feat: discord alerts for email events

### DIFF
--- a/app/api/admin/broadcast/route.ts
+++ b/app/api/admin/broadcast/route.ts
@@ -25,6 +25,7 @@ import { getSupabaseServiceRole } from '@/lib/supabase/server'
 import { sendEmail } from '@/lib/email/send'
 import { getUnsubscribeUrl } from '@/lib/email/unsubscribe-token'
 import { BROADCAST_TEMPLATES, type BroadcastSubjectVariant } from '@/lib/email/broadcast'
+import { sendAlert, formatBroadcastEmbed } from '@/lib/discord-webhook'
 
 const ADMIN_SECRET = process.env.ADMIN_API_KEY
 const BATCH_SIZE = 10
@@ -162,6 +163,15 @@ export async function POST(request: NextRequest) {
         extra: { errors, sent, skipped },
       })
     }
+
+    // Discord #ops-alerts (fire-and-forget)
+    void sendAlert('ops', '', [formatBroadcastEmbed({
+      templateId: templateId,
+      sent,
+      skipped,
+      errors: errors.length,
+      totalOptedIn: users.length,
+    })])
 
     return NextResponse.json({
       dryRun: false,

--- a/app/api/webhooks/resend/route.ts
+++ b/app/api/webhooks/resend/route.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { getSupabaseServiceRole } from '@/lib/supabase/server'
 import { serverEnv } from '@/lib/env'
 import { cancelAllPending } from '@/lib/email/sequences'
-import { sendAlert, formatUserSignalEmbed } from '@/lib/discord-webhook'
+import { sendAlert, formatEmailAlertEmbed } from '@/lib/discord-webhook'
 
 /**
  * POST /api/webhooks/resend?secret=<RESEND_WEBHOOK_SECRET>
@@ -91,10 +91,11 @@ export async function POST(request: NextRequest) {
         }
 
         // Discord #ops-alerts (fire-and-forget)
-        void sendAlert('ops', '', [formatUserSignalEmbed({
-          type: 'feedback',
-          category: type === 'email.complained' ? 'Spam Complaint' : 'Email Bounce',
-          message: `User ${seqRow.user_id} — pending emails cancelled${type === 'email.complained' ? ', email_opt_in set to false' : ''}`,
+        void sendAlert('ops', '', [formatEmailAlertEmbed({
+          event: type === 'email.complained' ? 'complaint' : 'bounce',
+          email: data.email_id,
+          resendId: data.email_id,
+          userId: seqRow.user_id,
         })])
 
         console.error(

--- a/lib/discord-webhook.ts
+++ b/lib/discord-webhook.ts
@@ -231,6 +231,65 @@ export function formatUserSignalEmbed(opts: {
   }
 }
 
+/** Email bounce/complaint embed for #ops-alerts. */
+export function formatEmailAlertEmbed(opts: {
+  event: 'bounce' | 'complaint'
+  email: string
+  resendId: string
+  userId?: string
+}): DiscordEmbed {
+  const isBounce = opts.event === 'bounce'
+
+  const fields: DiscordEmbedField[] = [
+    { name: 'Email', value: opts.email, inline: true },
+    { name: 'Resend ID', value: opts.resendId, inline: true },
+  ]
+  if (opts.userId) fields.push({ name: 'User ID', value: opts.userId, inline: true })
+  fields.push({
+    name: 'Action taken',
+    value: isBounce
+      ? 'Pending emails cancelled'
+      : 'Pending emails cancelled + unsubscribed',
+    inline: false,
+  })
+
+  return {
+    title: isBounce ? ':warning: Email Bounced' : ':red_circle: Spam Complaint',
+    color: isBounce ? COLORS.amber : COLORS.red,
+    fields,
+    footer: { text: 'Resend webhook' },
+    timestamp: new Date().toISOString(),
+  }
+}
+
+/** Broadcast completion embed for #ops-alerts. */
+export function formatBroadcastEmbed(opts: {
+  templateId: string
+  sent: number
+  skipped: number
+  errors: number
+  totalOptedIn: number
+}): DiscordEmbed {
+  const hasErrors = opts.errors > 0
+  const fields: DiscordEmbedField[] = [
+    { name: 'Template', value: opts.templateId, inline: true },
+    { name: 'Sent', value: String(opts.sent), inline: true },
+    { name: 'Skipped', value: String(opts.skipped), inline: true },
+    { name: 'Errors', value: String(opts.errors), inline: true },
+    { name: 'Total opted in', value: String(opts.totalOptedIn), inline: true },
+  ]
+
+  return {
+    title: hasErrors
+      ? ':warning: Broadcast Sent (with errors)'
+      : ':mega: Broadcast Sent',
+    color: hasErrors ? COLORS.amber : COLORS.green,
+    fields,
+    footer: { text: 'Admin broadcast' },
+    timestamp: new Date().toISOString(),
+  }
+}
+
 /** Data contribution embed for #growth. */
 export function formatGrowthEmbed(opts: {
   event: 'data_contribution' | 'new_signup'


### PR DESCRIPTION
## Summary
- Bounce/complaint alerts to #ops-alerts via dedicated `formatEmailAlertEmbed()`
- Broadcast completion summary to #ops-alerts via `formatBroadcastEmbed()`
- Replaces workaround that used `formatUserSignalEmbed` for email events

## What triggers alerts
| Event | Channel | Embed |
|-------|---------|-------|
| Resend bounce webhook | #ops-alerts | Email + user ID + action taken |
| Resend complaint webhook | #ops-alerts | Email + user ID + unsubscribed |
| Broadcast send completes | #ops-alerts | Template + sent/skipped/errors |

## Pre-merge checklist
- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] Bundle size impact: negligible (server-only)
- [ ] Vercel preview deploy verified by Demian
- [x] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)