### PR TITLE
fix: rate-limit email drip to 1/user/run + Sentry health alert

### DIFF
--- a/lib/email/cron-handler.ts
+++ b/lib/email/cron-handler.ts
@@ -13,6 +13,7 @@
  */
 
 import { SupabaseClient } from '@supabase/supabase-js';
+import * as Sentry from '@sentry/nextjs';
 import {
   getPendingEmails,
   markSent,
@@ -23,6 +24,8 @@ import {
 import { SEQUENCES } from './templates';
 import { getUnsubscribeUrl } from './unsubscribe-token';
 import { sendEmail } from './send';
+
+const OVERDUE_ALERT_THRESHOLD = 20;
 
 interface CronResult {
   sent: number;
@@ -56,10 +59,23 @@ export async function processEmailDrips(supabase: SupabaseClient): Promise<CronR
       acc[e.sequence_name] = (acc[e.sequence_name] || 0) + 1;
       return acc;
     }, {} as Record<string, number>);
-    console.error(`[email-drips] Processing ${pendingEmails.length} emails:`, JSON.stringify(seqCounts));
+    console.error(`[email-drips] ${pendingEmails.length} due emails:`, JSON.stringify(seqCounts));
   }
 
-  for (const email of pendingEmails) {
+  // Rate limit: max 1 email per user per cron run to avoid flooding inboxes
+  // when catching up on overdue emails. Pick the lowest step per user.
+  const seen = new Set<string>();
+  const deduped = pendingEmails.filter((e) => {
+    if (seen.has(e.user_id)) return false;
+    seen.add(e.user_id);
+    return true;
+  });
+
+  if (deduped.length < pendingEmails.length) {
+    console.error(`[email-drips] Rate limited: ${pendingEmails.length} due -> ${deduped.length} to send (1/user/run)`);
+  }
+
+  for (const email of deduped) {
     const config = SEQUENCES[email.sequence_name];
     if (!config) {
       console.error(`[email-drips] No SEQUENCES config for: ${email.sequence_name}`);
@@ -92,6 +108,19 @@ export async function processEmailDrips(supabase: SupabaseClient): Promise<CronR
 
   // 3. Apply sunset policy for persistently unengaged users
   result.sunsetted = await applySunsetPolicy(supabase);
+
+  // 4. Health check: alert if drip system looks broken
+  const { count: overdueCount } = await supabase
+    .from('email_sequences')
+    .select('*', { count: 'exact', head: true })
+    .eq('status', 'pending')
+    .lte('scheduled_at', new Date().toISOString());
+
+  if (overdueCount && overdueCount > OVERDUE_ALERT_THRESHOLD) {
+    const msg = `Email drip health check: ${overdueCount} overdue emails after processing (sent=${result.sent}, failed=${result.failed}). Threshold: ${OVERDUE_ALERT_THRESHOLD}.`;
+    console.error(`[email-drips] ALERT: ${msg}`);
+    Sentry.captureMessage(msg, { level: 'warning', tags: { subsystem: 'email-drips' } });
+  }
 
   return result;
 }


### PR DESCRIPTION
## Summary

Follow-up to #328 (email drip FK fix). Prevents inbox flooding and adds monitoring.

### Rate limiting (prevents overload)
- Each user receives max 1 email per cron run
- When catching up on 81 overdue emails, users get their step 1 today, step 2 tomorrow
- Logs when rate limiting activates

### Stale follow-up cleanup (already applied via SQL)
- Cancelled 35 step-2+ emails where step 1 was never delivered
- Example: activation step 2 ("this is our last email") makes no sense if step 1 never arrived

### Health monitoring (prevents recurrence)
- After each cron run, counts remaining overdue emails
- If >20 overdue: fires Sentry warning with sent/failed/overdue counts
- The "0 sent for 18 days" scenario would trigger an alert within 24h

## What users will receive tomorrow

| Sequence | Users | Email content |
|----------|-------|---------------|
| activation step 1 | 34 | "Need help uploading your SD card data?" |
| post_upload step 2 | 28 | "One night is a snapshot" |
| post_upload step 3 | 12 | "The metric your clinician wants to see" |
| dormancy step 1 | 3 | "How's your therapy going this month?" |
| premium_onboarding step 1 | 3 | "Here's what's different now" |
| feature_education step 2 | 1 | "Share your results with your clinician" |

Each person gets exactly 1 email. No flooding.

## Test plan
- [ ] Verify rate limiting: trigger cron, check logs for "Rate limited: X due -> Y to send"
- [ ] Verify Sentry alert fires when overdue > 20 (will fire on first run since 81 are overdue)
- [ ] After 2 cron cycles: verify all overdue emails cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)