### PR TITLE
feat: add CSL parser for Cheyne-Stokes events + expand STR nightly statistics

### DIFF
--- a/__tests__/ai-credits-tracking.test.ts
+++ b/__tests__/ai-credits-tracking.test.ts
@@ -106,7 +106,7 @@ describe('AI Credits Tracking — API response parsing', () => {
       oximetry: null,
       oximetryTrace: null,
       settingsMetrics: null,
-      crossDevice: null, machineSummary: null, settingsFingerprint: null,
+      crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
     }] as never[];
 
     const result = await fetchAIInsights(nights, 0, null);
@@ -141,7 +141,7 @@ describe('AI Credits Tracking — API response parsing', () => {
       oximetry: null,
       oximetryTrace: null,
       settingsMetrics: null,
-      crossDevice: null, machineSummary: null, settingsFingerprint: null,
+      crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
     }] as never[];
 
     const result = await fetchAIInsights(nights, 0, null);
@@ -173,7 +173,7 @@ describe('AI Credits Tracking — API response parsing', () => {
       oximetry: null,
       oximetryTrace: null,
       settingsMetrics: null,
-      crossDevice: null, machineSummary: null, settingsFingerprint: null,
+      crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
     }] as never[];
 
     await expect(fetchAIInsights(nights, 0, null)).rejects.toThrow('AI service error');

--- a/__tests__/analysis-orchestrator.test.ts
+++ b/__tests__/analysis-orchestrator.test.ts
@@ -178,7 +178,7 @@ function makeNight(
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
     ...overrides,
   };
 }

--- a/__tests__/clinician-questions.test.ts
+++ b/__tests__/clinician-questions.test.ts
@@ -153,7 +153,7 @@ function makeNight(overrides?: {
     oximetry: overrides?.oximetry === null ? null : makeOximetry(overrides?.oximetry),
     oximetryTrace: null,
     settingsMetrics: overrides?.settingsMetrics === null ? null : makeSettingsMetrics(overrides?.settingsMetrics),
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
   };
 }
 

--- a/__tests__/contribute.test.ts
+++ b/__tests__/contribute.test.ts
@@ -77,7 +77,7 @@ function makeNight(dateStr: string): NightResult {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
   } as unknown as NightResult;
 }
 

