### PR TITLE
fix: reduce Upstash Redis usage to stay within free tier

### DIFF
--- a/app/api/files/presign/route.ts
+++ b/app/api/files/presign/route.ts
@@ -7,7 +7,7 @@ import { validateOrigin } from '@/lib/csrf';
 import { hasStorageConsent } from '@/lib/storage/quota';
 import { STORAGE_BUCKET, MAX_FILE_SIZE, SUPPORTED_EXTENSIONS } from '@/lib/storage/types';
 
-const rateLimiter = new RateLimiter({ windowMs: 3_600_000, max: 5000 });
+const rateLimiter = new RateLimiter({ windowMs: 3_600_000, max: 5000, persistent: true });
 
 const presignSchema = z.object({
   filePath: z.string().min(1).max(500),

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -42,12 +42,16 @@ interface RateLimiterOptions {
   windowMs: number;
   /** Maximum requests per window */
   max: number;
+  /** Use Upstash Redis for cross-instance persistence (default: false).
+   *  Enable for abuse-sensitive routes (AI insights, Stripe, file uploads). */
+  persistent?: boolean;
 }
 
 export class RateLimiter {
   private readonly map = new Map<string, RateLimitEntry>();
   private readonly windowMs: number;
   private readonly max: number;
+  private readonly persistent: boolean;
   private lastCleanup = Date.now();
   private upstash: Ratelimit | null = null;
   private upstashInitialised = false;
@@ -55,6 +59,7 @@ export class RateLimiter {
   constructor(options: RateLimiterOptions) {
     this.windowMs = options.windowMs;
     this.max = options.max;
+    this.persistent = options.persistent ?? false;
   }
 
   /**
@@ -65,11 +70,13 @@ export class RateLimiter {
     if (this.upstashInitialised) return this.upstash;
     this.upstashInitialised = true;
 
+    if (!this.persistent) return null;
+
     const redis = getRedis();
     if (redis) {
       this.upstash = new Ratelimit({
         redis,
-        limiter: Ratelimit.slidingWindow(this.max, `${this.windowMs} ms`),
+        limiter: Ratelimit.fixedWindow(this.max, `${this.windowMs} ms`),
         prefix: 'airwaylab_rl',
       });
     }
@@ -161,16 +168,19 @@ export function getUserRateLimitKey(userId: string): string {
 export const aiRateLimiter = new RateLimiter({
   windowMs: 3_600_000,
   max: 20,
+  persistent: true,
 });
 
 /** AI insights — paid tiers: 60 requests per hour per user */
 export const aiPremiumRateLimiter = new RateLimiter({
   windowMs: 3_600_000,
   max: 60,
+  persistent: true,
 });
 
 /** Checkout/portal: 10 requests per 15 minutes per IP */
 export const stripeRateLimiter = new RateLimiter({
   windowMs: 900_000,
   max: 10,
+  persistent: true,
 });


### PR DESCRIPTION
## Summary
- Switch rate limiter from `slidingWindow` (~4 Redis commands/call) to `fixedWindow` (~2 commands/call)
- Add `persistent` flag to `RateLimiter` (default `false`) — only abuse-sensitive routes (AI insights, Stripe, file presign) use Upstash Redis; all other routes use in-memory fallback
- ~90% reduction in Upstash command usage to stay within 500k/month free tier

## Test plan
- [x] TypeScript passes (`npx tsc --noEmit`)
- [x] All 6 rate-limit tests pass
- [x] Full test suite passes (1370 tests, 0 failures)
- [ ] Verify Vercel preview deploy
- [ ] Monitor Upstash console for command reduction after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)