### PR TITLE
feat: add PLD.edf parser for low-resolution therapy data

### DIFF
--- a/__tests__/analysis-orchestrator.test.ts
+++ b/__tests__/analysis-orchestrator.test.ts
@@ -178,7 +178,7 @@ function makeNight(
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
     ...overrides,
   };
 }

--- a/__tests__/clinician-questions.test.ts
+++ b/__tests__/clinician-questions.test.ts
@@ -153,7 +153,7 @@ function makeNight(overrides?: {
     oximetry: overrides?.oximetry === null ? null : makeOximetry(overrides?.oximetry),
     oximetryTrace: null,
     settingsMetrics: overrides?.settingsMetrics === null ? null : makeSettingsMetrics(overrides?.settingsMetrics),
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
   };
 }
 

--- a/__tests__/dashboard-ux-beginner-friendly.test.tsx
+++ b/__tests__/dashboard-ux-beginner-friendly.test.tsx
@@ -73,7 +73,7 @@ function makeNight(overrides: {
     } : null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
   };
 }
 

--- a/__tests__/date-sort-default.test.ts
+++ b/__tests__/date-sort-default.test.ts
@@ -36,7 +36,7 @@ function makeNight(dateStr: string, glasgowOverall: number): NightResult {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
   };
 }
 

--- a/__tests__/graphs-tab-always-show-data.test.ts
+++ b/__tests__/graphs-tab-always-show-data.test.ts
@@ -61,7 +61,7 @@ function makeNight(dateStr: string, glasgowOverall = 2.5): NightResult {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
   };
 }
 

--- a/__tests__/ifl-risk.test.ts
+++ b/__tests__/ifl-risk.test.ts
@@ -66,7 +66,7 @@ function makeNight(overrides: {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
   };
 }
 

--- a/__tests__/metric-reliability.test.ts
+++ b/__tests__/metric-reliability.test.ts
@@ -140,6 +140,7 @@ function makeNight(dateStr: string, settings: Partial<MachineSettings> = {}): Ni
     machineSummary: null,
     settingsFingerprint: computeFingerprint(s),
     csl: null,
+    pldSummary: null,
   };
 }
 

--- a/__tests__/night-summary-hero.test.tsx
+++ b/__tests__/night-summary-hero.test.tsx
@@ -57,7 +57,7 @@ function makeNight(overrides: {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
   };
 }
 