--- a/__tests__/csl-parser.test.ts
+++ b/__tests__/csl-parser.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import { parseCSL } from '@/lib/parsers/csl-parser';
+import { filterCSLFiles } from '@/lib/parsers/night-grouper';
+
+// ============================================================
+// Helpers — build synthetic CSL.edf files with EDF+ Annotations
+// ============================================================
+
+/**
+ * Build a minimal valid EDF+ Annotations buffer containing CSR annotations.
+ * Follows the same TAL (Time-stamped Annotation List) format as EVE.edf.
+ */
+function buildCSLBuffer(annotations: { onset: number; label: string }[], options?: {
+  numDataRecords?: number;
+  recordDuration?: number;
+}): ArrayBuffer {
+  const numDataRecords = options?.numDataRecords ?? 1;
+  const recordDuration = options?.recordDuration ?? 3600; // 1 hour default
+
+  // Build annotation bytes as TAL format:
+  // For timekeeping: +onset\x14\x14\x00
+  // For event annotations: +onset\x14label\x14\x00
+  const annotParts: string[] = [];
+
+  // Add timekeeping TAL first (like real EDF+ files)
+  annotParts.push(`+0\x14\x14\x00`);
+
+  for (const ann of annotations) {
+    // CSR annotations use onset-only TAL (no duration separator \x15)
+    annotParts.push(`+${ann.onset}\x14${ann.label}\x14\x00`);
+  }
+
+  const annotString = annotParts.join('');
+  const annotBytes = new TextEncoder().encode(annotString);
+
+  // Pad to even number of bytes (EDF requires int16 samples)
+  const paddedSize = Math.ceil(annotBytes.length / 2) * 2;
+
+  // EDF header: 256 bytes fixed + 256 bytes per signal (1 signal)
+  const numSignals = 1;
+  const headerBytes = 256 + numSignals * 256;
+  const samplesPerRecord = paddedSize / 2;
+  const dataSize = numDataRecords * paddedSize;
+  const totalSize = headerBytes + dataSize;
+
+  const buf = new ArrayBuffer(totalSize);
+  const view = new Uint8Array(buf);
+  const encoder = new TextEncoder();
+
+  // Fixed header (256 bytes)
+  writeField(view, encoder, 0, '0       ', 8);                      // version
+  writeField(view, encoder, 8, '                                                                                ', 80); // patientId
+  writeField(view, encoder, 88, '                                                                                ', 80); // recordingId
+  writeField(view, encoder, 168, '01.01.26', 8);                    // startDate
+  writeField(view, encoder, 176, '22.00.00', 8);                    // startTime
+  writeField(view, encoder, 184, String(headerBytes).padEnd(8), 8); // headerBytes
+  writeField(view, encoder, 192, 'EDF+C'.padEnd(44), 44);           // reserved (EDF+C = continuous)
+  writeField(view, encoder, 236, String(numDataRecords).padEnd(8), 8); // numDataRecords
+  writeField(view, encoder, 244, String(recordDuration).padEnd(8), 8); // recordDuration
+  writeField(view, encoder, 252, String(numSignals).padEnd(4), 4);  // numSignals
+
+  // Signal header (256 bytes for 1 signal)
+  const sigBase = 256;
+  writeField(view, encoder, sigBase, 'EDF Annotations '.padEnd(16), 16); // label
+  writeField(view, encoder, sigBase + 16, ''.padEnd(80), 80);        // transducer
+  writeField(view, encoder, sigBase + 96, ''.padEnd(8), 8);          // physical dimension
+  writeField(view, encoder, sigBase + 104, '-1      ', 8);           // physical min
+  writeField(view, encoder, sigBase + 112, '1       ', 8);           // physical max
+  writeField(view, encoder, sigBase + 120, '-32768  ', 8);           // digital min
+  writeField(view, encoder, sigBase + 128, '32767   ', 8);           // digital max
+  writeField(view, encoder, sigBase + 136, ''.padEnd(80), 80);       // prefiltering
+  writeField(view, encoder, sigBase + 216, String(samplesPerRecord).padEnd(8), 8); // numSamples
+  writeField(view, encoder, sigBase + 224, ''.padEnd(32), 32);       // reserved
+
+  // Data records — write annotation bytes
+  for (let rec = 0; rec < numDataRecords; rec++) {
+    const offset = headerBytes + rec * paddedSize;
+    if (rec === 0) {
+      view.set(annotBytes, offset);
+    }
+    // Other records are zero-filled (no annotations)
+  }
+
+  return buf;
+}
+
+function writeField(view: Uint8Array, encoder: TextEncoder, offset: number, value: string, length: number): void {
+  const bytes = encoder.encode(value.padEnd(length).slice(0, length));
+  view.set(bytes, offset);
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('CSL Parser', () => {
+  describe('parseCSL — paired CSR episodes', () => {
+    it('parses paired CSR Start / CSR End annotations', () => {
+      const result = parseCSL(buildCSLBuffer([
+        { onset: 100, label: 'CSR Start' },
+        { onset: 400, label: 'CSR End' },
+        { onset: 1000, label: 'CSR Start' },
+        { onset: 1200, label: 'CSR End' },
+      ]));
+
+      expect(result).not.toBeNull();
+      expect(result!.episodeCount).toBe(2);
+      expect(result!.episodes[0]!.startSec).toBe(100);
+      expect(result!.episodes[0]!.endSec).toBe(400);
+      expect(result!.episodes[0]!.durationSec).toBe(300);
+      expect(result!.episodes[1]!.startSec).toBe(1000);
+      expect(result!.episodes[1]!.endSec).toBe(1200);
+      expect(result!.episodes[1]!.durationSec).toBe(200);
+    });
+
+    it('computes totalCSRSeconds as sum of episode durations', () => {
+      const result = parseCSL(buildCSLBuffer([
+        { onset: 100, label: 'CSR Start' },
+        { onset: 400, label: 'CSR End' },
+        { onset: 1000, label: 'CSR Start' },
+        { onset: 1200, label: 'CSR End' },
+      ]));
+
+      expect(result).not.toBeNull();
+      expect(result!.totalCSRSeconds).toBe(500); // 300 + 200
+    });
+
+    it('computes csrPercentage correctly', () => {
+      const result = parseCSL(buildCSLBuffer([
+        { onset: 0, label: 'CSR Start' },
+        { onset: 360, label: 'CSR End' },
+      ], { recordDuration: 3600, numDataRecords: 1 }));
+
+      expect(result).not.toBeNull();
+      // 360 / 3600 * 100 = 10%
+      expect(result!.csrPercentage).toBe(10);
+    });
+  });
+
+  describe('parseCSL — unpaired CSR Start', () => {
+    it('estimates end as recording end when session ends during CSR', () => {
+      const result = parseCSL(buildCSLBuffer([
+        { onset: 3000, label: 'CSR Start' },
+        // No CSR End — session ended during CSR
+      ], { recordDuration: 3600, numDataRecords: 1 }));
+
+      expect(result).not.toBeNull();
+      expect(result!.episodeCount).toBe(1);
+      expect(result!.episodes[0]!.startSec).toBe(3000);
+      expect(result!.episodes[0]!.endSec).toBe(3600);
+      expect(result!.episodes[0]!.durationSec).toBe(600);
+    });
+  });
+
+  describe('parseCSL — orphan CSR End', () => {
+    it('ignores CSR End without preceding CSR Start', () => {
+      const result = parseCSL(buildCSLBuffer([
+        { onset: 100, label: 'CSR End' },
+        { onset: 500, label: 'CSR Start' },
+        { onset: 700, label: 'CSR End' },
+      ]));
+
+      expect(result).not.toBeNull();
+      expect(result!.episodeCount).toBe(1);
+      expect(result!.episodes[0]!.startSec).toBe(500);
+      expect(result!.episodes[0]!.endSec).toBe(700);
+    });
+  });
+
+  describe('parseCSL — error resilience', () => {
+    it('returns null for truncated buffer', () => {
+      expect(parseCSL(new ArrayBuffer(10))).toBeNull();
+    });
+
+    it('returns null for empty buffer', () => {
+      expect(parseCSL(new ArrayBuffer(0))).toBeNull();
+    });
+
+    it('returns null for buffer with no EDF Annotations signal', () => {
+      const buf = new ArrayBuffer(768);
+      const view = new Uint8Array(buf);
+      const encoder = new TextEncoder();
+      writeField(view, encoder, 0, '0       ', 8);
+      writeField(view, encoder, 252, '1   ', 4);
+      writeField(view, encoder, 256, 'SomeOther       ', 16);
+      writeField(view, encoder, 184, '512     ', 8);
+      writeField(view, encoder, 236, '0       ', 8);
+      writeField(view, encoder, 244, '0.00    ', 8);
+
+      expect(parseCSL(buf)).toBeNull();
+    });
+  });
+
+  describe('parseCSL — empty file', () => {
+    it('returns empty episodes when no CSR annotations present', () => {
+      const result = parseCSL(buildCSLBuffer([]));
+
+      expect(result).not.toBeNull();
+      expect(result!.episodeCount).toBe(0);
+      expect(result!.episodes).toHaveLength(0);
+      expect(result!.totalCSRSeconds).toBe(0);
+      expect(result!.csrPercentage).toBe(0);
+    });
+  });
+
+  describe('parseCSL — skips Recording starts', () => {
+    it('ignores Recording starts annotation', () => {
+      const result = parseCSL(buildCSLBuffer([
+        { onset: 500, label: 'CSR Start' },
+        { onset: 700, label: 'CSR End' },
+      ]));
+
+      // The timekeeping TAL is included in buildCSLBuffer already
+      expect(result).not.toBeNull();
+      expect(result!.episodeCount).toBe(1);
+    });
+  });
+});
+
+describe('filterCSLFiles', () => {
+  it('matches _CSL.edf files', () => {
+    const files = [
+      { name: '20260111_210642_CSL.edf', path: 'DATALOG/20260111/20260111_210642_CSL.edf', size: 1000 },
+      { name: '20260111_210642_BRP.edf', path: 'DATALOG/20260111/20260111_210642_BRP.edf', size: 500000 },
+      { name: 'STR.edf', path: 'STR.edf', size: 10000 },
+    ];
+
+    const result = filterCSLFiles(files);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe('20260111_210642_CSL.edf');
+  });
+
+  it('matches case-insensitively', () => {
+    const files = [
+      { name: '20260111_210642_csl.edf', path: 'test/20260111_210642_csl.edf', size: 500 },
+      { name: '20260111_210642_CSL.EDF', path: 'test/20260111_210642_CSL.EDF', size: 500 },
+    ];
+
+    const result = filterCSLFiles(files);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array when no CSL files', () => {
+    const files = [
+      { name: 'BRP.edf', path: 'test/BRP.edf', size: 500000 },
+      { name: 'STR.edf', path: 'test/STR.edf', size: 10000 },
+    ];
+
+    const result = filterCSLFiles(files);
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not match partial CSL in filename', () => {
+    const files = [
+      { name: 'EXCLUSION_CSL.edf', path: 'test/EXCLUSION_CSL.edf', size: 500 },
+      { name: 'CSLDATA.edf', path: 'test/CSLDATA.edf', size: 500 },
+    ];
+
+    // EXCLUSION_CSL.edf ends with _CSL.edf so it should match
+    // CSLDATA.edf does not end with CSL.edf properly
+    const result = filterCSLFiles(files);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe('EXCLUSION_CSL.edf');
+  });
+});

--- a/__tests__/dashboard-ux-beginner-friendly.test.tsx
+++ b/__tests__/dashboard-ux-beginner-friendly.test.tsx
@@ -73,7 +73,7 @@ function makeNight(overrides: {
     } : null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
   };
 }
 

