### PR TITLE
fix: capture machine RERA events + persist settingsMetrics

### DIFF
--- a/lib/parsers/eve-parser.ts
+++ b/lib/parsers/eve-parser.ts
@@ -12,7 +12,7 @@ interface MachineEvent {
   /** Raw annotation label from EVE.edf */
   rawLabel: string;
   /** Normalised event type */
-  type: 'obstructive-apnea' | 'central-apnea' | 'hypopnea' | 'unclassified-apnea';
+  type: 'obstructive-apnea' | 'central-apnea' | 'hypopnea' | 'unclassified-apnea' | 'rera';
 }
 
 /** Map lowercase annotation labels to normalised event types */
@@ -21,6 +21,8 @@ const LABEL_MAP: Record<string, MachineEvent['type']> = {
   'central apnea': 'central-apnea',
   'hypopnea': 'hypopnea',
   'apnea': 'unclassified-apnea',
+  'rera': 'rera',
+  'arousal': 'rera',
 };
 
 /** Labels to silently skip (not events) */

--- a/lib/persistence.ts
+++ b/lib/persistence.ts
@@ -39,7 +39,7 @@ function stripBulkData(nights: NightResult[]): NightResult[] {
       breaths: [], // per-breath array can be huge — not needed for persistence
     },
     oximetryTrace: null, // trace data too large for localStorage — re-extract on demand
-    settingsMetrics: null,
+    // settingsMetrics is a small summary object — keep it for persistence
   }));
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -261,6 +261,10 @@ export interface NEDResults {
   hypopneaH1Index?: number;
   hypopneaH2Index?: number;
 
+  // Machine RERA metrics (from EVE.edf)
+  machineReraCount?: number;
+  machineReraIndex?: number;
+
   // Brief obstruction metrics (v0.7.0+)
   briefObstructionCount?: number;
   briefObstructionIndex?: number;

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -216,6 +216,7 @@ async function processFiles(
   // Step 3.5: Parse EVE.edf files and group events by night date
   const eveFileInfos = filterEVEFiles(fileList);
   const eveEventsByDate = new Map<string, MachineHypopneaSummary[]>();
+  const eveReraCountByDate = new Map<string, number>();
   for (const eveInfo of eveFileInfos) {
     const fileData = files.find((f) => f.path === eveInfo.path);
     if (!fileData) continue;
@@ -230,6 +231,10 @@ async function processFiles(
         const existing = eveEventsByDate.get(nightDate) ?? [];
         existing.push(...hypopneas);
         eveEventsByDate.set(nightDate, existing);
+      }
+      const reraCount = events.filter((e) => e.type === 'rera').length;
+      if (reraCount > 0) {
+        eveReraCountByDate.set(nightDate, (eveReraCountByDate.get(nightDate) ?? 0) + reraCount);
       }
     } catch (err) {
       const filename = eveInfo.path.split('/').pop() || eveInfo.path;
@@ -385,6 +390,15 @@ async function processFiles(
     // Machine hypopnea events for this night (from EVE.edf)
     const machineHypopneas = eveEventsByDate.get(group.nightDate);
     const ned = computeNED(combinedFlow, avgSamplingRate, machineHypopneas);
+
+    // Machine RERA events (from EVE.edf) — count and index
+    const machineReraCount = eveReraCountByDate.get(group.nightDate) ?? 0;
+    if (machineReraCount > 0) {
+      ned.machineReraCount = machineReraCount;
+      ned.machineReraIndex = totalDuration > 0
+        ? Math.round((machineReraCount / (totalDuration / 3600)) * 100) / 100
+        : 0;
+    }
 
     // Recording date from first session
     const recordingDate = group.sessions[0]!.recordingDate;


### PR DESCRIPTION
## Summary
- **EVE parser**: Add 'rera' and 'arousal' annotation labels to the LABEL_MAP, mapping both to the new 'rera' event type. These were previously silently dropped.
- **Worker**: Extract RERA event counts per night from parsed EVE events and populate `machineReraCount` / `machineReraIndex` on NEDResults (same pattern as machineHypopneas).
- **Types**: Add `machineReraCount?: number` and `machineReraIndex?: number` to `NEDResults` interface.
- **Persistence**: Stop nullifying `settingsMetrics` in `stripBulkData()` — it's a small summary object (~30 fields), not bulk data like breath arrays or oximetry traces.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (1442 tests, 0 failures)
- [x] `npm run build` passes
- [ ] Upload SD card data with EVE.edf files containing RERA/arousal annotations and verify `machineReraCount`/`machineReraIndex` appear in NED results
- [ ] Upload data, verify settingsMetrics survives localStorage round-trip (persist -> reload page -> check settings metrics are present)
- [ ] Verify no regression on existing dashboard tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)