### PR TITLE
chore: gitignore research/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ prompts/
 !.github/prompts/
 specs/
 cache/
+research/
 
 # WIP files (untracked dev work, excluded from tsc)
 _wip/


### PR DESCRIPTION
## Summary
- Adds `research/` to `.gitignore` alongside existing `specs/` exclusion
- Competitive intel and internal research docs stay local, never committed to public repo

## Test plan
- [ ] Verify `research/` files don't appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)