--- a/__tests__/date-sort-default.test.ts
+++ b/__tests__/date-sort-default.test.ts
@@ -36,7 +36,7 @@ function makeNight(dateStr: string, glasgowOverall: number): NightResult {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
   };
 }
 

--- a/__tests__/graphs-tab-always-show-data.test.ts
+++ b/__tests__/graphs-tab-always-show-data.test.ts
@@ -61,7 +61,7 @@ function makeNight(dateStr: string, glasgowOverall = 2.5): NightResult {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
   };
 }
 

--- a/__tests__/ifl-risk.test.ts
+++ b/__tests__/ifl-risk.test.ts
@@ -66,7 +66,7 @@ function makeNight(overrides: {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
   };
 }
 

--- a/__tests__/machine-summary-extractor.test.ts
+++ b/__tests__/machine-summary-extractor.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest';
+import { extractMachineSummary } from '@/lib/parsers/machine-summary-extractor';
+
+// ============================================================
+// Helpers — build synthetic STR.edf buffers
+// ============================================================
+
+/**
+ * Build a minimal STR.edf buffer with specified signal labels and daily values.
+ * Each signal has 1 sample per data record. Each data record = 1 day.
+ */
+function buildSTRBuffer(
+  signalDefs: { label: string; values: number[]; physMin?: number; physMax?: number }[]
+): ArrayBuffer {
+  // Always include Date signal (required for extractMachineSummary)
+  const allSignals = signalDefs;
+  const numSignals = allSignals.length;
+  const numDataRecords = allSignals[0]?.values.length ?? 1;
+  const samplesPerRecord = 1; // 1 sample per signal per record
+  const headerBytes = 256 + numSignals * 256;
+  const dataSize = numDataRecords * numSignals * samplesPerRecord * 2; // int16
+  const totalSize = headerBytes + dataSize;
+
+  const buf = new ArrayBuffer(totalSize);
+  const view = new DataView(buf);
+  const rawView = new Uint8Array(buf);
+  const encoder = new TextEncoder();
+
+  // Fixed header (256 bytes)
+  writeField(rawView, encoder, 0, '0', 8);
+  writeField(rawView, encoder, 8, '', 80);   // patientId
+  writeField(rawView, encoder, 88, '', 80);  // recordingId
+  writeField(rawView, encoder, 168, '01.01.26', 8); // startDate
+  writeField(rawView, encoder, 176, '00.00.00', 8); // startTime
+  writeField(rawView, encoder, 184, String(headerBytes), 8);
+  writeField(rawView, encoder, 192, '', 44); // reserved
+  writeField(rawView, encoder, 236, String(numDataRecords), 8);
+  writeField(rawView, encoder, 244, '86400', 8); // recordDuration = 1 day in seconds
+  writeField(rawView, encoder, 252, String(numSignals), 4);
+
+  // Per-signal header fields (in blocks of numSignals)
+  let offset = 256;
+
+  // Labels (16 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(rawView, encoder, offset + i * 16, allSignals[i]!.label, 16);
+  }
+  offset += numSignals * 16;
+
+  // Transducers (80 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(rawView, encoder, offset + i * 80, '', 80);
+  }
+  offset += numSignals * 80;
+
+  // Physical dimension (8 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(rawView, encoder, offset + i * 8, '', 8);
+  }
+  offset += numSignals * 8;
+
+  // Physical min (8 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    const physMin = allSignals[i]!.physMin ?? 0;
+    writeField(rawView, encoder, offset + i * 8, String(physMin), 8);
+  }
+  offset += numSignals * 8;
+
+  // Physical max (8 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    const physMax = allSignals[i]!.physMax ?? 100;
+    writeField(rawView, encoder, offset + i * 8, String(physMax), 8);
+  }
+  offset += numSignals * 8;
+
+  // Digital min (8 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(rawView, encoder, offset + i * 8, '0', 8);
+  }
+  offset += numSignals * 8;
+
+  // Digital max (8 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(rawView, encoder, offset + i * 8, '32767', 8);
+  }
+  offset += numSignals * 8;
+
+  // Prefiltering (80 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(rawView, encoder, offset + i * 80, '', 80);
+  }
+  offset += numSignals * 80;
+
+  // Samples per record (8 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(rawView, encoder, offset + i * 8, String(samplesPerRecord), 8);
+  }
+  offset += numSignals * 8;
+
+  // Reserved (32 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(rawView, encoder, offset + i * 32, '', 32);
+  }
+
+  // Data records — write int16 values
+  // Physical value = (digital - digMin) * scale + physMin
+  // So digital = (physical - physMin) / scale + digMin
+  // Where scale = (physMax - physMin) / (digMax - digMin) = (physMax - physMin) / 32767
+  let dataPtr = headerBytes;
+  for (let rec = 0; rec < numDataRecords; rec++) {
+    for (let sig = 0; sig < numSignals; sig++) {
+      const physMin = allSignals[sig]!.physMin ?? 0;
+      const physMax = allSignals[sig]!.physMax ?? 100;
+      const scale = (physMax - physMin) / 32767;
+      const physical = allSignals[sig]!.values[rec] ?? 0;
+      const digital = Math.round((physical - physMin) / scale);
+      view.setInt16(dataPtr, digital, true);
+      dataPtr += 2;
+    }
+  }
+
+  return buf;
+}
+
+function writeField(view: Uint8Array, encoder: TextEncoder, offset: number, value: string, length: number): void {
+  const padded = value.padEnd(length).slice(0, length);
+  const bytes = encoder.encode(padded);
+  view.set(bytes, offset);
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('extractMachineSummary', () => {
+  it('extracts AHI and event indices from STR signals', () => {
+    const buf = buildSTRBuffer([
+      { label: 'Date', values: [0], physMin: 0, physMax: 36500 },
+      { label: 'AHI', values: [5.3], physMin: 0, physMax: 100 },
+      { label: 'OAI', values: [2.1], physMin: 0, physMax: 100 },
+      { label: 'CAI', values: [1.0], physMin: 0, physMax: 100 },
+    ]);
+
+    const result = extractMachineSummary(buf, 'AirSense 11');
+    const dates = Object.keys(result);
+    expect(dates).toHaveLength(1);
+
+    const day = result[dates[0]!]!;
+    expect(day.ahi).toBeCloseTo(5.3, 1);
+    expect(day.oai).toBeCloseTo(2.1, 1);
+    expect(day.cai).toBeCloseTo(1.0, 1);
+  });
+
+  it('extracts new RIN (RERA index) signal', () => {
+    const buf = buildSTRBuffer([
+      { label: 'Date', values: [0], physMin: 0, physMax: 36500 },
+      { label: 'RIN', values: [8.5], physMin: 0, physMax: 100 },
+    ]);
+
+    const result = extractMachineSummary(buf, 'AirSense 11');
+    const day = Object.values(result)[0]!;
+    expect(day.reraIndex).toBeCloseTo(8.5, 1);
+  });
+
+  it('extracts new CSR (Cheyne-Stokes %) signal', () => {
+    const buf = buildSTRBuffer([
+      { label: 'Date', values: [0], physMin: 0, physMax: 36500 },
+      { label: 'CSR', values: [12.3], physMin: 0, physMax: 100 },
+    ]);
+
+    const result = extractMachineSummary(buf, 'AirSense 11');
+    const day = Object.values(result)[0]!;
+    expect(day.csrPercentage).toBeCloseTo(12.3, 1);
+  });
+
+  it('extracts new MaskPress.Max signal', () => {
+    const buf = buildSTRBuffer([
+      { label: 'Date', values: [0], physMin: 0, physMax: 36500 },
+      { label: 'MaskPress.Max', values: [18.5], physMin: 0, physMax: 30 },
+    ]);
+
+    const result = extractMachineSummary(buf, 'AirSense 11');
+    const day = Object.values(result)[0]!;
+    expect(day.maskPressMax).toBeCloseTo(18.5, 1);
+  });
+
+  it('defaults missing signals to null', () => {
+    const buf = buildSTRBuffer([
+      { label: 'Date', values: [0], physMin: 0, physMax: 36500 },
+      { label: 'AHI', values: [3.0], physMin: 0, physMax: 100 },
+    ]);
+
+    const result = extractMachineSummary(buf, 'AirSense 11');
+    const day = Object.values(result)[0]!;
+    expect(day.reraIndex).toBeNull();
+    expect(day.csrPercentage).toBeNull();
+    expect(day.maskPressMax).toBeNull();
+    expect(day.leak50).toBeNull();
+    expect(day.spo2_50).toBeNull();
+  });
+
+  it('extracts fault flags correctly', () => {
+    const buf = buildSTRBuffer([
+      { label: 'Date', values: [0], physMin: 0, physMax: 36500 },
+      { label: 'Fault.Device', values: [1], physMin: 0, physMax: 1 },
+      { label: 'Fault.Alarm', values: [0], physMin: 0, physMax: 1 },
+      { label: 'Fault.Humidifier', values: [1], physMin: 0, physMax: 1 },
+      { label: 'Fault.HeatedTube', values: [0], physMin: 0, physMax: 1 },
+    ]);
+
+    const result = extractMachineSummary(buf, 'AirSense 11');
+    const day = Object.values(result)[0]!;
+    expect(day.faultDevice).toBe(true);
+    expect(day.faultAlarm).toBe(false);
+    expect(day.faultHumidifier).toBe(true);
+    expect(day.faultHeatedTube).toBe(false);
+    expect(day.anyFault).toBe(true);
+  });
+
+  it('extracts multiple days from multi-record STR', () => {
+    const buf = buildSTRBuffer([
+      { label: 'Date', values: [0, 1, 2], physMin: 0, physMax: 36500 },
+      { label: 'AHI', values: [3.0, 5.0, 2.0], physMin: 0, physMax: 100 },
+      { label: 'RIN', values: [4.0, 6.0, 3.0], physMin: 0, physMax: 100 },
+    ]);
+
+    const result = extractMachineSummary(buf, 'AirSense 11');
+    expect(Object.keys(result)).toHaveLength(3);
+
+    const days = Object.values(result);
+    expect(days[0]!.ahi).toBeCloseTo(3.0, 1);
+    expect(days[0]!.reraIndex).toBeCloseTo(4.0, 1);
+    expect(days[1]!.ahi).toBeCloseTo(5.0, 1);
+    expect(days[1]!.reraIndex).toBeCloseTo(6.0, 1);
+    expect(days[2]!.ahi).toBeCloseTo(2.0, 1);
+    expect(days[2]!.reraIndex).toBeCloseTo(3.0, 1);
+  });
+
+  it('returns empty object when Date signal is missing', () => {
+    const buf = buildSTRBuffer([
+      { label: 'AHI', values: [5.0], physMin: 0, physMax: 100 },
+    ]);
+
+    const result = extractMachineSummary(buf, 'AirSense 11');
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('clamps negative event indices to zero', () => {
+    // Digital-to-physical conversion can sometimes produce small negatives
+    const buf = buildSTRBuffer([
+      { label: 'Date', values: [0], physMin: 0, physMax: 36500 },
+      { label: 'AHI', values: [0], physMin: -0.1, physMax: 100 },
+    ]);
+
+    const result = extractMachineSummary(buf, 'AirSense 11');
+    const day = Object.values(result)[0]!;
+    // The actual value might be slightly negative due to quantization, but should be clamped to 0
+    expect(day.ahi).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/__tests__/metric-reliability.test.ts
+++ b/__tests__/metric-reliability.test.ts
@@ -139,6 +139,7 @@ function makeNight(dateStr: string, settings: Partial<MachineSettings> = {}): Ni
     crossDevice: null,
     machineSummary: null,
     settingsFingerprint: computeFingerprint(s),
+    csl: null,
   };
 }
 

--- a/__tests__/night-summary-hero.test.tsx
+++ b/__tests__/night-summary-hero.test.tsx
@@ -57,7 +57,7 @@ function makeNight(overrides: {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
   };
 }
 

--- a/__tests__/settings-timeline.test.tsx
+++ b/__tests__/settings-timeline.test.tsx
@@ -41,7 +41,7 @@ function makeNight(dateStr: string, settings?: Partial<MachineSettings>): NightR
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
   };
 }
 

--- a/__tests__/share-strip-bulk.test.ts
+++ b/__tests__/share-strip-bulk.test.ts
@@ -14,7 +14,7 @@ function stripForShare(nights: NightResult[]): NightResult[] {
     },
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
   }));
 }
 
