### PR TITLE
feat: educational context for premium AI insights

### DIFF
--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -59,7 +59,14 @@ In addition to the standard categories, you may use these categories for premium
 - "correlation": Cross-engine correlations (e.g. Glasgow flat-top + high NED suggests steady-state FL; WAT periodicity + oximetry ODI coupling suggests central component)
 - "temporal": Time-based patterns (e.g. progressive FL worsening across H1→H2, periodic clustering at specific intervals, REM-associated breath shape changes, positional transitions visible in H1/H2 splits)
 
-Prioritise correlation and temporal insights — these are the analysis patterns that go beyond what rule-based systems detect.`;
+Prioritise correlation and temporal insights — these are the analysis patterns that go beyond what rule-based systems detect.
+
+For every warning or actionable insight, include a "context" field (2-3 sentences) providing educational background:
+- What factors commonly contribute to this finding (e.g. mask fit, sleep position, pressure settings, nasal congestion, medication effects)
+- What areas the user could explore or discuss with their clinician
+- Frame as educational and informational ("common contributing factors include...", "areas worth exploring..."), NEVER as therapy recommendations ("change X to Y", "try setting X to N")
+- The context helps users understand WHY a metric is elevated, not WHAT to change about their therapy
+Do not include the "context" field on positive or info insights — only on warning and actionable.`;
 
 // Model selection based on user tier
 const MODEL_COMMUNITY = 'claude-haiku-4-5-20251001';

--- a/components/dashboard/insights-panel.tsx
+++ b/components/dashboard/insights-panel.tsx
@@ -118,6 +118,16 @@ export function InsightsPanel({
                       <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
                         {insight.body}
                       </p>
+                      {insight.context && (
+                        <details className="mt-1.5 group/ctx">
+                          <summary className="cursor-pointer text-[11px] font-medium text-primary/70 hover:text-primary">
+                            Understanding this finding
+                          </summary>
+                          <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground/80">
+                            {insight.context}
+                          </p>
+                        </details>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -23,6 +23,8 @@ export interface Insight {
   category: 'glasgow' | 'wat' | 'ned' | 'oximetry' | 'therapy' | 'trend' | 'settings' | 'correlation' | 'temporal';
   /** Optional link for further reading */
   link?: { text: string; href: string };
+  /** Educational context explaining contributing factors (premium AI only) */
+  context?: string;
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- Premium AI insights now include an expandable "Understanding this finding" section on warning/actionable insights
- Explains common contributing factors (mask fit, sleep position, pressure settings, etc.) without prescribing specific changes
- Legally safe: educational framing ("common factors include...") rather than therapeutic recommendations ("change X to Y")

Addresses FB-6 (actionable guidance gap, 2 user requests) with the legally safe Option A approach.

## Changes (20 lines, 3 files)
- `lib/insights.ts`: Added optional `context` field to `Insight` interface
- `app/api/ai-insights/route.ts`: Extended premium prompt to request educational context on warning/actionable insights
- `components/dashboard/insights-panel.tsx`: Expandable `<details>` section renders context below insight body

## Test plan
- [ ] Vercel preview deploy verified by Demian
- [ ] Premium account: generate AI insights → warning/actionable insights show "Understanding this finding" expandable
- [ ] Community account: no `context` field appears (prompt extension is premium-only)
- [ ] Expandable section opens/closes cleanly, text is readable

### Pre-Merge Checklist
- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [x] Self-review: no regressions, loading/error/empty states handled
- [x] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)