### PR TITLE
fix: resolve AI insights timeout for paid users (P1)

### DIFF
--- a/__tests__/ai-insights-timeout-config.test.ts
+++ b/__tests__/ai-insights-timeout-config.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock external dependencies before importing route ──────────
+
+vi.mock('@/lib/csrf', () => ({
+  validateOrigin: vi.fn(() => true),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  aiRateLimiter: { isLimited: vi.fn(() => false) },
+  aiPremiumRateLimiter: { isLimited: vi.fn(() => false) },
+  getRateLimitKey: vi.fn(() => '127.0.0.1'),
+  getUserRateLimitKey: vi.fn((id: string) => `user:${id}`),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseServer: vi.fn(() => ({
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { tier: 'supporter' } }),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+    }),
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'test-user' } }, error: null }) },
+  })),
+  getSupabaseServiceRole: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/email/sequences', () => ({
+  cancelSequence: vi.fn(),
+}));
+
+vi.mock('@/lib/discord-webhook', () => ({
+  sendAlert: vi.fn(),
+  COLORS: { amber: 0xf59e0b },
+}));
+
+// Capture the constructor args passed to Anthropic
+let capturedConstructorArgs: Record<string, unknown> | undefined;
+const mockMessagesCreate = vi.fn().mockResolvedValue({
+  content: [{ type: 'text', text: JSON.stringify([{
+    id: 'ai-1', type: 'positive', title: 'Test', body: 'Test insight', category: 'glasgow',
+  }]) }],
+  stop_reason: 'end_turn',
+  usage: { input_tokens: 100, output_tokens: 50 },
+});
+
+vi.mock('@anthropic-ai/sdk', async () => {
+  const actual = await vi.importActual<typeof import('@anthropic-ai/sdk')>('@anthropic-ai/sdk');
+  class MockAnthropic {
+    messages = { create: (...args: unknown[]) => mockMessagesCreate(...args) };
+    constructor(args: Record<string, unknown>) {
+      capturedConstructorArgs = args;
+    }
+    static AuthenticationError = actual.AuthenticationError;
+    static PermissionDeniedError = actual.PermissionDeniedError;
+    static BadRequestError = actual.BadRequestError;
+    static NotFoundError = actual.NotFoundError;
+    static InternalServerError = actual.InternalServerError;
+    static APIConnectionError = actual.APIConnectionError;
+    static APIConnectionTimeoutError = actual.APIConnectionTimeoutError;
+    static RateLimitError = actual.RateLimitError;
+  }
+  return { ...actual, default: MockAnthropic };
+});
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('https://airwaylab.app/api/ai-insights', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: 'https://airwaylab.app',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function validBody(): Record<string, unknown> {
+  return {
+    nights: [{
+      dateStr: '2026-03-12',
+      durationHours: 7,
+      sessionCount: 1,
+      settings: {},
+      glasgow: { overall: 3.5 },
+      wat: { flScore: 40 },
+      ned: { nedMean: 25 },
+      oximetry: null,
+    }],
+    selectedNightIndex: 0,
+    therapyChangeDate: null,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe('AI Insights Timeout Configuration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedConstructorArgs = undefined;
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+  });
+
+  it('exports maxDuration = 60 for Vercel function timeout', async () => {
+    const routeModule = await import('@/app/api/ai-insights/route');
+    expect(routeModule.maxDuration).toBe(60);
+  });
+
+  it('creates Anthropic client with maxRetries: 1', async () => {
+    const { POST } = await import('@/app/api/ai-insights/route');
+    await POST(makeRequest(validBody()) as never);
+    expect(capturedConstructorArgs).toBeDefined();
+    expect(capturedConstructorArgs!.maxRetries).toBe(1);
+  });
+
+  it('creates Anthropic client with timeout: 50000', async () => {
+    const { POST } = await import('@/app/api/ai-insights/route');
+    await POST(makeRequest(validBody()) as never);
+    expect(capturedConstructorArgs).toBeDefined();
+    expect(capturedConstructorArgs!.timeout).toBe(50_000);
+  });
+
+  it('returns successful insights with correct config', async () => {
+    const { POST } = await import('@/app/api/ai-insights/route');
+    const res = await POST(makeRequest(validBody()) as never);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.insights).toHaveLength(1);
+    expect(body.insights[0].id).toBe('ai-1');
+  });
+});

--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -11,6 +11,10 @@ import { sanitizePromptInput } from '@/lib/prompt-sanitize';
 import { cancelSequence } from '@/lib/email/sequences';
 import { sendAlert, COLORS } from '@/lib/discord-webhook';
 