--- a/__tests__/pld-parser.test.ts
+++ b/__tests__/pld-parser.test.ts
@@ -1,0 +1,510 @@
+import { describe, it, expect } from 'vitest';
+import { parsePLD, computePLDSummary } from '@/lib/parsers/pld-parser';
+import type { PLDData } from '@/lib/types';
+
+// ── Helpers: build a minimal valid EDF buffer with PLD-typical channels ──
+
+interface TestChannel {
+  label: string;
+  data: number[];
+  physicalMin: number;
+  physicalMax: number;
+  unit?: string;
+}
+
+/**
+ * Create a minimal EDF binary buffer with the given channels.
+ * Each channel contributes 1 sample per data record (mimics 0.5 Hz with 2s records).
+ */
+function makePLDBuffer(channels: TestChannel[]): ArrayBuffer {
+  const numSignals = channels.length;
+  const numDataRecords = channels[0]?.data.length ?? 0;
+  const samplesPerRecord = 1; // 1 sample per signal per record (PLD is low-res)
+  const recordDuration = 2; // 2 seconds per record (0.5 Hz)
+  const headerBytes = 256 + numSignals * 256;
+  const dataBytes = numDataRecords * numSignals * samplesPerRecord * 2;
+  const totalBytes = headerBytes + dataBytes;
+
+  const buffer = new ArrayBuffer(totalBytes);
+  const view = new DataView(buffer);
+  const encoder = new TextEncoder();
+
+  // Write a fixed-width ASCII field into the buffer
+  function writeField(offset: number, length: number, value: string): void {
+    const padded = value.padEnd(length);
+    const bytes = encoder.encode(padded.slice(0, length));
+    new Uint8Array(buffer, offset, length).set(bytes);
+  }
+
+  // ── Fixed header (256 bytes) ──
+  writeField(0, 8, '0');                             // version
+  writeField(8, 80, 'test patient');                  // patient ID
+  writeField(88, 80, 'test recording');               // recording ID
+  writeField(168, 8, '01.01.25');                     // start date (dd.MM.yy)
+  writeField(176, 8, '22.00.00');                     // start time (HH.mm.ss)
+  writeField(184, 8, String(headerBytes));            // header bytes
+  writeField(192, 44, '');                            // reserved
+  writeField(236, 8, String(numDataRecords));         // num data records
+  writeField(244, 8, String(recordDuration));         // record duration
+  writeField(252, 4, String(numSignals));             // num signals
+
+  // ── Per-signal headers ──
+  let offset = 256;
+
+  // Labels (16 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(offset + i * 16, 16, channels[i]!.label);
+  }
+  offset += numSignals * 16;
+
+  // Transducer type (80 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(offset + i * 80, 80, '');
+  }
+  offset += numSignals * 80;
+
+  // Physical dimension (8 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(offset + i * 8, 8, channels[i]!.unit ?? '');
+  }
+  offset += numSignals * 8;
+
+  // Physical min (8 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(offset + i * 8, 8, String(channels[i]!.physicalMin));
+  }
+  offset += numSignals * 8;
+
+  // Physical max (8 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(offset + i * 8, 8, String(channels[i]!.physicalMax));
+  }
+  offset += numSignals * 8;
+
+  // Digital min (8 bytes each) — use -32768
+  for (let i = 0; i < numSignals; i++) {
+    writeField(offset + i * 8, 8, '-32768');
+  }
+  offset += numSignals * 8;
+
+  // Digital max (8 bytes each) — use 32767
+  for (let i = 0; i < numSignals; i++) {
+    writeField(offset + i * 8, 8, '32767');
+  }
+  offset += numSignals * 8;
+
+  // Prefiltering (80 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(offset + i * 80, 80, '');
+  }
+  offset += numSignals * 80;
+
+  // Number of samples per record (8 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(offset + i * 8, 8, String(samplesPerRecord));
+  }
+  offset += numSignals * 8;
+
+  // Reserved (32 bytes each)
+  for (let i = 0; i < numSignals; i++) {
+    writeField(offset + i * 32, 32, '');
+  }
+
+  // ── Data records ──
+  let dataPtr = headerBytes;
+  for (let rec = 0; rec < numDataRecords; rec++) {
+    for (let sig = 0; sig < numSignals; sig++) {
+      const ch = channels[sig]!;
+      const physValue = ch.data[rec] ?? 0;
+      // Convert physical to digital: reverse of (dv - digMin) * scale + physMin
+      const digRange = 32767 - (-32768); // 65535
+      const physRange = ch.physicalMax - ch.physicalMin;
+      const digitalValue = physRange === 0
+        ? 0
+        : Math.round(((physValue - ch.physicalMin) / physRange) * digRange + (-32768));
+      const clamped = Math.max(-32768, Math.min(32767, digitalValue));
+      view.setInt16(dataPtr, clamped, true);
+      dataPtr += 2;
+    }
+  }
+
+  return buffer;
+}
+
+// ── Test data generators ──
+
+function makeFullPLDChannels(numRecords: number): TestChannel[] {
+  const data = (min: number, max: number) =>
+    Array.from({ length: numRecords }, (_, i) => min + (max - min) * (i / numRecords));
+
+  return [
+    { label: 'MaskPress', data: data(4, 12), physicalMin: 0, physicalMax: 25, unit: 'cmH2O' },
+    { label: 'Therapy Pres', data: data(6, 14), physicalMin: 0, physicalMax: 25, unit: 'cmH2O' },
+    { label: 'Exp Press', data: data(4, 8), physicalMin: 0, physicalMax: 25, unit: 'cmH2O' },
+    { label: 'Insp Pres', data: data(8, 16), physicalMin: 0, physicalMax: 25, unit: 'cmH2O' },
+    { label: 'Leak', data: data(0, 0.5), physicalMin: 0, physicalMax: 2, unit: 'L/s' },
+    { label: 'RR', data: data(12, 18), physicalMin: 0, physicalMax: 30, unit: '/min' },
+    { label: 'Vt', data: data(0.3, 0.6), physicalMin: 0, physicalMax: 2, unit: 'L' },
+    { label: 'MV', data: data(5, 10), physicalMin: 0, physicalMax: 20, unit: 'L/min' },
+    { label: 'Snore', data: data(0, 3), physicalMin: 0, physicalMax: 10 },
+    { label: 'FFL Index', data: data(0, 1), physicalMin: 0, physicalMax: 1 },
+    { label: 'I:E', data: Array.from({ length: numRecords }, () => 250), physicalMin: 0, physicalMax: 500 },
+    { label: 'Ti', data: data(0.8, 1.2), physicalMin: 0, physicalMax: 3, unit: 's' },
+    { label: 'Te', data: data(2.0, 3.0), physicalMin: 0, physicalMax: 5, unit: 's' },
+    { label: 'TgMV', data: data(6, 8), physicalMin: 0, physicalMax: 20, unit: 'L/min' },
+  ];
+}
+
+function makeCPAPOnlyChannels(numRecords: number): TestChannel[] {
+  const data = (min: number, max: number) =>
+    Array.from({ length: numRecords }, (_, i) => min + (max - min) * (i / numRecords));
+
+  return [
+    { label: 'MaskPress', data: data(8, 12), physicalMin: 0, physicalMax: 25, unit: 'cmH2O' },
+    { label: 'Therapy Pres', data: data(10, 10), physicalMin: 0, physicalMax: 25, unit: 'cmH2O' },
+    { label: 'Leak', data: data(0, 0.3), physicalMin: 0, physicalMax: 2, unit: 'L/s' },
+    { label: 'RR', data: data(14, 16), physicalMin: 0, physicalMax: 30, unit: '/min' },
+    { label: 'Vt', data: data(0.4, 0.5), physicalMin: 0, physicalMax: 2, unit: 'L' },
+    { label: 'MV', data: data(6, 8), physicalMin: 0, physicalMax: 20, unit: 'L/min' },
+    { label: 'Snore', data: Array.from({ length: numRecords }, () => 0), physicalMin: 0, physicalMax: 10 },
+    { label: 'FFL Index', data: data(0, 0.5), physicalMin: 0, physicalMax: 1 },
+  ];
+}
+
+// ── Tests ──
+
+describe('PLD Parser', () => {
+  describe('parsePLD', () => {
+    it('parses a PLD with all channels present', () => {
+      const numRecords = 100;
+      const channels = makeFullPLDChannels(numRecords);
+      const buffer = makePLDBuffer(channels);
+
+      const result = parsePLD(buffer, 'DATALOG/20250110/20250110_220000_PLD.edf');
+
+      expect(result).not.toBeNull();
+      expect(result!.samplingRate).toBe(0.5); // 1 sample per 2s record
+      expect(result!.durationSeconds).toBe(200); // 100 records x 2s
+      expect(result!.startTime).toBeInstanceOf(Date);
+
+      // All channels should be present
+      expect(result!.maskPressure).toBeInstanceOf(Float32Array);
+      expect(result!.therapyPressure).toBeInstanceOf(Float32Array);
+      expect(result!.expiratoryPressure).toBeInstanceOf(Float32Array);
+      expect(result!.inspiratoryPressure).toBeInstanceOf(Float32Array);
+      expect(result!.leak).toBeInstanceOf(Float32Array);
+      expect(result!.respiratoryRate).toBeInstanceOf(Float32Array);
+      expect(result!.tidalVolume).toBeInstanceOf(Float32Array);
+      expect(result!.minuteVentilation).toBeInstanceOf(Float32Array);
+      expect(result!.snore).toBeInstanceOf(Float32Array);
+      expect(result!.fflIndex).toBeInstanceOf(Float32Array);
+      expect(result!.ieRatio).toBeInstanceOf(Float32Array);
+      expect(result!.ti).toBeInstanceOf(Float32Array);
+      expect(result!.te).toBeInstanceOf(Float32Array);
+      expect(result!.targetMV).toBeInstanceOf(Float32Array);
+
+      // Each channel should have numRecords samples
+      expect(result!.maskPressure!.length).toBe(numRecords);
+      expect(result!.leak!.length).toBe(numRecords);
+    });
+
+    it('parses PLD with only CPAP channels (no BiPAP-specific)', () => {
+      const numRecords = 50;
+      const channels = makeCPAPOnlyChannels(numRecords);
+      const buffer = makePLDBuffer(channels);
+
+      const result = parsePLD(buffer, 'test_PLD.edf');
+
+      expect(result).not.toBeNull();
+      expect(result!.maskPressure).toBeInstanceOf(Float32Array);
+      expect(result!.therapyPressure).toBeInstanceOf(Float32Array);
+      expect(result!.leak).toBeInstanceOf(Float32Array);
+      expect(result!.respiratoryRate).toBeInstanceOf(Float32Array);
+
+      // BiPAP-specific channels should be absent
+      expect(result!.expiratoryPressure).toBeUndefined();
+      expect(result!.inspiratoryPressure).toBeUndefined();
+      expect(result!.ieRatio).toBeUndefined();
+      expect(result!.ti).toBeUndefined();
+      expect(result!.te).toBeUndefined();
+      expect(result!.targetMV).toBeUndefined();
+    });
+
+    it('handles missing channels gracefully (null fields)', () => {
+      // Only leak and snore
+      const numRecords = 30;
+      const channels: TestChannel[] = [
+        { label: 'Leak', data: Array.from({ length: numRecords }, () => 0.2), physicalMin: 0, physicalMax: 2, unit: 'L/s' },
+        { label: 'Snore', data: Array.from({ length: numRecords }, () => 1), physicalMin: 0, physicalMax: 10 },
+      ];
+      const buffer = makePLDBuffer(channels);
+
+      const result = parsePLD(buffer, 'test_PLD.edf');
+
+      expect(result).not.toBeNull();
+      expect(result!.leak).toBeInstanceOf(Float32Array);
+      expect(result!.snore).toBeInstanceOf(Float32Array);
+      // Everything else should be undefined
+      expect(result!.maskPressure).toBeUndefined();
+      expect(result!.therapyPressure).toBeUndefined();
+      expect(result!.respiratoryRate).toBeUndefined();
+      expect(result!.fflIndex).toBeUndefined();
+    });
+
+    it('converts leak from L/s to L/min', () => {
+      const numRecords = 10;
+      const leakInLS = 0.5; // 0.5 L/s = 30 L/min
+      const channels: TestChannel[] = [
+        { label: 'Leak', data: Array.from({ length: numRecords }, () => leakInLS), physicalMin: 0, physicalMax: 2, unit: 'L/s' },
+      ];
+      const buffer = makePLDBuffer(channels);
+
+      const result = parsePLD(buffer, 'test_PLD.edf');
+
+      expect(result).not.toBeNull();
+      // Should be converted to L/min
+      for (let i = 0; i < numRecords; i++) {
+        expect(result!.leak![i]).toBeCloseTo(leakInLS * 60, 0);
+      }
+    });
+
+    it('converts tidal volume from L to mL', () => {
+      const numRecords = 10;
+      const vtInL = 0.5; // 0.5 L = 500 mL
+      const channels: TestChannel[] = [
+        { label: 'Vt', data: Array.from({ length: numRecords }, () => vtInL), physicalMin: 0, physicalMax: 2, unit: 'L' },
+      ];
+      const buffer = makePLDBuffer(channels);
+
+      const result = parsePLD(buffer, 'test_PLD.edf');
+
+      expect(result).not.toBeNull();
+      for (let i = 0; i < numRecords; i++) {
+        expect(result!.tidalVolume![i]).toBeCloseTo(vtInL * 1000, 0);
+      }
+    });
+
+    it('converts I:E ratio by dividing by 100', () => {
+      const numRecords = 10;
+      const ieRawValue = 250; // Represents 2.50 ratio
+      const channels: TestChannel[] = [
+        { label: 'I:E', data: Array.from({ length: numRecords }, () => ieRawValue), physicalMin: 0, physicalMax: 500 },
+      ];
+      const buffer = makePLDBuffer(channels);
+
+      const result = parsePLD(buffer, 'test_PLD.edf');
+
+      expect(result).not.toBeNull();
+      for (let i = 0; i < numRecords; i++) {
+        expect(result!.ieRatio![i]).toBeCloseTo(ieRawValue * 0.01, 1);
+      }
+    });
+
+    it('returns null for empty/malformed PLD', () => {
+      // Buffer too small
+      const tinyBuffer = new ArrayBuffer(100);
+      expect(parsePLD(tinyBuffer, 'test.edf')).toBeNull();
+
+      // Buffer with 0 signals — create manually since makePLDBuffer requires channels
+      const emptyBuffer = new ArrayBuffer(256);
+      const encoder = new TextEncoder();
+      const writeField = (offset: number, length: number, value: string) => {
+        const padded = value.padEnd(length);
+        new Uint8Array(emptyBuffer, offset, length).set(encoder.encode(padded.slice(0, length)));
+      };
+      writeField(0, 8, '0');
+      writeField(236, 8, '0'); // 0 data records
+      writeField(252, 4, '0'); // 0 signals
+      expect(parsePLD(emptyBuffer, 'test.edf')).toBeNull();
+    });
+
+    it('returns null when no recognizable channel labels found', () => {
+      const numRecords = 10;
+      const channels: TestChannel[] = [
+        { label: 'UnknownChan1', data: Array.from({ length: numRecords }, () => 1), physicalMin: 0, physicalMax: 10 },
+        { label: 'RandomLabel2', data: Array.from({ length: numRecords }, () => 2), physicalMin: 0, physicalMax: 10 },
+      ];
+      const buffer = makePLDBuffer(channels);
+
+      const result = parsePLD(buffer, 'test_PLD.edf');
+
+      expect(result).toBeNull();
+    });
+
+    it('handles alternative label variants (case-insensitive)', () => {
+      const numRecords = 10;
+      const channels: TestChannel[] = [
+        { label: 'Leak.2s', data: Array.from({ length: numRecords }, () => 0.3), physicalMin: 0, physicalMax: 2, unit: 'L/s' },
+        { label: 'RespRate.2s', data: Array.from({ length: numRecords }, () => 15), physicalMin: 0, physicalMax: 30, unit: '/min' },
+        { label: 'FlowLim.2s', data: Array.from({ length: numRecords }, () => 0.5), physicalMin: 0, physicalMax: 1 },
+        { label: 'TidVol.2s', data: Array.from({ length: numRecords }, () => 0.4), physicalMin: 0, physicalMax: 2, unit: 'L' },
+        { label: 'MinVent.2s', data: Array.from({ length: numRecords }, () => 7), physicalMin: 0, physicalMax: 20, unit: 'L/min' },
+        { label: 'Snore.2s', data: Array.from({ length: numRecords }, () => 0), physicalMin: 0, physicalMax: 10 },
+      ];
+      const buffer = makePLDBuffer(channels);
+
+      const result = parsePLD(buffer, 'test_PLD.edf');
+
+      expect(result).not.toBeNull();
+      expect(result!.leak).toBeInstanceOf(Float32Array);
+      expect(result!.respiratoryRate).toBeInstanceOf(Float32Array);
+      expect(result!.fflIndex).toBeInstanceOf(Float32Array);
+      expect(result!.tidalVolume).toBeInstanceOf(Float32Array);
+      expect(result!.minuteVentilation).toBeInstanceOf(Float32Array);
+      expect(result!.snore).toBeInstanceOf(Float32Array);
+    });
+
+    it('handles truncated buffer gracefully', () => {
+      const numRecords = 100;
+      const channels = makeCPAPOnlyChannels(numRecords);
+      const fullBuffer = makePLDBuffer(channels);
+
+      // Truncate to ~60% of the data section
+      const headerBytes = 256 + channels.length * 256;
+      const dataBytes = numRecords * channels.length * 2;
+      const truncatedSize = headerBytes + Math.floor(dataBytes * 0.6);
+      const truncatedBuffer = fullBuffer.slice(0, truncatedSize);
+
+      const result = parsePLD(truncatedBuffer, 'test_PLD.edf');
+
+      // Should still parse some records
+      expect(result).not.toBeNull();
+      expect(result!.leak!.length).toBeGreaterThan(0);
+      expect(result!.leak!.length).toBeLessThan(numRecords);
+    });
+
+    it('parses correct recording date from EDF header', () => {
+      const channels: TestChannel[] = [
+        { label: 'Leak', data: [0.2], physicalMin: 0, physicalMax: 2, unit: 'L/s' },
+      ];
+      const buffer = makePLDBuffer(channels);
+
+      const result = parsePLD(buffer, 'test_PLD.edf');
+
+      expect(result).not.toBeNull();
+      // Date header is '01.01.25' -> 2025-01-01, Time is '22.00.00'
+      expect(result!.startTime.getFullYear()).toBe(2025);
+      expect(result!.startTime.getMonth()).toBe(0); // January
+      expect(result!.startTime.getDate()).toBe(1);
+      expect(result!.startTime.getHours()).toBe(22);
+    });
+  });
+
+  describe('computePLDSummary', () => {
+    it('computes summary stats for all channels', () => {
+      const numRecords = 100;
+      const channels = makeFullPLDChannels(numRecords);
+      const buffer = makePLDBuffer(channels);
+      const pld = parsePLD(buffer, 'test_PLD.edf')!;
+
+      const summary = computePLDSummary(pld);
+
+      expect(summary.samplingRate).toBe(0.5);
+      expect(summary.durationSeconds).toBe(200);
+      expect(summary.sampleCount).toBe(numRecords);
+
+      // Capability flags
+      expect(summary.hasLeakData).toBe(true);
+      expect(summary.hasSnoreData).toBe(true);
+      expect(summary.hasFflData).toBe(true);
+      expect(summary.hasPressureData).toBe(true);
+
+      // Leak stats
+      expect(summary.leak).toBeDefined();
+      expect(summary.leak!.median).toBeGreaterThan(0);
+      expect(summary.leak!.p95).toBeGreaterThan(summary.leak!.median);
+      expect(summary.leak!.max).toBeGreaterThanOrEqual(summary.leak!.p95);
+
+      // Pressure stats (with min)
+      expect(summary.therapyPressure).toBeDefined();
+      expect(summary.therapyPressure!.min).toBeLessThanOrEqual(summary.therapyPressure!.median);
+
+      // Snore stats (with percentAboveZero)
+      expect(summary.snore).toBeDefined();
+      expect(summary.snore!.percentAboveZero).toBeGreaterThan(0);
+      expect(summary.snore!.percentAboveZero).toBeLessThanOrEqual(100);
+
+      // Median-only stats
+      expect(summary.ieRatio).toBeDefined();
+      expect(summary.ieRatio!.median).toBeGreaterThan(0);
+
+      // Median+p95 stats
+      expect(summary.respiratoryRate).toBeDefined();
+      expect(summary.respiratoryRate!.median).toBeGreaterThan(0);
+      expect(summary.respiratoryRate!.p95).toBeGreaterThanOrEqual(summary.respiratoryRate!.median);
+    });
+
+    it('handles PLD with only some channels', () => {
+      const numRecords = 50;
+      const channels = makeCPAPOnlyChannels(numRecords);
+      const buffer = makePLDBuffer(channels);
+      const pld = parsePLD(buffer, 'test_PLD.edf')!;
+
+      const summary = computePLDSummary(pld);
+
+      expect(summary.hasLeakData).toBe(true);
+      expect(summary.hasSnoreData).toBe(true);
+      expect(summary.hasFflData).toBe(true);
+      expect(summary.hasPressureData).toBe(true); // therapyPressure is present
+
+      // BiPAP channels should be absent
+      expect(summary.expiratoryPressure).toBeUndefined();
+      expect(summary.inspiratoryPressure).toBeUndefined();
+      expect(summary.ieRatio).toBeUndefined();
+      expect(summary.ti).toBeUndefined();
+      expect(summary.te).toBeUndefined();
+      expect(summary.targetMV).toBeUndefined();
+    });
+
+    it('computes correct median for known values', () => {
+      // Create a simple PLD with known values
+      const data = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      const pld: PLDData = {
+        samplingRate: 0.5,
+        durationSeconds: 20,
+        startTime: new Date(),
+        leak: data,
+      };
+
+      const summary = computePLDSummary(pld);
+
+      expect(summary.leak).toBeDefined();
+      expect(summary.leak!.median).toBeCloseTo(5.5, 1); // median of 1-10
+      expect(summary.leak!.max).toBe(10);
+      expect(summary.leak!.p95).toBeCloseTo(9.55, 1); // 95th percentile
+    });
+
+    it('computes correct snore percentAboveZero', () => {
+      // 3 out of 10 samples are above zero
+      const snoreData = new Float32Array([0, 0, 0, 0, 0, 0, 0, 1, 2, 3]);
+      const pld: PLDData = {
+        samplingRate: 0.5,
+        durationSeconds: 20,
+        startTime: new Date(),
+        snore: snoreData,
+      };
+
+      const summary = computePLDSummary(pld);
+
+      expect(summary.snore).toBeDefined();
+      expect(summary.snore!.percentAboveZero).toBeCloseTo(30, 0);
+    });
+
+    it('sets capability flags correctly when channels are missing', () => {
+      const pld: PLDData = {
+        samplingRate: 0.5,
+        durationSeconds: 20,
+        startTime: new Date(),
+        respiratoryRate: new Float32Array([15, 16, 14]),
+      };
+
+      const summary = computePLDSummary(pld);
+
+      expect(summary.hasLeakData).toBe(false);
+      expect(summary.hasSnoreData).toBe(false);
+      expect(summary.hasFflData).toBe(false);
+      expect(summary.hasPressureData).toBe(false);
+      expect(summary.respiratoryRate).toBeDefined();
+    });
+  });
+});