@@ -49,7 +49,7 @@ function makeNight(overrides: Partial<NightResult> = {}): NightResult {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
     ...overrides,
   };
 }

--- a/__tests__/shared-waveform-edf-storage.test.ts
+++ b/__tests__/shared-waveform-edf-storage.test.ts
@@ -37,7 +37,7 @@ function makeMinimalNight(dateStr: string) {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
     settings: { deviceModel: 'AirSense 10', papMode: 'APAP', epap: 6, ipap: 12 },
   };
 }

--- a/__tests__/waveform-contribution-integration.test.ts
+++ b/__tests__/waveform-contribution-integration.test.ts
@@ -120,7 +120,7 @@ function makeNight(dateStr: string): NightResult {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
   };
 }
 

--- a/app/shared/[id]/page.tsx
+++ b/app/shared/[id]/page.tsx
@@ -51,6 +51,7 @@ function rehydrateNight(raw: Record<string, unknown>): NightResult {
     },
     machineSummary: (raw.machineSummary as NightResult['machineSummary']) ?? null,
     settingsFingerprint: (raw.settingsFingerprint as NightResult['settingsFingerprint']) ?? null,
+    csl: (raw.csl as NightResult['csl']) ?? null,
   } as NightResult;
 }
 

--- a/lib/parsers/csl-parser.ts
+++ b/lib/parsers/csl-parser.ts
@@ -1,0 +1,240 @@
+// ============================================================
+// AirwayLab — CSL.edf Parser (Cheyne-Stokes Respiration Events)
+// Parses EDF+ Annotations (TAL format) from ResMed CSL.edf files.
+// Extracts CSR Start/End episode pairs and computes summary stats.
+// ============================================================
+
+export interface CSREpisode {
+  /** Onset in seconds from recording start */
+  startSec: number;
+  /** End time in seconds from recording start */
+  endSec: number;
+  /** Episode duration in seconds */
+  durationSec: number;
+}
+
+export interface CSLData {
+  episodes: CSREpisode[];
+  /** Sum of all episode durations in seconds */
+  totalCSRSeconds: number;
+  /** totalCSRSeconds / recording duration x 100 */
+  csrPercentage: number;
+  episodeCount: number;
+}
+
+/** Labels to silently skip (not events) */
+const SKIP_LABELS = new Set(['recording starts', '']);
+
+/**
+ * Parse a CSL.edf file and extract Cheyne-Stokes respiration episodes.
+ * Returns null if the file can't be parsed (non-fatal).
+ */
+export function parseCSL(buffer: ArrayBuffer): CSLData | null {
+  try {
+    return parseCSLUnsafe(buffer);
+  } catch {
+    return null;
+  }
+}
+
+function parseCSLUnsafe(buffer: ArrayBuffer): CSLData | null {
+  if (buffer.byteLength < 256) return null;
+
+  const decoder = new TextDecoder('ascii');
+
+  // --- Fixed header (256 bytes) ---
+  const headerBytes = parseInt(readField(buffer, decoder, 184, 8)) || 0;
+  const numDataRecords = parseInt(readField(buffer, decoder, 236, 8)) || 0;
+  const recordDuration = parseFloat(readField(buffer, decoder, 244, 8)) || 1;
+  const numSignals = parseInt(readField(buffer, decoder, 252, 4)) || 0;
+
+  if (numSignals === 0 || numDataRecords === 0 || headerBytes === 0) return null;
+  if (buffer.byteLength < headerBytes) return null;
+
+  // Total recording duration in seconds
+  const totalRecordingSeconds = numDataRecords * recordDuration;
+
+  // --- Find "EDF Annotations" signal ---
+  let annotIdx = -1;
+  for (let i = 0; i < numSignals; i++) {
+    const label = readField(buffer, decoder, 256 + i * 16, 16);
+    if (label.toLowerCase().includes('edf annotation')) {
+      annotIdx = i;
+      break;
+    }
+  }
+
+  if (annotIdx === -1) return null;
+
+  // --- Read numSamples per signal (needed to compute record layout) ---
+  const samplesPerSignal: number[] = [];
+  const samplesOffset = 256 + numSignals * (16 + 80 + 8 + 8 + 8 + 8 + 8 + 80);
+  for (let i = 0; i < numSignals; i++) {
+    samplesPerSignal.push(
+      parseInt(readField(buffer, decoder, samplesOffset + i * 8, 8)) || 0
+    );
+  }
+
+  // Annotation signal bytes per record = numSamples * 2 (EDF stores as int16 but TAL uses raw bytes)
+  const annotBytesPerRecord = samplesPerSignal[annotIdx]! * 2;
+  if (annotBytesPerRecord === 0) return null;
+
+  // Compute byte offset of annotation signal within each data record
+  let annotOffsetInRecord = 0;
+  for (let i = 0; i < annotIdx; i++) {
+    annotOffsetInRecord += samplesPerSignal[i]! * 2;
+  }
+
+  const recordSize = samplesPerSignal.reduce((sum, n) => sum + n * 2, 0);
+
+  // --- Parse each data record's annotation bytes ---
+  interface RawAnnotation {
+    onsetSec: number;
+    durationSec: number;
+    label: string;
+  }
+  const annotations: RawAnnotation[] = [];
+  const utf8Decoder = new TextDecoder('utf-8');
+
+  for (let rec = 0; rec < numDataRecords; rec++) {
+    const recordStart = headerBytes + rec * recordSize;
+    const annotStart = recordStart + annotOffsetInRecord;
+    const annotEnd = annotStart + annotBytesPerRecord;
+
+    if (annotEnd > buffer.byteLength) break;
+
+    const annotBytes = new Uint8Array(buffer, annotStart, annotBytesPerRecord);
+    const annotStr = utf8Decoder.decode(annotBytes);
+
+    // Split on \x00 to get individual TALs
+    const tals = annotStr.split('\x00');
+
+    for (const tal of tals) {
+      if (tal.length === 0) continue;
+      const parsed = parseTAL(tal);
+      if (parsed) annotations.push(parsed);
+    }
+  }
+
+  // Sort annotations by onset time
+  annotations.sort((a, b) => a.onsetSec - b.onsetSec);
+
+  // --- Pair CSR Start / CSR End annotations ---
+  const episodes: CSREpisode[] = [];
+  let openStart: number | null = null;
+
+  for (const ann of annotations) {
+    const labelLower = ann.label.toLowerCase().trim();
+
+    if (labelLower === 'csr start') {
+      // If there's already an open start, close it at this new start
+      // (shouldn't happen normally but handle gracefully)
+      if (openStart !== null) {
+        const duration = ann.onsetSec - openStart;
+        if (duration > 0) {
+          episodes.push({
+            startSec: openStart,
+            endSec: ann.onsetSec,
+            durationSec: duration,
+          });
+        }
+      }
+      openStart = ann.onsetSec;
+    } else if (labelLower === 'csr end') {
+      if (openStart !== null) {
+        const endSec = ann.onsetSec;
+        const duration = endSec - openStart;
+        if (duration > 0) {
+          episodes.push({
+            startSec: openStart,
+            endSec,
+            durationSec: duration,
+          });
+        }
+        openStart = null;
+      }
+      // Ignore orphan CSR End (no matching start)
+    }
+  }
+
+  // Handle unpaired CSR Start at end of recording
+  if (openStart !== null) {
+    const duration = totalRecordingSeconds - openStart;
+    if (duration > 0) {
+      episodes.push({
+        startSec: openStart,
+        endSec: totalRecordingSeconds,
+        durationSec: duration,
+      });
+    }
+  }
+
+  const totalCSRSeconds = episodes.reduce((sum, ep) => sum + ep.durationSec, 0);
+  const csrPercentage = totalRecordingSeconds > 0
+    ? (totalCSRSeconds / totalRecordingSeconds) * 100
+    : 0;
+
+  return {
+    episodes,
+    totalCSRSeconds: Math.round(totalCSRSeconds * 100) / 100,
+    csrPercentage: Math.round(csrPercentage * 100) / 100,
+    episodeCount: episodes.length,
+  };
+}
+
+/**
+ * Parse a single TAL (Time-stamped Annotation List) string.
+ * CSL TALs may have duration (CSR Start: +onset\x15duration\x14CSR Start\x14)
+ * or just onset (timekeeping: +onset\x14\x14).
+ * Returns null for timekeeping TALs or unrecognised annotations.
+ */
+function parseTAL(tal: string): { onsetSec: number; durationSec: number; label: string } | null {
+  // Find separator positions
+  const durationSepIdx = tal.indexOf('\x15');
+  const annotSepIdx = tal.indexOf('\x14');
+
+  if (annotSepIdx === -1) return null;
+
+  let onsetStr: string;
+  let durationStr = '0';
+
+  if (durationSepIdx !== -1 && durationSepIdx < annotSepIdx) {
+    // Has explicit duration: +onset\x15duration\x14annotation\x14
+    onsetStr = tal.slice(0, durationSepIdx);
+    durationStr = tal.slice(durationSepIdx + 1, annotSepIdx);
+  } else {
+    // No duration separator before annotation — onset only
+    onsetStr = tal.slice(0, annotSepIdx);
+  }
+
+  // Extract annotation text between first \x14 and second \x14 (or end)
+  const restAfterFirstSep = tal.slice(annotSepIdx + 1);
+  const secondSepIdx = restAfterFirstSep.indexOf('\x14');
+  const annotationText = secondSepIdx >= 0
+    ? restAfterFirstSep.slice(0, secondSepIdx)
+    : restAfterFirstSep;
+
+  const onset = parseFloat(onsetStr.replace('+', ''));
+  const duration = parseFloat(durationStr);
+
+  if (isNaN(onset)) return null;
+
+  const labelLower = annotationText.toLowerCase().trim();
+
+  // Skip non-event annotations
+  if (SKIP_LABELS.has(labelLower)) return null;
+
+  // Only accept CSR-related annotations
+  if (labelLower !== 'csr start' && labelLower !== 'csr end') return null;
+
+  return {
+    onsetSec: onset,
+    durationSec: isNaN(duration) ? 0 : duration,
+    label: annotationText.trim(),
+  };
+}
+
+function readField(buffer: ArrayBuffer, decoder: TextDecoder, offset: number, length: number): string {
+  if (offset + length > buffer.byteLength) return '';
+  return decoder.decode(new Uint8Array(buffer, offset, length)).trim();
+}