+// Vercel Pro default is 15s — far too short for Claude Sonnet (10-25s typical).
+// 60s allows for cold starts + slow responses + deep mode with large payloads.
+export const maxDuration = 60;
+
 const AI_MONTHLY_LIMIT = 3;
 
 // Dedup rate-limit alerts: one alert per user per hour max
@@ -377,7 +381,11 @@ export async function POST(request: NextRequest) {
       systemPrompt += PREMIUM_INSIGHT_EXTENSION;
     }
 
-    const client = new Anthropic({ apiKey: anthropicKey, maxRetries: 3 });
+    const client = new Anthropic({
+      apiKey: anthropicKey,
+      maxRetries: 1,    // Fail fast — silent retries burn 30s+ and look like a hang
+      timeout: 50_000,  // 50s SDK timeout — leaves 10s headroom under maxDuration
+    });
 
     // Premium users get Sonnet for higher quality analysis; community gets Haiku
     const model = isPaidTier ? MODEL_PREMIUM : MODEL_COMMUNITY;

--- a/lib/ai-insights-client.ts
+++ b/lib/ai-insights-client.ts
@@ -102,7 +102,7 @@ export async function fetchAIInsights(
   nightNotes?: NightNotes
 ): Promise<AIInsightsResult> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 15000);
+  const timeout = setTimeout(() => controller.abort(), 55000);
 
   const onExternalAbort = () => controller.abort();
   signal?.addEventListener('abort', onExternalAbort);
@@ -151,7 +151,7 @@ export async function fetchAIInsights(
       if (signal?.aborted) {
         throw err; // External abort (unmount / re-generate)
       }
-      console.error('[ai-insights] Request timed out after 15s');
+      console.error('[ai-insights] Request timed out after 55s');
       throw new Error('AI analysis timed out. Please try again.');
     }
     if (err instanceof TypeError && err.message === 'Failed to fetch') {
@@ -179,7 +179,7 @@ export async function fetchDeepAIInsights(
   perBreathSummary?: PerBreathSummary
 ): Promise<AIInsightsResult> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 45000);
+  const timeout = setTimeout(() => controller.abort(), 65000);
 
   const onExternalAbort = () => controller.abort();
   signal?.addEventListener('abort', onExternalAbort);
@@ -230,7 +230,7 @@ export async function fetchDeepAIInsights(
       if (signal?.aborted) {
         throw err; // External abort (unmount / re-generate)
       }
-      console.error('[ai-insights] Request timed out after 45s');
+      console.error('[ai-insights] Request timed out after 65s');
       throw new Error('AI analysis timed out. Please try again.');
     }
     if (err instanceof TypeError && err.message === 'Failed to fetch') {


### PR DESCRIPTION
## Summary

- **Root cause:** No `maxDuration` export on the AI insights route. Vercel Pro default is 15s, Claude Sonnet responses take 10-25s. Combined with `maxRetries: 3` and no SDK timeout, the function was structurally guaranteed to timeout for paid users (Sonnet). Community users on Haiku sometimes succeeded (faster model).
- **Fix:** Add `maxDuration = 60`, set SDK `timeout: 50_000` + `maxRetries: 1`, raise client timeouts from 15s/45s to 55s/65s as safety net.
- **Impact:** 3 paying users affected (FB-13, FB-2). Feature has never worked for Supporter tier since Haiku→Sonnet upgrade.

## Files Changed

| File | Change |
|------|--------|
| `app/api/ai-insights/route.ts` | Add `maxDuration = 60`, change Anthropic client config |
| `lib/ai-insights-client.ts` | Raise client timeouts to exceed server timeout |
| `__tests__/ai-insights-timeout-config.test.ts` | New: verify maxDuration export + SDK config |

## Test Plan

- [x] Full pipeline passes (lint, typecheck, 1469 tests, build)
- [x] New timeout config tests pass (4/4)
- [x] Existing error handling tests pass (9/9) — no regressions
- [ ] Vercel preview deploy verified by Demian
- [ ] Upload SD card data, generate AI insights as Supporter tier
- [ ] Generate deep AI insights with per-breath data
- [ ] Verify Community tier (Haiku) still works
- [ ] Check Sentry for errors post-deploy
- [ ] ALL manual QA items checked (partial pass = no merge)

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] E2e tests pass locally (N/A — no UI changes)
- [x] Bundle size impact checked (config changes only, no bundle impact)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [x] Self-review: no regressions, loading/error/empty states handled
- [x] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)