--- a/__tests__/settings-timeline.test.tsx
+++ b/__tests__/settings-timeline.test.tsx
@@ -41,7 +41,7 @@ function makeNight(dateStr: string, settings?: Partial<MachineSettings>): NightR
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
   };
 }
 

--- a/__tests__/share-strip-bulk.test.ts
+++ b/__tests__/share-strip-bulk.test.ts
@@ -14,7 +14,7 @@ function stripForShare(nights: NightResult[]): NightResult[] {
     },
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
   }));
 }
 
@@ -49,7 +49,7 @@ function makeNight(overrides: Partial<NightResult> = {}): NightResult {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
     ...overrides,
   };
 }

--- a/__tests__/waveform-contribution-integration.test.ts
+++ b/__tests__/waveform-contribution-integration.test.ts
@@ -120,7 +120,7 @@ function makeNight(dateStr: string): NightResult {
     oximetry: null,
     oximetryTrace: null,
     settingsMetrics: null,
-    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null,
+    crossDevice: null, machineSummary: null, settingsFingerprint: null, csl: null, pldSummary: null,
   };
 }
 

--- a/lib/parsers/night-grouper.ts
+++ b/lib/parsers/night-grouper.ts
@@ -37,6 +37,18 @@ function extractFilenameDate(filePath: string): string | null {
 }
 
 /**
+ * Extract date from PLD filename (YYYYMMDD_HHMMSS_PLD.edf).
+ */
+export function extractPLDFilenameDate(filePath: string): string | null {
+  const match = filePath.match(/(\d{8})_(\d{6})_PLD/i);
+  if (match) {
+    const d = match[1]!;
+    return `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
+  }
+  return null;
+}
+
+/**
  * Determine the sleep night date for a session.
  *
  * Priority:
@@ -123,6 +135,19 @@ export function filterBRPFiles(
         f.size > 50 * 1024;
     }
   );
+}
+
+/**
+ * Filter uploaded files to only valid PLD.edf therapy data files (any size).
+ * PLD files contain low-resolution (0.5 Hz) machine-computed therapy metrics.
+ */
+export function filterPLDFiles(
+  files: { name: string; path: string; size: number }[]
+): { name: string; path: string; size: number }[] {
+  return files.filter((f) => {
+    const name = f.name.toLowerCase();
+    return name.endsWith('pld.edf') || name.endsWith('_pld.edf');
+  });
 }
 
 /**

--- a/lib/parsers/pld-parser.ts
+++ b/lib/parsers/pld-parser.ts
@@ -1,0 +1,512 @@
+// ============================================================
+// AirwayLab — PLD (Periodic Low-resolution Data) EDF Parser
+// Parses ResMed PLD.edf files containing therapy data at 0.5 Hz
+// (2-second intervals). Channels include leak, pressure, snore,
+// FFL index, respiratory rate, tidal volume, minute ventilation,
+// I:E ratio, Ti, Te, and target MV (ASV/iVAPS).
+// ============================================================
+
+import type { EDFHeader, EDFSignal, PLDData, PLDSummary } from '../types';
+
+// ── Channel label matchers ──────────────────────────────────
+// Each channel has multiple label variants across ResMed models.
+// Matching is case-insensitive.
+
+interface ChannelMatcher {
+  key: keyof Omit<PLDData, 'samplingRate' | 'durationSeconds' | 'startTime'>;
+  patterns: string[];
+  /** Unit conversion factor: multiply raw physical value by this */
+  conversionFactor?: number;
+}
+
+const CHANNEL_MATCHERS: ChannelMatcher[] = [
+  {
+    key: 'maskPressure',
+    patterns: ['maskpress', 'maskpress.2s'],
+  },
+  {
+    key: 'therapyPressure',
+    patterns: ['therapy pres', 'press.2s'],
+  },
+  {
+    key: 'expiratoryPressure',
+    patterns: ['exp press', 'eprpress.2s', 'eprpress', 'epress.2s'],
+  },
+  {
+    key: 'inspiratoryPressure',
+    patterns: ['insp pres', 'ipap'],
+  },
+  {
+    key: 'leak',
+    patterns: ['leak', 'leak.2s'],
+    // Leak is in L/s in EDF, convert to L/min
+    // Conversion applied conditionally based on unit detection
+  },
+  {
+    key: 'respiratoryRate',
+    patterns: ['rr', 'resprate.2s', 'af', 'fr'],
+  },
+  {
+    key: 'tidalVolume',
+    patterns: ['vt', 'tidvol.2s', 'vc'],
+    // Tidal volume may be in L, convert to mL
+    // Conversion applied conditionally based on unit detection
+  },
+  {
+    key: 'minuteVentilation',
+    patterns: ['mv', 'minvent.2s', 'vm'],
+  },
+  {
+    key: 'snore',
+    patterns: ['snore', 'snore.2s'],
+  },
+  {
+    key: 'fflIndex',
+    patterns: ['ffl index', 'flowlim.2s', 'ffl'],
+  },
+  {
+    key: 'ieRatio',
+    patterns: ['i:e', 'ieratio.2s'],
+    // I:E stored as integer x100, convert to ratio
+    conversionFactor: 0.01,
+  },
+  {
+    key: 'ti',
+    patterns: ['ti', 'b5itime.2s', 'r5ti.2s'],
+  },
+  {
+    key: 'te',
+    patterns: ['te', 'b5etime.2s'],
+  },
+  {
+    key: 'targetMV',
+    patterns: ['tgmv', 'tgtvent.2s'],
+  },
+];
+
+/**
+ * Match a signal label to a PLD channel key.
+ * Returns the matcher if found, null otherwise.
+ * Uses exact-start matching after trimming to avoid false positives
+ * (e.g. 'MV' should not match 'MVent' unless pattern includes it).
+ */
+function matchChannel(label: string): ChannelMatcher | null {
+  const trimmed = label.toLowerCase().trim();
+
+  for (const matcher of CHANNEL_MATCHERS) {
+    for (const pattern of matcher.patterns) {
+      if (trimmed === pattern) {
+        return matcher;
+      }
+    }
+  }
+
+  // Fallback: check if label starts with any pattern (handles trailing spaces/numbers)
+  for (const matcher of CHANNEL_MATCHERS) {
+    for (const pattern of matcher.patterns) {
+      if (trimmed.startsWith(pattern) && (trimmed.length === pattern.length || trimmed[pattern.length] === ' ' || trimmed[pattern.length] === '.')) {
+        return matcher;
+      }
+    }
+  }
+
+  return null;
+}
+
+// ── EDF header parsing helpers (reused from edf-parser.ts patterns) ──
+
+function readField(buffer: ArrayBuffer, decoder: TextDecoder, offset: number, length: number): string {
+  return decoder.decode(new Uint8Array(buffer, offset, length)).trim();
+}
+
+function parseTime(timeStr: string): [number, number, number] {
+  const parts = timeStr.split('.');
+  return [
+    parseInt(parts[0] || '0'),
+    parseInt(parts[1] || '0'),
+    parseInt(parts[2] || '0'),
+  ];
+}
+
+/**
+ * Parse a PLD.edf file and extract all available channels.
+ * Returns null if the file cannot be parsed or has no recognizable channels.
+ *
+ * PLD files are low-resolution (typically 0.5 Hz) and contain machine-computed
+ * therapy metrics. They do NOT contain raw flow waveforms (those are in BRP.edf).
+ */
+export function parsePLD(buffer: ArrayBuffer, _filePath: string): PLDData | null {
+  if (buffer.byteLength < 256) {
+    return null; // Too small to be a valid EDF
+  }
+
+  const view = new DataView(buffer);
+  const decoder = new TextDecoder('ascii');
+
+  // --- Fixed header (256 bytes) ---
+  const header: EDFHeader = {
+    version: readField(buffer, decoder, 0, 8),
+    patientId: readField(buffer, decoder, 8, 80),
+    recordingId: readField(buffer, decoder, 88, 80),
+    startDate: readField(buffer, decoder, 168, 8),
+    startTime: readField(buffer, decoder, 176, 8),
+    headerBytes: parseInt(readField(buffer, decoder, 184, 8)) || 0,
+    reserved: readField(buffer, decoder, 192, 44),
+    numDataRecords: parseInt(readField(buffer, decoder, 236, 8)) || 0,
+    recordDuration: parseFloat(readField(buffer, decoder, 244, 8)) || 1,
+    numSignals: parseInt(readField(buffer, decoder, 252, 4)) || 0,
+  };
+
+  if (header.numSignals === 0 || header.numDataRecords === 0) {
+    return null;
+  }
+
+  // --- Parse recording date ---
+  const dateParts = header.startDate.split('.');
+  let year = parseInt(dateParts[2] || '0');
+  if (year < 100) {
+    year += year < 85 ? 2000 : 1900;
+  }
+  const startTime = new Date(
+    year,
+    parseInt(dateParts[1] || '1') - 1,
+    parseInt(dateParts[0] || '1'),
+    ...parseTime(header.startTime)
+  );
+
+  // --- Per-signal headers ---
+  const n = header.numSignals;
+  const signals: EDFSignal[] = [];
+
+  let offset = 256;
+  for (let i = 0; i < n; i++) {
+    signals.push({
+      label: readField(buffer, decoder, offset + i * 16, 16),
+      transducer: '',
+      physicalDimension: '',
+      physicalMin: 0,
+      physicalMax: 0,
+      digitalMin: 0,
+      digitalMax: 0,
+      prefiltering: '',
+      numSamples: 0,
+      reserved: '',
+    });
+  }
+  offset += n * 16;
+
+  for (let i = 0; i < n; i++) {
+    signals[i]!.transducer = readField(buffer, decoder, offset + i * 80, 80);
+  }
+  offset += n * 80;
+
+  for (let i = 0; i < n; i++) {
+    signals[i]!.physicalDimension = readField(buffer, decoder, offset + i * 8, 8);
+  }
+  offset += n * 8;
+
+  for (let i = 0; i < n; i++) {
+    signals[i]!.physicalMin = parseFloat(readField(buffer, decoder, offset + i * 8, 8)) || 0;
+  }
+  offset += n * 8;
+
+  for (let i = 0; i < n; i++) {
+    signals[i]!.physicalMax = parseFloat(readField(buffer, decoder, offset + i * 8, 8)) || 0;
+  }
+  offset += n * 8;
+
+  for (let i = 0; i < n; i++) {
+    signals[i]!.digitalMin = parseInt(readField(buffer, decoder, offset + i * 8, 8)) || 0;
+  }
+  offset += n * 8;
+
+  for (let i = 0; i < n; i++) {
+    signals[i]!.digitalMax = parseInt(readField(buffer, decoder, offset + i * 8, 8)) || 0;
+  }
+  offset += n * 8;
+
+  for (let i = 0; i < n; i++) {
+    signals[i]!.prefiltering = readField(buffer, decoder, offset + i * 80, 80);
+  }
+  offset += n * 80;
+
+  for (let i = 0; i < n; i++) {
+    signals[i]!.numSamples = parseInt(readField(buffer, decoder, offset + i * 8, 8)) || 0;
+  }
+  offset += n * 8;
+
+  // skip reserved
+  // offset += n * 32; (not needed for data reading)
+
+  // --- Map signals to channels ---
+  interface ChannelMapping {
+    signalIndex: number;
+    matcher: ChannelMatcher;
+    signal: EDFSignal;
+  }
+
+  const mappings: ChannelMapping[] = [];
+  const usedKeys = new Set<string>();
+
+  for (let i = 0; i < n; i++) {
+    const sig = signals[i]!;
+    const matcher = matchChannel(sig.label);
+    if (matcher && !usedKeys.has(matcher.key)) {
+      mappings.push({ signalIndex: i, matcher, signal: sig });
+      usedKeys.add(matcher.key);
+    }
+  }
+
+  if (mappings.length === 0) {
+    return null; // No recognizable channels
+  }
+
+  // --- Validate buffer size ---
+  const samplesPerRecord = signals.reduce((sum, s) => sum + s.numSamples, 0);
+  const bytesPerRecord = samplesPerRecord * 2;
+  const expectedBytes = header.headerBytes + header.numDataRecords * bytesPerRecord;
+
+  let actualNumRecords = header.numDataRecords;
+  if (buffer.byteLength < expectedBytes) {
+    const availableDataBytes = buffer.byteLength - header.headerBytes;
+    const completeRecords = bytesPerRecord > 0
+      ? Math.floor(availableDataBytes / bytesPerRecord)
+      : 0;
+    if (completeRecords === 0) {
+      return null; // Truncated beyond usability
+    }
+    actualNumRecords = completeRecords;
+  }
+
+  // --- Precompute scaling factors for each mapped channel ---
+  interface ChannelReader {
+    key: keyof Omit<PLDData, 'samplingRate' | 'durationSeconds' | 'startTime'>;
+    signalIndex: number;
+    data: Float32Array;
+    scale: number;
+    physicalMin: number;
+    digitalMin: number;
+    conversionFactor: number;
+    writeIdx: number;
+  }
+
+  const readers: ChannelReader[] = mappings.map((m) => {
+    const sig = m.signal;
+    const digitalRange = sig.digitalMax - sig.digitalMin;
+    const scale = digitalRange === 0 ? 0 : (sig.physicalMax - sig.physicalMin) / digitalRange;
+    const totalSamples = actualNumRecords * sig.numSamples;
+
+    // Determine conversion factor
+    let convFactor = m.matcher.conversionFactor ?? 1;
+
+    // Leak: detect unit and convert L/s -> L/min
+    if (m.matcher.key === 'leak') {
+      const unit = sig.physicalDimension.toLowerCase().trim();
+      const isPerSecond = unit.includes('/s');
+      const isPerMinute = unit.includes('/min') || unit.includes('/m');
+      if (isPerSecond || (!isPerMinute && Math.abs(sig.physicalMax) < 5)) {
+        convFactor = 60; // L/s -> L/min
+      }
+    }
+
+    // Tidal volume: detect unit and convert L -> mL
+    if (m.matcher.key === 'tidalVolume') {
+      const unit = sig.physicalDimension.toLowerCase().trim();
+      if (unit === 'l' || unit === 'litre' || unit === 'liter') {
+        convFactor = 1000; // L -> mL
+      } else if (unit === 'ml' || unit === 'milliliter') {
+        convFactor = 1; // already mL
+      } else if (Math.abs(sig.physicalMax) < 5) {
+        // Heuristic: if max < 5, values are likely in litres
+        convFactor = 1000;
+      }
+    }
+
+    return {
+      key: m.matcher.key,
+      signalIndex: m.signalIndex,
+      data: new Float32Array(totalSamples),
+      scale,
+      physicalMin: sig.physicalMin,
+      digitalMin: sig.digitalMin,
+      conversionFactor: convFactor,
+      writeIdx: 0,
+    };
+  });
+
+  // --- Read data records ---
+  let dataOffset = header.headerBytes;
+
+  for (let rec = 0; rec < actualNumRecords; rec++) {
+    let recordPtr = dataOffset;
+
+    for (let sig = 0; sig < n; sig++) {
+      const samplesInRecord = signals[sig]!.numSamples;
+
+      // Check if this signal is one we're reading
+      const reader = readers.find((r) => r.signalIndex === sig);
+      if (reader) {
+        for (let s = 0; s < samplesInRecord; s++) {
+          const digitalValue = view.getInt16(recordPtr + s * 2, true);
+          const physicalValue = (digitalValue - reader.digitalMin) * reader.scale + reader.physicalMin;
+          reader.data[reader.writeIdx++] = physicalValue * reader.conversionFactor;
+        }
+      }
+
+      recordPtr += samplesInRecord * 2;
+    }
+
+    dataOffset = recordPtr;
+  }
+
+  // --- Build result ---
+  // Determine sampling rate from the first mapped signal
+  const firstMappedSignal = signals[mappings[0]!.signalIndex]!;
+  const samplingRate = firstMappedSignal.numSamples / header.recordDuration;
+  const durationSeconds = actualNumRecords * header.recordDuration;
+
+  const result: PLDData = {
+    samplingRate,
+    durationSeconds,
+    startTime,
+  };
+
+  for (const reader of readers) {
+    result[reader.key] = reader.data;
+  }
+
+  return result;
+}
+
+// ── PLDSummary computation ──────────────────────────────────
+
+/**
+ * Compute a percentile value from a sorted Float32Array.
+ */
+function percentile(sorted: Float32Array, p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo]!;
+  const weight = idx - lo;
+  return sorted[lo]! * (1 - weight) + sorted[hi]! * weight;
+}
+
+/**
+ * Sort a Float32Array in-place (ascending).
+ */
+function sortFloat32(arr: Float32Array): Float32Array {
+  // Float32Array.prototype.sort with comparator
+  arr.sort((a, b) => a - b);
+  return arr;
+}
+
+/**
+ * Compute PLDSummary from raw PLDData.
+ * This produces the small, serializable summary that gets persisted.
+ */
+export function computePLDSummary(pld: PLDData): PLDSummary {
+  const sampleCount = pld.leak?.length ?? pld.snore?.length ?? pld.fflIndex?.length ??
+    pld.therapyPressure?.length ?? pld.respiratoryRate?.length ?? 0;
+
+  const summary: PLDSummary = {
+    samplingRate: pld.samplingRate,
+    durationSeconds: pld.durationSeconds,
+    sampleCount,
+    hasLeakData: !!pld.leak && pld.leak.length > 0,
+    hasSnoreData: !!pld.snore && pld.snore.length > 0,
+    hasFflData: !!pld.fflIndex && pld.fflIndex.length > 0,
+    hasPressureData: !!(pld.therapyPressure || pld.expiratoryPressure || pld.inspiratoryPressure),
+  };
+
+  // Helper to compute stats for a channel
+  const computeStats = (data: Float32Array | undefined) => {
+    if (!data || data.length === 0) return null;
+    const sorted = sortFloat32(new Float32Array(data)); // copy to avoid mutating original
+    return {
+      median: percentile(sorted, 50),
+      p95: percentile(sorted, 95),
+      max: sorted[sorted.length - 1]!,
+    };
+  };
+
+  const computeStatsWithMin = (data: Float32Array | undefined) => {
+    if (!data || data.length === 0) return null;
+    const sorted = sortFloat32(new Float32Array(data));
+    return {
+      median: percentile(sorted, 50),
+      p95: percentile(sorted, 95),
+      max: sorted[sorted.length - 1]!,
+      min: sorted[0]!,
+    };
+  };
+
+  const computeMedianP95 = (data: Float32Array | undefined) => {
+    if (!data || data.length === 0) return null;
+    const sorted = sortFloat32(new Float32Array(data));
+    return {
+      median: percentile(sorted, 50),
+      p95: percentile(sorted, 95),
+    };
+  };
+
+  const computeMedianOnly = (data: Float32Array | undefined) => {
+    if (!data || data.length === 0) return null;
+    const sorted = sortFloat32(new Float32Array(data));
+    return { median: percentile(sorted, 50) };
+  };
+
+  // Compute stats for each channel
+  const leakStats = computeStats(pld.leak);
+  if (leakStats) summary.leak = leakStats;
+
+  if (pld.snore && pld.snore.length > 0) {
+    const sorted = sortFloat32(new Float32Array(pld.snore));
+    let aboveZero = 0;
+    for (let i = 0; i < pld.snore.length; i++) {
+      if (pld.snore[i]! > 0) aboveZero++;
+    }
+    summary.snore = {
+      median: percentile(sorted, 50),
+      p95: percentile(sorted, 95),
+      max: sorted[sorted.length - 1]!,
+      percentAboveZero: (aboveZero / pld.snore.length) * 100,
+    };
+  }
+
+  const fflStats = computeStats(pld.fflIndex);
+  if (fflStats) summary.fflIndex = fflStats;
+
+  const therapyStats = computeStatsWithMin(pld.therapyPressure);
+  if (therapyStats) summary.therapyPressure = therapyStats;
+
+  const expStats = computeStatsWithMin(pld.expiratoryPressure);
+  if (expStats) summary.expiratoryPressure = expStats;
+
+  const inspStats = computeStatsWithMin(pld.inspiratoryPressure);
+  if (inspStats) summary.inspiratoryPressure = inspStats;
+
+  const rrStats = computeMedianP95(pld.respiratoryRate);
+  if (rrStats) summary.respiratoryRate = rrStats;
+
+  const vtStats = computeMedianP95(pld.tidalVolume);
+  if (vtStats) summary.tidalVolume = vtStats;
+
+  const mvStats = computeMedianP95(pld.minuteVentilation);
+  if (mvStats) summary.minuteVentilation = mvStats;
+
+  const ieStats = computeMedianOnly(pld.ieRatio);
+  if (ieStats) summary.ieRatio = ieStats;
+
+  const tiStats = computeMedianOnly(pld.ti);
+  if (tiStats) summary.ti = tiStats;
+
+  const teStats = computeMedianOnly(pld.te);
+  if (teStats) summary.te = teStats;
+
+  const targetMVStats = computeMedianOnly(pld.targetMV);
+  if (targetMVStats) summary.targetMV = targetMVStats;
+
+  return summary;
+}

--- a/lib/persistence.ts
+++ b/lib/persistence.ts
@@ -229,6 +229,14 @@ export function loadPersistedResults(): {
       if ((night as Record<string, unknown>).settingsFingerprint === undefined) {
         night.settingsFingerprint = null;
       }
+      // Migrate: csl added for CSL.edf Cheyne-Stokes data
+      if ((night as Record<string, unknown>).csl === undefined) {
+        night.csl = null;
+      }
+      // Migrate: pldSummary added for PLD.edf low-resolution therapy data
+      if ((night as Record<string, unknown>).pldSummary === undefined) {
+        night.pldSummary = null;
+      }
       // Migrate: hypopnea & amplitude stability fields added in v0.7.0
       if (night.ned && night.ned.briefObstructionIndex === undefined) {
         night.ned.hypopneaCount = 0;

--- a/lib/sample-data.ts
+++ b/lib/sample-data.ts
@@ -324,6 +324,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     machineSummary: null,
     settingsFingerprint: null,
     csl: null,
+    pldSummary: null,
   },
   {
     date: dateFromStr('2025-01-14'),
@@ -341,6 +342,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     machineSummary: null,
     settingsFingerprint: null,
     csl: null,
+    pldSummary: null,
   },
   {
     date: dateFromStr('2025-01-13'),
@@ -358,6 +360,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     machineSummary: null,
     settingsFingerprint: null,
     csl: null,
+    pldSummary: null,
   },
   {
     date: dateFromStr('2025-01-12'),
@@ -375,6 +378,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     machineSummary: null,
     settingsFingerprint: null,
     csl: null,
+    pldSummary: null,
   },
   {
     date: dateFromStr('2025-01-11'),
@@ -392,6 +396,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     machineSummary: null,
     settingsFingerprint: null,
     csl: null,
+    pldSummary: null,
   },
 ];
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -449,6 +449,92 @@ export interface MachineSummaryStats {
   ambHumidity50: number | null;
 }
 
+// ============================================================
+// PLD (Periodic Low-resolution Data) types
+// ============================================================
+
+/**
+ * Raw PLD channel data parsed from PLD.edf files.
+ * All channels are optional — not all devices include all channels.
+ * PLD files are low-resolution (0.5 Hz / 2-second intervals, 30-day retention).
+ */
+export interface PLDData {
+  samplingRate: number;           // typically 0.5 Hz
+  durationSeconds: number;
+  startTime: Date;
+  maskPressure?: Float32Array;    // cmH2O
+  therapyPressure?: Float32Array; // cmH2O
+  expiratoryPressure?: Float32Array; // cmH2O (EPAP)
+  inspiratoryPressure?: Float32Array; // cmH2O (IPAP, BiPAP only)
+  leak?: Float32Array;            // L/min (converted from L/s)
+  respiratoryRate?: Float32Array; // breaths/min
+  tidalVolume?: Float32Array;     // mL (converted from L)
+  minuteVentilation?: Float32Array; // L/min
+  snore?: Float32Array;           // dimensionless
+  fflIndex?: Float32Array;        // dimensionless (machine FL score)
+  ieRatio?: Float32Array;         // ratio (converted from x100)
+  ti?: Float32Array;              // seconds
+  te?: Float32Array;              // seconds
+  targetMV?: Float32Array;        // L/min (ASV/iVAPS)
+}
+
+/** Summary statistics for a single PLD channel */
+export interface PLDChannelStats {
+  median: number;
+  p95: number;
+  max: number;
+}
+
+/** Extended channel stats including min */
+export interface PLDChannelStatsWithMin extends PLDChannelStats {
+  min: number;
+}
+
+/** Snore-specific stats including percentage above zero */
+export interface PLDSnoreStats extends PLDChannelStats {
+  percentAboveZero: number;
+}
+
+/** Minimal channel stats (median only) */
+export interface PLDChannelMedian {
+  median: number;
+}
+
+/** Two-stat channel stats (median + p95) */
+export interface PLDChannelMedianP95 {
+  median: number;
+  p95: number;
+}
+
+/**
+ * Aggregated PLD summary — small enough to persist in localStorage.
+ * Computed from raw PLDData Float32Arrays, which are NOT persisted.
+ */
+export interface PLDSummary {
+  samplingRate: number;
+  durationSeconds: number;
+  sampleCount: number;
+  // Summary stats for each channel
+  leak?: PLDChannelStats;
+  snore?: PLDSnoreStats;
+  fflIndex?: PLDChannelStats;
+  therapyPressure?: PLDChannelStatsWithMin;
+  expiratoryPressure?: PLDChannelStatsWithMin;
+  inspiratoryPressure?: PLDChannelStatsWithMin;
+  respiratoryRate?: PLDChannelMedianP95;
+  tidalVolume?: PLDChannelMedianP95;
+  minuteVentilation?: PLDChannelMedianP95;
+  ieRatio?: PLDChannelMedian;
+  ti?: PLDChannelMedian;
+  te?: PLDChannelMedian;
+  targetMV?: PLDChannelMedian;
+  // Capability flags
+  hasLeakData: boolean;
+  hasSnoreData: boolean;
+  hasFflData: boolean;
+  hasPressureData: boolean;
+}
+
 export interface SettingsFingerprint {
   epap: number;
   ps: number;
@@ -493,6 +579,7 @@ export interface NightResult {
   machineSummary: MachineSummaryStats | null;
   settingsFingerprint: SettingsFingerprint | null;
   csl: CSLData | null;
+  pldSummary: PLDSummary | null;
 }
 
 export interface AnalysisState {

--- a/lib/upload-validation.ts
+++ b/lib/upload-validation.ts
@@ -105,6 +105,11 @@ function validateResMedFiles(
     warnings.push('Pulse oximetry data detected on your SD card (SpO2 + heart rate will be included in your analysis).');
   }
 
+  const hasPLD = edfFiles.some((f) => /(?:^|_)pld\.edf$/i.test(f.name));
+  if (hasPLD) {
+    warnings.push('Therapy summary data detected (leak, pressure, snore metrics will be included in your analysis).');
+  }
+
   const hasIdentification = files.some((f) => f.name.toUpperCase().startsWith('IDENTIFICATION'));
   if (!hasIdentification) {
     warnings.push('No Identification file found. Select the SD card root folder (one level above DATALOG) so we can identify your device model.');

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -4,7 +4,8 @@
 // ============================================================
 
 import { parseEDF } from '../lib/parsers/edf-parser';
-import { groupByNight, filterBRPFiles, filterSA2Files, filterEVEFiles, filterCSLFiles, findSTRFile, findIdentificationFile, extractFolderDate } from '../lib/parsers/night-grouper';
+import { groupByNight, filterBRPFiles, filterSA2Files, filterEVEFiles, filterCSLFiles, filterPLDFiles, findSTRFile, findIdentificationFile, extractFolderDate, extractPLDFilenameDate } from '../lib/parsers/night-grouper';
+import { parsePLD, computePLDSummary } from '../lib/parsers/pld-parser';
 import { parseSA2 } from '../lib/parsers/sa2-parser';
 import { extractSettings, parseIdentification, getSettingsForDate, getSTRSignalLabels } from '../lib/parsers/settings-extractor';
 import { extractMachineSummary } from '../lib/parsers/machine-summary-extractor';
@@ -38,6 +39,8 @@ import type {
   OximetryTraceData,
   CrossDeviceResults,
   CSLData,
+  PLDData,
+  PLDSummary,
 } from '../lib/types';
 
 // Global error handler — catches uncaught errors and sends them as
@@ -284,6 +287,34 @@ async function processFiles(
     }
   }
 
+  // Step 3.7: Parse PLD.edf files and group by night date
+  const pldFiles = filterPLDFiles(fileList);
+  const pldByDate = new Map<string, PLDData[]>();
+  for (const pldInfo of pldFiles) {
+    const fileData = files.find((f) => f.path === pldInfo.path);
+    if (!fileData) continue;
+    try {
+      const pld = parsePLD(fileData.buffer, fileData.path);
+      if (!pld) continue;
+      // Determine night date from folder path or filename
+      const nightDate = extractFolderDate(pldInfo.path) ?? extractPLDFilenameDate(pldInfo.path);
+      if (!nightDate) continue;
+      const existing = pldByDate.get(nightDate) ?? [];
+      existing.push(pld);
+      pldByDate.set(nightDate, existing);
+    } catch (err) {
+      const filename = pldInfo.path.split('/').pop() || pldInfo.path;
+      const detail = err instanceof Error ? err.message : String(err);
+      const warning: WorkerWarning = {
+        type: 'WARNING',
+        checkpoint: 'parse_file_failed',
+        detail: `Failed to parse PLD ${filename}: ${detail}`,
+        tags: { file: filename, error: detail },
+      };
+      self.postMessage(warning);
+    }
+  }
+
   // Step 4: Group by night
   const nightGroups = groupByNight(parsedEdfs);
 
@@ -472,6 +503,18 @@ async function processFiles(
         : 0,
     } : null;
 
+    // PLD summary: match by night date, merge multiple PLD files per night
+    let pldSummary: PLDSummary | null = null;
+    const nightPldFiles = pldByDate.get(group.nightDate);
+    if (nightPldFiles && nightPldFiles.length > 0) {
+      // Use first PLD file for the night (typically one PLD per session)
+      // If multiple, pick the longest one
+      const bestPld = nightPldFiles.reduce((best, current) =>
+        current.durationSeconds > best.durationSeconds ? current : best
+      );
+      pldSummary = computePLDSummary(bestPld);
+    }
+
     nights.push({
       date: recordingDate,
       dateStr: group.nightDate,
@@ -488,6 +531,7 @@ async function processFiles(
       machineSummary: dailySummary[group.nightDate] ?? null,
       settingsFingerprint: computeFingerprint(settings),
       csl,
+      pldSummary,
     });
 
     // Emit incremental result so the orchestrator can persist progress
@@ -651,6 +695,7 @@ async function processBMCFiles(
       machineSummary: null,
       settingsFingerprint: computeFingerprint(nightSettings),
       csl: null,
+      pldSummary: null, // PLD is ResMed-specific, not available for BMC
     };
     nights.push(night);
 


### PR DESCRIPTION
## Summary

- Add new PLD.edf parser (`lib/parsers/pld-parser.ts`) that extracts 14 machine-computed therapy channels from ResMed low-resolution data files (0.5 Hz / 2-second intervals)
- Channels include leak, snore, FFL index, mask/therapy/EPAP/IPAP pressure, respiratory rate, tidal volume, minute ventilation, I:E ratio, Ti, Te, and target MV
- Integrate into analysis worker: PLD files are parsed, grouped by night, and summarized as `PLDSummary` on each `NightResult`
- PLDSummary (compact stats: median, p95, max) persists in localStorage; raw Float32Arrays do not

## Changes

| File | What |
|------|------|
| `lib/types.ts` | New types: `PLDData`, `PLDSummary`, helper stats interfaces |
| `lib/parsers/pld-parser.ts` | New parser: `parsePLD()` + `computePLDSummary()` |
| `lib/parsers/night-grouper.ts` | New: `filterPLDFiles()`, `extractPLDFilenameDate()` |
| `workers/analysis-worker.ts` | PLD parsing step + PLDSummary computation per night |
| `lib/upload-validation.ts` | PLD file detection info message |
| `lib/persistence.ts` | Migration guard for `pldSummary` field |
| `lib/sample-data.ts` | Add `pldSummary: null` to sample nights |
| `__tests__/pld-parser.test.ts` | 16 test cases (parsing, conversions, summary, edge cases) |
| 11 existing test files | Add `pldSummary: null` to `NightResult` constructors |

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` clean
- [x] `npm test` -- 96 files, 1458 tests pass (16 new PLD tests)
- [x] `npm run build` succeeds
- [ ] Verify Vercel preview deploy
- [ ] Upload real ResMed SD card data and confirm PLD channels are parsed
- [ ] Check PLDSummary appears in NightResult (console/debug)
- [ ] Verify existing analysis (Glasgow, WAT, NED, oximetry) unaffected