--- a/lib/parsers/machine-summary-extractor.ts
+++ b/lib/parsers/machine-summary-extractor.ts
@@ -18,6 +18,8 @@ const SIGNAL_MAP: Record<string, keyof MachineSummaryStats> = {
   'OAI': 'oai',
   'CAI': 'cai',
   'UAI': 'uai',
+  'RIN': 'reraIndex',
+  'CSR': 'csrPercentage',
   'Leak.50': 'leak50',
   'Leak.70': 'leak70',
   'Leak.95': 'leak95',
@@ -38,6 +40,7 @@ const SIGNAL_MAP: Record<string, keyof MachineSummaryStats> = {
   'TgtEPAP.95': 'tgtEpap95',
   'MaskPress.50': 'maskPress50',
   'MaskPress.95': 'maskPress95',
+  'MaskPress.Max': 'maskPressMax',
   'Duration': 'durationMin',
   'MaskOn': 'maskOnMin',
   'MaskOff': 'maskOffMin',
@@ -68,6 +71,7 @@ function setBooleanField(summary: MachineSummaryStats, field: keyof MachineSumma
 function makeEmptySummary(): MachineSummaryStats {
   return {
     ahi: null, hi: null, oai: null, cai: null, uai: null,
+    reraIndex: null, csrPercentage: null,
     leak50: null, leak70: null, leak95: null, leakMax: null,
     minVent50: null, minVent95: null,
     respRate50: null, respRate95: null,
@@ -76,7 +80,7 @@ function makeEmptySummary(): MachineSummaryStats {
     ieRatio50: null, spontCycPct: null,
     tgtIpap50: null, tgtIpap95: null,
     tgtEpap50: null, tgtEpap95: null,
-    maskPress50: null, maskPress95: null,
+    maskPress50: null, maskPress95: null, maskPressMax: null,
     durationMin: null, maskOnMin: null, maskOffMin: null, maskEvents: null,
     spo2_50: null, spo2_95: null,
     faultDevice: false, faultAlarm: false,

--- a/lib/parsers/night-grouper.ts
+++ b/lib/parsers/night-grouper.ts
@@ -161,6 +161,19 @@ export function filterEVEFiles(
 }
 
 /**
+ * Filter uploaded files to only valid CSL.edf Cheyne-Stokes files (any size).
+ * CSL files contain CSR Start/End events in EDF+ Annotations format.
+ */
+export function filterCSLFiles(
+  files: { name: string; path: string; size: number }[]
+): { name: string; path: string; size: number }[] {
+  return files.filter((f) => {
+    const name = f.name.toLowerCase();
+    return name.endsWith('csl.edf') && (name === 'csl.edf' || name.charAt(name.length - 8) === '_');
+  });
+}
+
+/**
  * Find Identification file from file list (case-insensitive).
  */
 export function findIdentificationFile(

--- a/lib/sample-data.ts
+++ b/lib/sample-data.ts
@@ -323,6 +323,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     crossDevice: null,
     machineSummary: null,
     settingsFingerprint: null,
+    csl: null,
   },
   {
     date: dateFromStr('2025-01-14'),
@@ -339,6 +340,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     crossDevice: null,
     machineSummary: null,
     settingsFingerprint: null,
+    csl: null,
   },
   {
     date: dateFromStr('2025-01-13'),
@@ -355,6 +357,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     crossDevice: null,
     machineSummary: null,
     settingsFingerprint: null,
+    csl: null,
   },
   {
     date: dateFromStr('2025-01-12'),
@@ -371,6 +374,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     crossDevice: null,
     machineSummary: null,
     settingsFingerprint: null,
+    csl: null,
   },
   {
     date: dateFromStr('2025-01-11'),
@@ -387,6 +391,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     crossDevice: null,
     machineSummary: null,
     settingsFingerprint: null,
+    csl: null,
   },
 ];
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -391,6 +391,12 @@ export interface MachineSummaryStats {
   cai: number | null;
   uai: number | null;
 
+  // Machine RERA index (events/hr) — from RIN signal
+  reraIndex: number | null;
+
+  // Cheyne-Stokes % of sleep time — from CSR signal
+  csrPercentage: number | null;
+
   // Leak statistics (data quality indicator)
   leak50: number | null;
   leak70: number | null;
@@ -416,6 +422,7 @@ export interface MachineSummaryStats {
   tgtEpap95: number | null;
   maskPress50: number | null;
   maskPress95: number | null;
+  maskPressMax: number | null;
 
   // Session metadata
   durationMin: number | null;
@@ -448,6 +455,24 @@ export interface SettingsFingerprint {
   hash: string;
 }
 
+export interface CSREpisode {
+  /** Onset in seconds from recording start */
+  startSec: number;
+  /** End time in seconds from recording start */
+  endSec: number;
+  /** Episode duration in seconds */
+  durationSec: number;
+}
+
+export interface CSLData {
+  episodes: CSREpisode[];
+  /** Sum of all episode durations in seconds */
+  totalCSRSeconds: number;
+  /** totalCSRSeconds / recording duration x 100 */
+  csrPercentage: number;
+  episodeCount: number;
+}
+
 export interface NightResult {
   date: Date;
   dateStr: string;
@@ -463,6 +488,7 @@ export interface NightResult {
   crossDevice: CrossDeviceResults | null;
   machineSummary: MachineSummaryStats | null;
   settingsFingerprint: SettingsFingerprint | null;
+  csl: CSLData | null;
 }
 
 export interface AnalysisState {

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -4,13 +4,14 @@
 // ============================================================
 
 import { parseEDF } from '../lib/parsers/edf-parser';
-import { groupByNight, filterBRPFiles, filterSA2Files, filterEVEFiles, findSTRFile, findIdentificationFile, extractFolderDate } from '../lib/parsers/night-grouper';
+import { groupByNight, filterBRPFiles, filterSA2Files, filterEVEFiles, filterCSLFiles, findSTRFile, findIdentificationFile, extractFolderDate } from '../lib/parsers/night-grouper';
 import { parseSA2 } from '../lib/parsers/sa2-parser';
 import { extractSettings, parseIdentification, getSettingsForDate, getSTRSignalLabels } from '../lib/parsers/settings-extractor';
 import { extractMachineSummary } from '../lib/parsers/machine-summary-extractor';
 import { computeFingerprint } from '../lib/settings-fingerprint';
 import { parseOximetryCSV } from '../lib/parsers/oximetry-csv-parser';
 import { parseEVE } from '../lib/parsers/eve-parser';
+import { parseCSL } from '../lib/parsers/csl-parser';
 import { parseBMCFiles, bmcSessionNightDate } from '../lib/parsers/bmc-parser';
 import { computeNightGlasgow } from '../lib/analyzers/glasgow-index';
 import { computeWAT } from '../lib/analyzers/wat-engine';
@@ -36,6 +37,7 @@ import type {
   OximetryResults,
   OximetryTraceData,
   CrossDeviceResults,
+  CSLData,
 } from '../lib/types';
 
 // Global error handler — catches uncaught errors and sends them as
@@ -244,6 +246,39 @@ async function processFiles(
     }
   }
 
+  // Step 3.6: Parse CSL.edf files and group CSR data by night date
+  const cslFileInfos = filterCSLFiles(fileList);
+  const cslDataByDate = new Map<string, CSLData>();
+  for (const cslInfo of cslFileInfos) {
+    const fileData = files.find((f) => f.path === cslInfo.path);
+    if (!fileData) continue;
+    try {
+      const cslData = parseCSL(fileData.buffer);
+      const nightDate = extractFolderDate(cslInfo.path);
+      if (!nightDate || !cslData) continue;
+      // Multiple CSL files per night: merge episodes
+      const existing = cslDataByDate.get(nightDate);
+      if (existing) {
+        existing.episodes.push(...cslData.episodes);
+        existing.totalCSRSeconds += cslData.totalCSRSeconds;
+        existing.episodeCount += cslData.episodeCount;
+        // csrPercentage will be recalculated below since it depends on total recording duration
+      } else {
+        cslDataByDate.set(nightDate, cslData);
+      }
+    } catch (err) {
+      const filename = cslInfo.path.split('/').pop() || cslInfo.path;
+      const detail = err instanceof Error ? err.message : String(err);
+      const warning: WorkerWarning = {
+        type: 'WARNING',
+        checkpoint: 'parse_file_failed',
+        detail: `Failed to parse ${filename}: ${detail}`,
+        tags: { file: filename, error: detail },
+      };
+      self.postMessage(warning);
+    }
+  }
+
   // Step 4: Group by night
   const nightGroups = groupByNight(parsedEdfs);
 
@@ -413,6 +448,16 @@ async function processFiles(
       );
     }
 
+    // CSL (Cheyne-Stokes) data for this night
+    const cslRaw = cslDataByDate.get(group.nightDate) ?? null;
+    // Recalculate CSR percentage using total night duration if merged from multiple CSL files
+    const csl: CSLData | null = cslRaw ? {
+      ...cslRaw,
+      csrPercentage: totalDuration > 0
+        ? Math.round((cslRaw.totalCSRSeconds / totalDuration) * 100 * 100) / 100
+        : 0,
+    } : null;
+
     nights.push({
       date: recordingDate,
       dateStr: group.nightDate,
@@ -428,6 +473,7 @@ async function processFiles(
       crossDevice,
       machineSummary: dailySummary[group.nightDate] ?? null,
       settingsFingerprint: computeFingerprint(settings),
+      csl,
     });
 
     // Emit incremental result so the orchestrator can persist progress
@@ -590,6 +636,7 @@ async function processBMCFiles(
       crossDevice,
       machineSummary: null,
       settingsFingerprint: computeFingerprint(nightSettings),
+      csl: null,
     };
     nights.push(night);
 


### PR DESCRIPTION
## Summary

- **New CSL.edf parser** (`lib/parsers/csl-parser.ts`): Parses EDF+ Annotations format from ResMed CSL.edf files to extract Cheyne-Stokes respiration (CSR) episodes. Pairs CSR Start/End annotations, computes episode durations, total CSR seconds, and CSR percentage. Handles unpaired starts (session ended during CSR) by estimating end as recording end.
- **Expanded STR.edf machine summary**: Added 3 new signals to the machine-summary-extractor -- RIN (machine RERA index), CSR (Cheyne-Stokes % of sleep time), MaskPress.Max (mask pressure maximum).
- **Worker integration**: CSL files are detected via `filterCSLFiles`, parsed per night date, and merged into `NightResult.csl`. Multiple CSL files per night are merged with recalculated CSR percentage based on total night duration.
- **New tests**: `csl-parser.test.ts` (14 tests covering paired episodes, unpaired starts, orphan ends, error resilience, empty files, filter logic) and `machine-summary-extractor.test.ts` (8 tests covering new and existing signals, faults, multi-day extraction).

## Test plan

- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm run lint` passes (0 warnings)
- [x] `npm test` passes (1465 tests across 97 files)
- [x] `npm run build` passes
- [ ] Verify on Vercel preview: upload SD card with CSL.edf files, confirm CSL data appears in night results
- [ ] Verify STR.edf extraction includes RIN/CSR/MaskPress.Max when device reports them

🤖 Generated with [Claude Code](https://claude.com/claude-code)