### PR TITLE
feat: expand demo dataset to 7 nights with richer data coverage

### DIFF
--- a/__tests__/contribute-symptoms.test.ts
+++ b/__tests__/contribute-symptoms.test.ts
@@ -84,7 +84,8 @@ describe('buildContributionPayload', () => {
   });
 
   it('omits enhanced fields when not available', () => {
-    const night = SAMPLE_NIGHTS[0]!;
+    // Use a night without settingsMetrics or enhanced NED fields
+    const night = { ...SAMPLE_NIGHTS[0]!, settingsMetrics: null } as NightResult;
     const payload = buildContributionPayload(night, 3);
 
     expect(payload.hypopnea_index).toBeUndefined();

--- a/__tests__/forum-export.test.ts
+++ b/__tests__/forum-export.test.ts
@@ -56,7 +56,7 @@ describe('exportForumSingleNight', () => {
   });
 
   it('omits oximetry when not present', () => {
-    const nightNoOx = SAMPLE_NIGHTS[2]!; // night3 has no oximetry
+    const nightNoOx = SAMPLE_NIGHTS[3]!; // night4 has no oximetry
     const output = exportForumSingleNight(nightNoOx);
     expect(output).not.toContain('**Oximetry**');
     expect(output).not.toContain('ODI-3');
@@ -80,7 +80,7 @@ describe('exportForumSingleNight', () => {
   });
 
   it('pluralizes sessions correctly', () => {
-    const nightMultiSession = SAMPLE_NIGHTS[2]!; // 2 sessions
+    const nightMultiSession = SAMPLE_NIGHTS[3]!; // night4 has 2 sessions
     const output = exportForumSingleNight(nightMultiSession);
     expect(output).toContain('2 sessions');
   });
@@ -120,7 +120,7 @@ describe('exportForumMultiNight', () => {
 
   it('includes oximetry table for nights with oximetry', () => {
     const output = exportForumMultiNight(SAMPLE_NIGHTS);
-    // nights 1, 2, and 5 have oximetry
+    // nights 1, 2, 3, and 6 have oximetry
     expect(output).toContain('**Oximetry**');
     expect(output).toContain('ODI-3');
   });
@@ -141,7 +141,7 @@ describe('exportForumMultiNight', () => {
   it('includes date range', () => {
     const output = exportForumMultiNight(SAMPLE_NIGHTS);
     expect(output).toContain('2025-01-11');
-    expect(output).toContain('2025-01-15');
+    expect(output).toContain('2025-01-17');
   });
 
   it('includes AirwayLab attribution', () => {

--- a/__tests__/insights.test.ts
+++ b/__tests__/insights.test.ts
@@ -4,8 +4,12 @@ import { SAMPLE_NIGHTS, SAMPLE_THERAPY_CHANGE_DATE } from '@/lib/sample-data';
 import type { NightResult } from '@/lib/types';
 
 describe('generateInsights', () => {
-  // SAMPLE_NIGHTS: [night1(1.8), night2(1.2), night3(2.6), night4(1.5), night5(2.1)]
-  // night1 = most recent (2025-01-15), night5 = oldest (2025-01-11)
+  // SAMPLE_NIGHTS (7 nights, newest first):
+  // [0] night1(1.8) Jan 17, [1] night2(1.2) Jan 16, [2] night3(1.5) Jan 15,
+  // [3] night4(2.6) Jan 14, [4] night5(1.5) Jan 13, [5] night6(2.1) Jan 12,
+  // [6] night7(2.3) Jan 11
+  // Settings change at Jan 15: [0-2] = new settings (EPAP 10), [3-6] = old settings (EPAP 8)
+  // Oximetry: [0,1,2,5] have it, [3,4,6] do not
 
   it('returns an array of insights', () => {
     const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[0]!, SAMPLE_NIGHTS[1]!, null);
@@ -45,31 +49,30 @@ describe('generateInsights', () => {
 
   describe('single-night insights', () => {
     it('generates Glasgow warning for night with bad Glasgow', () => {
-      // night3 has Glasgow 2.6 → bad
-      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[2]!, SAMPLE_NIGHTS[3]!, null);
+      // night4 (index 3) has Glasgow 2.6 → bad
+      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[3]!, SAMPLE_NIGHTS[4]!, null);
       const glasgowWarning = result.find((i) => i.id === 'glasgow-bad');
       expect(glasgowWarning).toBeDefined();
       expect(glasgowWarning!.type).toBe('warning');
     });
 
     it('generates Glasgow positive for good Glasgow night', () => {
-      // night2 has Glasgow 1.2 → warn (not quite good at ≤1.0)
-      // night4 has Glasgow 1.5 → warn
+      // night2 (index 1) has Glasgow 1.2 → warn (not quite good at ≤1.0)
       // We need a night with Glasgow ≤ 1.0 for 'good'
       // Sample data doesn't have one that's ≤1.0, so this tests that warn nights don't get 'good' insight
-      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[1]!, SAMPLE_NIGHTS[2]!, null);
+      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[1]!, SAMPLE_NIGHTS[3]!, null);
       const glasgowGood = result.find((i) => i.id === 'glasgow-good');
       // night2 Glasgow is 1.2 which is > 1.0 (green threshold), so no 'good' insight
       expect(glasgowGood).toBeUndefined();
     });
 
     it('detects elevated RERA on bad nights', () => {
-      // night3 has RERA 11.8 >= 10
+      // night4 (index 3) has RERA 11.8 >= 10
       // Use only 2 nights to avoid trend insights consuming the 6-insight cap
       const result = generateInsights(
-        [SAMPLE_NIGHTS[2]!, SAMPLE_NIGHTS[3]!],
-        SAMPLE_NIGHTS[2]!,
+        [SAMPLE_NIGHTS[3]!, SAMPLE_NIGHTS[4]!],
         SAMPLE_NIGHTS[3]!,
+        SAMPLE_NIGHTS[4]!,
         null
       );
       const reraWarning = result.find((i) => i.id === 'rera-high');
@@ -77,38 +80,40 @@ describe('generateInsights', () => {
       expect(reraWarning!.category).toBe('ned');
     });
 
-    it('generates regularity-bad for night3 (regularity 52 > amber threshold 50, lowerIsBetter)', () => {
-      // night3 has regularity 52 → bad (threshold: green=30, amber=50, lowerIsBetter)
+    it('generates regularity-bad for night4 (regularity 52 > amber threshold 50, lowerIsBetter)', () => {
+      // night4 (index 3) has regularity 52 → bad (threshold: green=30, amber=50, lowerIsBetter)
       // 52 > 50 (amber) → 'bad', so regularity-bad insight fires
-      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[2]!, SAMPLE_NIGHTS[3]!, null);
+      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[3]!, SAMPLE_NIGHTS[4]!, null);
       const regWarning = result.find((i) => i.id === 'regularity-bad');
       expect(regWarning).toBeDefined();
       expect(regWarning!.type).toBe('warning');
     });
 
     it('detects night-over-night Glasgow change', () => {
-      // night3 (2.6) to night2 (1.2) = delta -1.4 → improved
-      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[1]!, SAMPLE_NIGHTS[2]!, null);
+      // night4 (2.6) to night2 (1.2) = delta -1.4 → improved
+      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[1]!, SAMPLE_NIGHTS[3]!, null);
       const delta = result.find((i) => i.id === 'night-delta');
       expect(delta).toBeDefined();
       expect(delta!.type).toBe('positive'); // improved
     });
 
     it('does not generate dominant component when worst < 0.5', () => {
-      // night3: flatTop is 0.48 (highest component), but threshold is ≥0.5
+      // night4 (index 3): flatTop is 0.48 (highest component), but threshold is ≥0.5
       // So glasgow-dominant insight should NOT fire
-      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[2]!, SAMPLE_NIGHTS[3]!, null);
+      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[3]!, SAMPLE_NIGHTS[4]!, null);
       const dominant = result.find((i) => i.id === 'glasgow-dominant');
       expect(dominant).toBeUndefined();
     });
 
     it('detects H1/H2 NED split when difference is >5', () => {
-      // night3: h1=24.2, h2=32.8 → diff=8.6 → insight expected
-      // Pass only 2 nights to avoid trend insights filling the 6-insight cap
+      // night4 (index 3): h1=24.2, h2=32.8 → diff=8.6 → insight expected
+      // Pass only 2 nights and strip machineSummary to avoid filling the 6-insight cap
+      const n3 = { ...SAMPLE_NIGHTS[3]!, machineSummary: null };
+      const n4 = { ...SAMPLE_NIGHTS[4]!, machineSummary: null };
       const result = generateInsights(
-        [SAMPLE_NIGHTS[2]!, SAMPLE_NIGHTS[3]!],
-        SAMPLE_NIGHTS[2]!,
-        SAMPLE_NIGHTS[3]!,
+        [n3, n4],
+        n3,
+        n4,
         null
       );
       const h1h2 = result.find((i) => i.id === 'ned-h1h2');
@@ -118,17 +123,17 @@ describe('generateInsights', () => {
 
   describe('oximetry insights', () => {
     it('no oximetry insights when oximetry is null', () => {
-      // night3 has no oximetry
-      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[2]!, SAMPLE_NIGHTS[3]!, null);
+      // night4 (index 3) has no oximetry
+      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[3]!, SAMPLE_NIGHTS[4]!, null);
       const oxInsights = result.filter((i) => i.category === 'oximetry');
       expect(oxInsights).toHaveLength(0);
     });
 
-    it('generates ODI insight for night5 (higher ODI)', () => {
-      // night5 ODI-3 = 6.8, threshold bad >15, so not bad
-      // night5 ODI-3 = 6.8 → warn (green=5, amber=15, lowerIsBetter → 6.8 > 5 ≤ 15 = warn)
+    it('generates ODI insight for night6 (higher ODI)', () => {
+      // night6 (index 5) ODI-3 = 6.8, threshold bad >15, so not bad
+      // night6 ODI-3 = 6.8 → warn (green=5, amber=15, lowerIsBetter → 6.8 > 5 ≤ 15 = warn)
       // Not "bad" so no odi-high insight. But we can verify that.
-      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[4]!, SAMPLE_NIGHTS[3]!, null);
+      const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[5]!, SAMPLE_NIGHTS[4]!, null);
       const odiHigh = result.find((i) => i.id === 'odi-high');
       // ODI 6.8 is warn, not bad, so no odi-high
       expect(odiHigh).toBeUndefined();
@@ -184,7 +189,7 @@ describe('generateInsights', () => {
   describe('trend insights', () => {
     it('returns trend insights when 3+ nights provided', () => {
       const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[0]!, SAMPLE_NIGHTS[1]!, null);
-      // With 5 nights there should be some trend insights
+      // With 7 nights there should be some trend insights
       const trendInsights = result.filter((i) => i.category === 'trend');
       expect(trendInsights.length).toBeGreaterThanOrEqual(0); // May or may not fire depending on slope
     });
@@ -199,10 +204,10 @@ describe('generateInsights', () => {
     it('generates therapy change insight when date is provided', () => {
       const result = generateInsights(SAMPLE_NIGHTS, SAMPLE_NIGHTS[0]!, SAMPLE_NIGHTS[1]!, SAMPLE_THERAPY_CHANGE_DATE);
       const therapyInsight = result.find((i) => i.id === 'therapy-change-impact');
-      // Therapy change date is 2025-01-14, which is night2
-      // Before: nights 3,4,5 avg Glasgow = (2.6+1.5+2.1)/3 = 2.07
-      // After: nights 1,2 avg Glasgow = (1.8+1.2)/2 = 1.5
-      // Delta = 1.5 - 2.07 = -0.57 → improved
+      // Therapy change date is 2025-01-15, which is night3
+      // Before: nights 4,5,6,7 avg Glasgow = (2.6+1.5+2.1+2.3)/4 = 2.125
+      // After: nights 1,2,3 avg Glasgow = (1.8+1.2+1.5)/3 = 1.5
+      // Delta = 1.5 - 2.125 = -0.625 → improved
       expect(therapyInsight).toBeDefined();
       expect(therapyInsight!.type).toBe('positive');
     });
@@ -214,10 +219,10 @@ describe('generateInsights', () => {
       // FL Score 70*0.35=24.5, NED 35*0.30=10.5, FI Math.max(0,(0.70-0.5)/0.5)*100=40*0.20=8.0, Glasgow (2.0/9)*100*0.15=3.33
       // Total = 46.33 → above 45 threshold
       const highFLNight = {
-        ...SAMPLE_NIGHTS[2]!,
-        wat: { ...SAMPLE_NIGHTS[2]!.wat, flScore: 70, regularityScore: 25, periodicityIndex: 10 },
-        ned: { ...SAMPLE_NIGHTS[2]!.ned, nedMean: 35, fiMean: 0.70, reraIndex: 3, estimatedArousalIndex: 4, h1NedMean: 33, h2NedMean: 35, briefObstructionIndex: 1 },
-        glasgow: { ...SAMPLE_NIGHTS[2]!.glasgow, overall: 2.0 },
+        ...SAMPLE_NIGHTS[3]!,
+        wat: { ...SAMPLE_NIGHTS[3]!.wat, flScore: 70, regularityScore: 25, periodicityIndex: 10 },
+        ned: { ...SAMPLE_NIGHTS[3]!.ned, nedMean: 35, fiMean: 0.70, reraIndex: 3, estimatedArousalIndex: 4, h1NedMean: 33, h2NedMean: 35, briefObstructionIndex: 1 },
+        glasgow: { ...SAMPLE_NIGHTS[3]!.glasgow, overall: 2.0 },
       };
       const result = generateInsights([highFLNight], highFLNight, null, null, 2);
       const correlation = result.find((i) => i.id === 'symptom-fl-correlation');
@@ -228,11 +233,13 @@ describe('generateInsights', () => {
 
     it('generates symptom-fl-asymptomatic when IFL >45 and rating >=4', () => {
       // Same IFL Risk calculation as above = 46.33 → above 45 threshold
+      // Strip machineSummary to avoid machine-ahi-elevated crowding the 6-insight cap
       const highFLNight = {
-        ...SAMPLE_NIGHTS[2]!,
-        wat: { ...SAMPLE_NIGHTS[2]!.wat, flScore: 70, regularityScore: 25, periodicityIndex: 10 },
-        ned: { ...SAMPLE_NIGHTS[2]!.ned, nedMean: 35, fiMean: 0.70, reraIndex: 3, estimatedArousalIndex: 4, h1NedMean: 33, h2NedMean: 35, briefObstructionIndex: 1 },
-        glasgow: { ...SAMPLE_NIGHTS[2]!.glasgow, overall: 2.0 },
+        ...SAMPLE_NIGHTS[3]!,
+        machineSummary: null,
+        wat: { ...SAMPLE_NIGHTS[3]!.wat, flScore: 70, regularityScore: 25, periodicityIndex: 10 },
+        ned: { ...SAMPLE_NIGHTS[3]!.ned, nedMean: 35, fiMean: 0.70, reraIndex: 3, estimatedArousalIndex: 4, h1NedMean: 33, h2NedMean: 35, briefObstructionIndex: 1 },
+        glasgow: { ...SAMPLE_NIGHTS[3]!.glasgow, overall: 2.0 },
       };
       const result = generateInsights([highFLNight], highFLNight, null, null, 4);
       const asymptomatic = result.find((i) => i.id === 'symptom-fl-asymptomatic');
@@ -364,7 +371,7 @@ describe('generateInsights', () => {
     });
 
     it('handles night with null oximetry gracefully', () => {
-      const nightNoOx = SAMPLE_NIGHTS[2]!; // night3 has no oximetry
+      const nightNoOx = SAMPLE_NIGHTS[3]!; // night4 has no oximetry
       expect(() => generateInsights([nightNoOx], nightNoOx, null, null)).not.toThrow();
     });
   });

--- a/__tests__/sample-data.test.ts
+++ b/__tests__/sample-data.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { SAMPLE_NIGHTS, SAMPLE_THERAPY_CHANGE_DATE } from '@/lib/sample-data';
+
+describe('SAMPLE_NIGHTS data integrity', () => {
+  it('contains exactly 7 nights', () => {
+    expect(SAMPLE_NIGHTS).toHaveLength(7);
+  });
+
+  it('dates are in descending order (newest first)', () => {
+    for (let i = 0; i < SAMPLE_NIGHTS.length - 1; i++) {
+      const current = SAMPLE_NIGHTS[i]!;
+      const next = SAMPLE_NIGHTS[i + 1]!;
+      expect(current.dateStr > next.dateStr).toBe(true);
+    }
+  });
+
+  it('all nights have required core fields', () => {
+    for (const night of SAMPLE_NIGHTS) {
+      expect(night.date).toBeInstanceOf(Date);
+      expect(night.dateStr).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(night.durationHours).toBeGreaterThan(0);
+      expect(night.sessionCount).toBeGreaterThanOrEqual(1);
+      expect(night.settings).toBeDefined();
+      expect(night.settings.deviceModel).toBeTruthy();
+      expect(night.settings.settingsSource).toBe('extracted');
+      expect(night.glasgow).toBeDefined();
+      expect(night.glasgow.overall).toBeGreaterThanOrEqual(0);
+      expect(night.wat).toBeDefined();
+      expect(night.wat.flScore).toBeGreaterThanOrEqual(0);
+      expect(night.ned).toBeDefined();
+      expect(night.ned.breathCount).toBeGreaterThan(0);
+    }
+  });
+
+  it('all nights have machineSummary populated', () => {
+    for (const night of SAMPLE_NIGHTS) {
+      expect(night.machineSummary).not.toBeNull();
+      expect(night.machineSummary!.ahi).not.toBeNull();
+      expect(night.machineSummary!.ahi).toBeGreaterThanOrEqual(0);
+      expect(night.machineSummary!.durationMin).not.toBeNull();
+      expect(night.machineSummary!.durationMin!).toBeGreaterThan(0);
+    }
+  });
+
+  it('has oximetry on exactly 5 of 7 nights', () => {
+    const withOximetry = SAMPLE_NIGHTS.filter((n) => n.oximetry !== null);
+    expect(withOximetry).toHaveLength(5);
+  });
+
+  it('oximetry is present on expected nights', () => {
+    // Nights 1-3 (newest, post-change), night 5, and night 6 (old settings) have oximetry
+    // Nights 4 and 7 do not
+    expect(SAMPLE_NIGHTS[0]!.oximetry).not.toBeNull(); // Jan 17
+    expect(SAMPLE_NIGHTS[1]!.oximetry).not.toBeNull(); // Jan 16
+    expect(SAMPLE_NIGHTS[2]!.oximetry).not.toBeNull(); // Jan 15
+    expect(SAMPLE_NIGHTS[3]!.oximetry).toBeNull();      // Jan 14
+    expect(SAMPLE_NIGHTS[4]!.oximetry).not.toBeNull(); // Jan 13
+    expect(SAMPLE_NIGHTS[5]!.oximetry).not.toBeNull(); // Jan 12
+    expect(SAMPLE_NIGHTS[6]!.oximetry).toBeNull();      // Jan 11
+  });
+
+  it('night 1 has settingsMetrics and crossDevice populated', () => {
+    const night1 = SAMPLE_NIGHTS[0]!;
+    expect(night1.settingsMetrics).not.toBeNull();
+    expect(night1.settingsMetrics!.breathCount).toBeGreaterThan(0);
+    expect(night1.crossDevice).not.toBeNull();
+    expect(night1.crossDevice!.couplingPct).toBeGreaterThan(0);
+  });
+
+  it('therapy change date falls within the sample date range', () => {
+    const dateStrs = SAMPLE_NIGHTS.map((n) => n.dateStr);
+    const oldest = dateStrs[dateStrs.length - 1]!;
+    const newest = dateStrs[0]!;
+    expect(SAMPLE_THERAPY_CHANGE_DATE >= oldest).toBe(true);
+    expect(SAMPLE_THERAPY_CHANGE_DATE <= newest).toBe(true);
+  });
+
+  it('settings differ before and after therapy change', () => {
+    // Nights after the change (newer dates) use baseSettings (EPAP 10)
+    // Nights on or before the change use oldSettings (EPAP 8)
+    const postChange = SAMPLE_NIGHTS.filter((n) => n.dateStr >= SAMPLE_THERAPY_CHANGE_DATE);
+    const preChange = SAMPLE_NIGHTS.filter((n) => n.dateStr < SAMPLE_THERAPY_CHANGE_DATE);
+
+    for (const night of postChange) {
+      expect(night.settings.epap).toBe(10);
+      expect(night.settings.ipap).toBe(16);
+    }
+    for (const night of preChange) {
+      expect(night.settings.epap).toBe(8);
+      expect(night.settings.ipap).toBe(14);
+    }
+  });
+
+  it('machineSummary AHI values are clinically plausible (0-30 range)', () => {
+    for (const night of SAMPLE_NIGHTS) {
+      const ahi = night.machineSummary!.ahi!;
+      expect(ahi).toBeGreaterThanOrEqual(0);
+      expect(ahi).toBeLessThanOrEqual(30);
+    }
+  });
+
+  it('glasgow overall scores are within valid range (0-9)', () => {
+    for (const night of SAMPLE_NIGHTS) {
+      expect(night.glasgow.overall).toBeGreaterThanOrEqual(0);
+      expect(night.glasgow.overall).toBeLessThanOrEqual(9);
+    }
+  });
+
+  it('glasgow component scores are within valid range (0-1)', () => {
+    const componentKeys = [
+      'skew', 'spike', 'flatTop', 'topHeavy', 'multiPeak',
+      'noPause', 'inspirRate', 'multiBreath', 'variableAmp',
+    ] as const;
+    for (const night of SAMPLE_NIGHTS) {
+      for (const key of componentKeys) {
+        expect(night.glasgow[key]).toBeGreaterThanOrEqual(0);
+        expect(night.glasgow[key]).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it('date strings match Date objects', () => {
+    for (const night of SAMPLE_NIGHTS) {
+      const y = night.date.getFullYear();
+      const m = String(night.date.getMonth() + 1).padStart(2, '0');
+      const d = String(night.date.getDate()).padStart(2, '0');
+      expect(night.dateStr).toBe(`${y}-${m}-${d}`);
+    }
+  });
+});

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -567,7 +567,7 @@ function AnalyzePageInner() {
               See sample data
             </Button>
             <p className="text-[11px] text-muted-foreground/50">
-              See what AirwayLab looks like with 5 nights of example data
+              See what AirwayLab looks like with 7 nights of example data
             </p>
           </div>
         </div>
@@ -638,8 +638,8 @@ function AnalyzePageInner() {
               </div>
               {/* Sample data context — update if lib/sample-data.ts changes */}
               <p className="text-xs text-muted-foreground/70">
-                Sample scenario: BiPAP ST user with moderate flow limitation across 5 nights.
-                Settings were adjusted (EPAP 8&rarr;10, IPAP 14&rarr;16) on Jan 14 &mdash; compare nights before and after to see the effect.
+                Sample scenario: BiPAP ST user with moderate flow limitation across 7 nights.
+                Settings were adjusted (EPAP 8&rarr;10, IPAP 14&rarr;16) on Jan 15 &mdash; compare nights before and after to see the effect.
               </p>
             </div>
           )}

--- a/app/getting-started/page.tsx
+++ b/app/getting-started/page.tsx
@@ -278,7 +278,7 @@ export default function GettingStartedPage() {
             Don&apos;t have your SD card handy?
           </h2>
           <p className="max-w-md text-sm text-muted-foreground">
-            See what AirwayLab looks like with 5 nights of sample data
+            See what AirwayLab looks like with 7 nights of sample data
           </p>
           <Link href="/analyze?demo">
             <Button size="lg" variant="outline" className="gap-2">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -710,7 +710,7 @@ export default function Home() {
                 <p className="mt-0.5 text-[10px] text-muted-foreground">Glasgow Index went from 2.1 to 1.5.</p>
               </div>
               <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-2">
-                <p className="text-xs font-medium text-emerald-300">Trending down over 5 nights</p>
+                <p className="text-xs font-medium text-emerald-300">Trending down over 7 nights</p>
                 <p className="mt-0.5 text-[10px] text-muted-foreground">Flow limitation is improving (2.1 → 1.8).</p>
               </div>
             </div>

--- a/e2e/demo-flow.spec.ts
+++ b/e2e/demo-flow.spec.ts
@@ -73,20 +73,20 @@ test.describe('Demo Mode Flow', () => {
     }
   });
 
-  // ── Demo shows 5 sample nights ─────────────────────────────
-  test('demo mode provides 5 sample nights', async ({ page }) => {
+  // ── Demo shows 7 sample nights ─────────────────────────────
+  test('demo mode provides 7 sample nights', async ({ page }) => {
     await page.goto('/analyze?demo=1');
 
     await expect(
       page.locator('[data-slot="tabs-trigger"]').filter({ hasText: /overview/i })
     ).toBeVisible({ timeout: 30_000 });
 
-    // Night selector should contain 5 nights
+    // Night selector should contain 7 nights
     const nightOptions = page.locator('select option, [data-slot="select-option"]');
     const count = await nightOptions.count().catch(() => 0);
-    // If using a select element, verify 5 options
+    // If using a select element, verify 7 options
     if (count > 0) {
-      expect(count).toBe(5);
+      expect(count).toBe(7);
     }
   });
 

--- a/lib/demo-ai-insights.ts
+++ b/lib/demo-ai-insights.ts
@@ -15,7 +15,7 @@ export const DEMO_AI_INSIGHTS: Insight[] = [
     id: 'demo-ai-therapy',
     type: 'positive',
     title: 'Pressure increase correlating with multi-metric improvement',
-    body: 'The EPAP 8\u200A\u2192\u200A10 change on Jan 14 shows a correlated response across engines: Glasgow dropped from 2.6 to the 1.2\u20131.8 range, and flat-top scoring fell from 0.48 to 0.22 \u2014 consistent with reduced inspiratory flow limitation. Discuss the sustained improvement with your clinician at your next review.',
+    body: 'The EPAP 8\u200A\u2192\u200A10 change on Jan 15 shows a correlated response across engines: Glasgow dropped from 2.6 to the 1.2\u20131.8 range, and flat-top scoring fell from 0.48 to 0.22 \u2014 consistent with reduced inspiratory flow limitation. Discuss the sustained improvement with your clinician at your next review.',
     category: 'therapy',
   },
   {
@@ -38,5 +38,19 @@ export const DEMO_AI_INSIGHTS: Insight[] = [
     title: 'Coupled HR-desaturation events linked to flow limitation',
     body: 'Coupled heart-rate and desaturation events at 1.4/hr (HR Clin 10) are occurring alongside elevated flow limitation scores. Research suggests that flow limitation itself triggers a limbic stress response that can drive these coupled autonomic events, independent of cortical arousals. Discuss whether further flow limitation reduction could improve this pattern with your clinician.',
     category: 'oximetry',
+  },
+  {
+    id: 'demo-ai-trend-7night',
+    type: 'positive',
+    title: '7-night trend shows consistent post-change improvement',
+    body: 'Across all 7 nights, AHI dropped from a pre-change average of 6.5/hr (nights 4\u20137) to 3.2/hr (nights 1\u20133). The flow limitation engines confirm this is a genuine improvement: combined FL percentage fell from 29% to 19%, and RERA index from 8.8 to 5.4. The trend is holding over 3 post-change nights, suggesting the settings adjustment is effective.',
+    category: 'therapy',
+  },
+  {
+    id: 'demo-ai-leak-correlation',
+    type: 'info',
+    title: 'Leak reduction co-occurring with settings change',
+    body: 'P95 leak dropped from 15.8\u201318.2 L/min pre-change to 8.5\u201312.8 L/min post-change. While the pressure increase might have been expected to worsen leaks, the lower AHI and fewer arousals likely reduced mouth-opening events. The leak improvement adds confidence that the current settings are well-tolerated.',
+    category: 'therapy',
   },
 ];

--- a/lib/sample-data.ts
+++ b/lib/sample-data.ts
@@ -1,14 +1,26 @@
 // ============================================================
 // AirwayLab — Demo Sample Data
-// 5 nights of realistic NightResult data for demo mode
+// 7 nights of realistic NightResult data for demo mode
 // ============================================================
 
-import type { NightResult, MachineSettings, GlasgowComponents, WATResults, NEDResults, OximetryResults } from './types';
+import type {
+  NightResult,
+  MachineSettings,
+  MachineSummaryStats,
+  GlasgowComponents,
+  WATResults,
+  NEDResults,
+  OximetryResults,
+  SettingsMetrics,
+  CrossDeviceResults,
+} from './types';
 
 function dateFromStr(s: string): Date {
   const [y, m, d] = s.split('-').map(Number) as [number, number, number];
   return new Date(y, m - 1, d);
 }
+
+// ── Shared settings ──────────────────────────────────────────
 
 const baseSettings: MachineSettings = {
   deviceModel: 'AirCurve 10 VAuto',
@@ -23,7 +35,71 @@ const baseSettings: MachineSettings = {
   settingsSource: 'extracted',
 };
 
-// Night 1: Most recent — moderate FL, with oximetry
+const oldSettings: MachineSettings = {
+  deviceModel: 'AirCurve 10 VAuto',
+  epap: 8,
+  ipap: 14,
+  pressureSupport: 6,
+  papMode: 'BiPAP ST',
+  riseTime: 3,
+  trigger: 'Medium',
+  cycle: 'Medium',
+  easyBreathe: false,
+  settingsSource: 'extracted',
+};
+
+// ── Helper: build MachineSummaryStats with defaults ──────────
+
+function makeMachineSummary(overrides: Partial<MachineSummaryStats>): MachineSummaryStats {
+  return {
+    ahi: null,
+    hi: null,
+    oai: null,
+    cai: null,
+    uai: null,
+    reraIndex: null,
+    csrPercentage: null,
+    leak50: null,
+    leak70: null,
+    leak95: null,
+    leakMax: null,
+    minVent50: null,
+    minVent95: null,
+    respRate50: null,
+    respRate95: null,
+    tidVol50: null,
+    tidVol95: null,
+    ti50: null,
+    ti95: null,
+    ieRatio50: null,
+    spontCycPct: null,
+    tgtIpap50: null,
+    tgtIpap95: null,
+    tgtEpap50: null,
+    tgtEpap95: null,
+    maskPress50: null,
+    maskPress95: null,
+    maskPressMax: null,
+    durationMin: null,
+    maskOnMin: null,
+    maskOffMin: null,
+    maskEvents: null,
+    spo2_50: null,
+    spo2_95: null,
+    faultDevice: false,
+    faultAlarm: false,
+    faultHumidifier: false,
+    faultHeatedTube: false,
+    anyFault: false,
+    ambHumidity50: null,
+    ...overrides,
+  };
+}
+
+// ============================================================
+// Night 1 (2025-01-17): Most recent — moderate FL, with oximetry
+// ============================================================
+
 const night1Glasgow: GlasgowComponents = {
   overall: 1.8,
   skew: 0.3,
@@ -87,7 +163,51 @@ const night1Ox: OximetryResults = {
   doubleTrackingCorrected: 142,
 };
 
-// Night 2: Good night — low FL
+const night1SettingsMetrics: SettingsMetrics = {
+  breathCount: 4120,
+  epapDetected: 10.1,
+  ipapDetected: 15.8,
+  psDetected: 5.7,
+  triggerDelayMedianMs: 85,
+  triggerDelayP10Ms: 52,
+  triggerDelayP90Ms: 145,
+  autoTriggerPct: 2.1,
+  tiMedianMs: 1120,
+  tiP25Ms: 980,
+  tiP75Ms: 1260,
+  teMedianMs: 2450,
+  ieRatio: 0.46,
+  timeAtIpapMedianMs: 820,
+  timeAtIpapP25Ms: 680,
+  ipapDwellMedianPct: 73.2,
+  ipapDwellP10Pct: 58.5,
+  prematureCyclePct: 4.2,
+  lateCyclePct: 6.8,
+  endExpPressureMean: 10.05,
+  endExpPressureSd: 0.12,
+  tidalVolumeMedianMl: 485,
+  tidalVolumeP25Ml: 420,
+  tidalVolumeP75Ml: 555,
+  tidalVolumeCv: 0.18,
+  minuteVentProxy: 7.2,
+};
+
+const night1CrossDevice: CrossDeviceResults = {
+  couplingPct: 62.5,
+  h1CouplingPct: 55.8,
+  h2CouplingPct: 69.2,
+  matchedCount: 30,
+  totalCount: 48,
+  clockOffsetSec: 12,
+  offsetConfidence: 'high',
+  reraCoupledRate: 0.625,
+  nonReraRate: 0.18,
+};
+
+// ============================================================
+// Night 2 (2025-01-16): Good night — low FL, with oximetry
+// ============================================================
+
 const night2Glasgow: GlasgowComponents = {
   overall: 1.2,
   skew: 0.18,
@@ -151,8 +271,79 @@ const night2Ox: OximetryResults = {
   doubleTrackingCorrected: 98,
 };
 
-// Night 3: Moderate-bad night — elevated FL, settings changed
+// ============================================================
+// Night 3 (2025-01-15): Moderate FL — first night after settings change
+// ============================================================
+
 const night3Glasgow: GlasgowComponents = {
+  overall: 1.5,
+  skew: 0.25,
+  spike: 0.12,
+  flatTop: 0.3,
+  topHeavy: 0.2,
+  multiPeak: 0.16,
+  noPause: 0.1,
+  inspirRate: 0.22,
+  multiBreath: 0.12,
+  variableAmp: 0.25,
+};
+
+const night3WAT: WATResults = {
+  flScore: 30,
+  regularityScore: 70,
+  periodicityIndex: 16,
+};
+
+const night3NED: NEDResults = {
+  breathCount: 4080,
+  nedMean: 17.2,
+  nedMedian: 15.0,
+  nedP95: 36.0,
+  nedClearFLPct: 2.6,
+  nedBorderlinePct: 7.2,
+  fiMean: 0.7,
+  fiFL85Pct: 10.8,
+  tpeakMean: 0.37,
+  mShapePct: 4.0,
+  reraIndex: 5.5,
+  reraCount: 42,
+  h1NedMean: 15.8,
+  h2NedMean: 18.6,
+  combinedFLPct: 20,
+  estimatedArousalIndex: 10.5,
+};
+
+const night3Ox: OximetryResults = {
+  odi3: 3.8,
+  odi4: 1.5,
+  tBelow90: 1.5,
+  tBelow94: 7.0,
+  hrClin8: 12.5,
+  hrClin10: 7.8,
+  hrClin12: 4.5,
+  hrClin15: 2.0,
+  hrMean10: 5.5,
+  hrMean15: 2.8,
+  coupled3_6: 2.2,
+  coupled3_10: 1.1,
+  coupledHRRatio: 0.58,
+  spo2Mean: 95.4,
+  spo2Min: 87,
+  hrMean: 61.5,
+  hrSD: 5.2,
+  h1: { hrClin10: 6.5, odi3: 3.2, tBelow94: 5.5 },
+  h2: { hrClin10: 9.1, odi3: 4.4, tBelow94: 8.5 },
+  totalSamples: 28200,
+  retainedSamples: 27474,
+  doubleTrackingCorrected: 118,
+};
+
+// ============================================================
+// Night 4 (2025-01-14): Settings change day — EPAP 8→10, IPAP 14→16
+// Worst pre-change night: elevated FL
+// ============================================================
+
+const night4Glasgow: GlasgowComponents = {
   overall: 2.6,
   skew: 0.42,
   spike: 0.28,
@@ -165,13 +356,13 @@ const night3Glasgow: GlasgowComponents = {
   variableAmp: 0.31,
 };
 
-const night3WAT: WATResults = {
+const night4WAT: WATResults = {
   flScore: 48,
   regularityScore: 52,
   periodicityIndex: 32,
 };
 
-const night3NED: NEDResults = {
+const night4NED: NEDResults = {
   breathCount: 4350,
   nedMean: 28.5,
   nedMedian: 25.8,
@@ -190,8 +381,11 @@ const night3NED: NEDResults = {
   estimatedArousalIndex: 22.5,
 };
 
-// Night 4: Good-moderate, no oximetry
-const night4Glasgow: GlasgowComponents = {
+// ============================================================
+// Night 5 (2025-01-13): Good-moderate, no oximetry (old settings)
+// ============================================================
+
+const night5Glasgow: GlasgowComponents = {
   overall: 1.5,
   skew: 0.25,
   spike: 0.12,
@@ -204,13 +398,13 @@ const night4Glasgow: GlasgowComponents = {
   variableAmp: 0.23,
 };
 
-const night4WAT: WATResults = {
+const night5WAT: WATResults = {
   flScore: 28,
   regularityScore: 72,
   periodicityIndex: 16,
 };
 
-const night4NED: NEDResults = {
+const night5NED: NEDResults = {
   breathCount: 4050,
   nedMean: 16.8,
   nedMedian: 14.5,
@@ -229,8 +423,36 @@ const night4NED: NEDResults = {
   estimatedArousalIndex: 9.8,
 };
 
-// Night 5: Oldest — moderate FL
-const night5Glasgow: GlasgowComponents = {
+const night5Ox: OximetryResults = {
+  odi3: 4.5,
+  odi4: 1.9,
+  tBelow90: 2.5,
+  tBelow94: 9.0,
+  hrClin8: 13.8,
+  hrClin10: 8.2,
+  hrClin12: 4.8,
+  hrClin15: 2.1,
+  hrMean10: 5.8,
+  hrMean15: 2.9,
+  coupled3_6: 2.5,
+  coupled3_10: 1.2,
+  coupledHRRatio: 0.58,
+  spo2Mean: 95.0,
+  spo2Min: 85,
+  hrMean: 63.2,
+  hrSD: 5.5,
+  h1: { hrClin10: 7.0, odi3: 3.8, tBelow94: 7.0 },
+  h2: { hrClin10: 9.4, odi3: 5.2, tBelow94: 11.0 },
+  totalSamples: 27000,
+  retainedSamples: 26325,
+  doubleTrackingCorrected: 128,
+};
+
+// ============================================================
+// Night 6 (2025-01-12): Moderate FL, with oximetry (old settings)
+// ============================================================
+
+const night6Glasgow: GlasgowComponents = {
   overall: 2.1,
   skew: 0.35,
   spike: 0.2,
@@ -243,13 +465,13 @@ const night5Glasgow: GlasgowComponents = {
   variableAmp: 0.26,
 };
 
-const night5WAT: WATResults = {
+const night6WAT: WATResults = {
   flScore: 38,
   regularityScore: 62,
   periodicityIndex: 24,
 };
 
-const night5NED: NEDResults = {
+const night6NED: NEDResults = {
   breathCount: 4200,
   nedMean: 22.0,
   nedMedian: 19.5,
@@ -268,7 +490,7 @@ const night5NED: NEDResults = {
   estimatedArousalIndex: 16.1,
 };
 
-const night5Ox: OximetryResults = {
+const night6Ox: OximetryResults = {
   odi3: 6.8,
   odi4: 3.2,
   tBelow90: 5.5,
@@ -293,24 +515,57 @@ const night5Ox: OximetryResults = {
   doubleTrackingCorrected: 185,
 };
 
-// Old settings (before therapy change on night 3)
-const oldSettings: MachineSettings = {
-  deviceModel: 'AirCurve 10 VAuto',
-  epap: 8,
-  ipap: 14,
-  pressureSupport: 6,
-  papMode: 'BiPAP ST',
-  riseTime: 3,
-  trigger: 'Medium',
-  cycle: 'Medium',
-  easyBreathe: false,
-  settingsSource: 'extracted',
+// ============================================================
+// Night 7 (2025-01-11): Oldest — moderate-high FL, no oximetry
+// ============================================================
+
+const night7Glasgow: GlasgowComponents = {
+  overall: 2.3,
+  skew: 0.38,
+  spike: 0.24,
+  flatTop: 0.42,
+  topHeavy: 0.3,
+  multiPeak: 0.28,
+  noPause: 0.2,
+  inspirRate: 0.32,
+  multiBreath: 0.2,
+  variableAmp: 0.28,
 };
 
+const night7WAT: WATResults = {
+  flScore: 42,
+  regularityScore: 58,
+  periodicityIndex: 28,
+};
+
+const night7NED: NEDResults = {
+  breathCount: 4280,
+  nedMean: 25.2,
+  nedMedian: 22.5,
+  nedP95: 46.5,
+  nedClearFLPct: 6.5,
+  nedBorderlinePct: 12.2,
+  fiMean: 0.78,
+  fiFL85Pct: 18.8,
+  tpeakMean: 0.41,
+  mShapePct: 7.0,
+  reraIndex: 9.8,
+  reraCount: 72,
+  h1NedMean: 22.5,
+  h2NedMean: 27.9,
+  combinedFLPct: 32,
+  estimatedArousalIndex: 18.5,
+};
+
+// ============================================================
+// SAMPLE_NIGHTS — 7 nights, newest first
+// ============================================================
+
 export const SAMPLE_NIGHTS: NightResult[] = [
+  // Night 1: 2025-01-17 — moderate FL, oximetry, settingsMetrics, crossDevice
   {
-    date: dateFromStr('2025-01-15'),
-    dateStr: '2025-01-15',
+    date: dateFromStr('2025-01-17'),
+    dateStr: '2025-01-17',
     durationHours: 7.7,
     sessionCount: 1,
     settings: { ...baseSettings },
@@ -319,16 +574,32 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     ned: night1NED,
     oximetry: night1Ox,
     oximetryTrace: null,
-    settingsMetrics: null,
-    crossDevice: null,
-    machineSummary: null,
+    settingsMetrics: night1SettingsMetrics,
+    crossDevice: night1CrossDevice,
+    machineSummary: makeMachineSummary({
+      ahi: 3.8,
+      hi: 2.1,
+      oai: 0.8,
+      cai: 0.5,
+      uai: 0.4,
+      leak50: 2.4,
+      leak95: 12.8,
+      leakMax: 28.5,
+      respRate50: 14.2,
+      tidVol50: 485,
+      spontCycPct: 92,
+      durationMin: 462,
+      maskOnMin: 455,
+      maskEvents: 1,
+    }),
     settingsFingerprint: null,
     csl: null,
     pldSummary: null,
   },
+  // Night 2: 2025-01-16 — good night, low FL, oximetry
   {
-    date: dateFromStr('2025-01-14'),
-    dateStr: '2025-01-14',
+    date: dateFromStr('2025-01-16'),
+    dateStr: '2025-01-16',
     durationHours: 7.2,
     sessionCount: 1,
     settings: { ...baseSettings },
@@ -339,34 +610,66 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     oximetryTrace: null,
     settingsMetrics: null,
     crossDevice: null,
-    machineSummary: null,
+    machineSummary: makeMachineSummary({
+      ahi: 2.5,
+      hi: 1.4,
+      oai: 0.5,
+      cai: 0.3,
+      uai: 0.3,
+      leak50: 1.8,
+      leak95: 8.5,
+      leakMax: 18.2,
+      respRate50: 13.8,
+      tidVol50: 510,
+      spontCycPct: 95,
+      durationMin: 432,
+      maskOnMin: 428,
+      maskEvents: 0,
+    }),
     settingsFingerprint: null,
     csl: null,
     pldSummary: null,
   },
+  // Night 3: 2025-01-15 — moderate FL, first night after settings change, oximetry
   {
-    date: dateFromStr('2025-01-13'),
-    dateStr: '2025-01-13',
-    durationHours: 8.1,
-    sessionCount: 2,
-    settings: { ...oldSettings },
+    date: dateFromStr('2025-01-15'),
+    dateStr: '2025-01-15',
+    durationHours: 7.4,
+    sessionCount: 1,
+    settings: { ...baseSettings },
     glasgow: night3Glasgow,
     wat: night3WAT,
     ned: night3NED,
-    oximetry: null,
+    oximetry: night3Ox,
     oximetryTrace: null,
     settingsMetrics: null,
     crossDevice: null,
-    machineSummary: null,
+    machineSummary: makeMachineSummary({
+      ahi: 3.2,
+      hi: 1.8,
+      oai: 0.6,
+      cai: 0.4,
+      uai: 0.4,
+      leak50: 2.1,
+      leak95: 10.5,
+      leakMax: 22.0,
+      respRate50: 14.0,
+      tidVol50: 495,
+      spontCycPct: 93,
+      durationMin: 444,
+      maskOnMin: 440,
+      maskEvents: 1,
+    }),
     settingsFingerprint: null,
     csl: null,
     pldSummary: null,
   },
+  // Night 4: 2025-01-14 — worst night, elevated FL, old settings (settings change day)
   {
-    date: dateFromStr('2025-01-12'),
-    dateStr: '2025-01-12',
-    durationHours: 6.9,
-    sessionCount: 1,
+    date: dateFromStr('2025-01-14'),
+    dateStr: '2025-01-14',
+    durationHours: 8.1,
+    sessionCount: 2,
     settings: { ...oldSettings },
     glasgow: night4Glasgow,
     wat: night4WAT,
@@ -375,15 +678,31 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     oximetryTrace: null,
     settingsMetrics: null,
     crossDevice: null,
-    machineSummary: null,
+    machineSummary: makeMachineSummary({
+      ahi: 8.2,
+      hi: 4.5,
+      oai: 2.0,
+      cai: 0.8,
+      uai: 0.9,
+      leak50: 3.5,
+      leak95: 18.2,
+      leakMax: 42.0,
+      respRate50: 15.2,
+      tidVol50: 440,
+      spontCycPct: 85,
+      durationMin: 486,
+      maskOnMin: 475,
+      maskEvents: 2,
+    }),
     settingsFingerprint: null,
     csl: null,
     pldSummary: null,
   },
+  // Night 5: 2025-01-13 — good-moderate, with oximetry (old settings)
   {
-    date: dateFromStr('2025-01-11'),
-    dateStr: '2025-01-11',
-    durationHours: 7.5,
+    date: dateFromStr('2025-01-13'),
+    dateStr: '2025-01-13',
+    durationHours: 6.9,
     sessionCount: 1,
     settings: { ...oldSettings },
     glasgow: night5Glasgow,
@@ -393,7 +712,90 @@ export const SAMPLE_NIGHTS: NightResult[] = [
     oximetryTrace: null,
     settingsMetrics: null,
     crossDevice: null,
-    machineSummary: null,
+    machineSummary: makeMachineSummary({
+      ahi: 4.1,
+      hi: 2.2,
+      oai: 0.9,
+      cai: 0.5,
+      uai: 0.5,
+      leak50: 2.6,
+      leak95: 13.5,
+      leakMax: 30.0,
+      respRate50: 14.5,
+      tidVol50: 470,
+      spontCycPct: 90,
+      durationMin: 414,
+      maskOnMin: 408,
+      maskEvents: 1,
+    }),
+    settingsFingerprint: null,
+    csl: null,
+    pldSummary: null,
+  },
+  // Night 6: 2025-01-12 — moderate FL, with oximetry (old settings)
+  {
+    date: dateFromStr('2025-01-12'),
+    dateStr: '2025-01-12',
+    durationHours: 7.5,
+    sessionCount: 1,
+    settings: { ...oldSettings },
+    glasgow: night6Glasgow,
+    wat: night6WAT,
+    ned: night6NED,
+    oximetry: night6Ox,
+    oximetryTrace: null,
+    settingsMetrics: null,
+    crossDevice: null,
+    machineSummary: makeMachineSummary({
+      ahi: 6.5,
+      hi: 3.5,
+      oai: 1.5,
+      cai: 0.7,
+      uai: 0.8,
+      leak50: 3.0,
+      leak95: 15.8,
+      leakMax: 35.0,
+      respRate50: 14.8,
+      tidVol50: 455,
+      spontCycPct: 88,
+      durationMin: 450,
+      maskOnMin: 444,
+      maskEvents: 1,
+    }),
+    settingsFingerprint: null,
+    csl: null,
+    pldSummary: null,
+  },
+  // Night 7: 2025-01-11 — oldest, moderate-high FL, no oximetry (old settings)
+  {
+    date: dateFromStr('2025-01-11'),
+    dateStr: '2025-01-11',
+    durationHours: 7.0,
+    sessionCount: 1,
+    settings: { ...oldSettings },
+    glasgow: night7Glasgow,
+    wat: night7WAT,
+    ned: night7NED,
+    oximetry: null,
+    oximetryTrace: null,
+    settingsMetrics: null,
+    crossDevice: null,
+    machineSummary: makeMachineSummary({
+      ahi: 7.1,
+      hi: 3.8,
+      oai: 1.8,
+      cai: 0.6,
+      uai: 0.9,
+      leak50: 3.2,
+      leak95: 16.5,
+      leakMax: 38.0,
+      respRate50: 15.0,
+      tidVol50: 450,
+      spontCycPct: 87,
+      durationMin: 420,
+      maskOnMin: 414,
+      maskEvents: 1,
+    }),
     settingsFingerprint: null,
     csl: null,
     pldSummary: null,
@@ -402,7 +804,7 @@ export const SAMPLE_NIGHTS: NightResult[] = [
 
 /**
  * Therapy change date for sample data.
- * Settings changed between night 3 (2025-01-13) and night 2 (2025-01-14):
+ * Settings changed between night 4 (2025-01-14) and night 3 (2025-01-15):
  * EPAP 8→10, IPAP 14→16.
  */
-export const SAMPLE_THERAPY_CHANGE_DATE = '2025-01-14';
+export const SAMPLE_THERAPY_CHANGE_DATE = '2025-01-15';


### PR DESCRIPTION
## Summary
- Extends demo mode from 5 to 7 sample nights (Jan 11-17, 2025) with richer data coverage
- Adds `machineSummary` (AHI, leak, respRate, etc.) to all 7 nights so the metrics table shows real data
- Increases oximetry coverage from 3/5 to 5/7 nights
- Adds `settingsMetrics` and `crossDevice` data to night 1 for settings tab content
- Adds 2 new static AI insights referencing 7-night trends and leak correlation
- Updates all UI copy from "5 nights" to "7 nights"
- Shifts therapy change boundary from Jan 14 to Jan 15 (to accommodate the 2 new earlier nights)

## Files changed
- `lib/sample-data.ts` — Core data: 2 new nights, machineSummary on all, settingsMetrics + crossDevice on night 1, oximetry on night 5
- `lib/demo-ai-insights.ts` — 2 new insights (7-night trend, leak correlation)
- `app/analyze/page.tsx` — Demo banner copy: "5 nights" → "7 nights", settings change date Jan 14 → Jan 15
- `app/getting-started/page.tsx` — "5 nights" → "7 nights"
- `app/page.tsx` — Landing page insight example: "5 nights" → "7 nights"
- `e2e/demo-flow.spec.ts` — Night count assertion: 5 → 7
- `__tests__/sample-data.test.ts` — New test file: 13 tests validating data integrity
- `__tests__/insights.test.ts` — Updated indices and comments to match new night ordering
- `__tests__/forum-export.test.ts` — Updated indices for nights without oximetry / multi-session
- `__tests__/contribute-symptoms.test.ts` — Strip settingsMetrics in "omits enhanced fields" test

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (1538 tests, all green)
- [x] `npm run build` passes
- [ ] Verify Vercel preview: demo mode loads 7 nights
- [ ] Verify: all dashboard tabs render without errors in demo mode
- [ ] Verify: metrics table shows AHI column with values
- [ ] Verify: AI insights section shows 6 static insights
- [ ] Verify: exit demo returns to upload form
- [ ] E2E tests pass on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)