### PR TITLE
feat: auth-required contribution foundation (ML Phase 1)

### DIFF
--- a/__tests__/data-contribution.test.tsx
+++ b/__tests__/data-contribution.test.tsx
@@ -45,6 +45,25 @@ vi.mock('@/lib/contribute', () => ({
   trackContributedDates: vi.fn(),
 }));
 
+// ── Mock auth context ──────────────────────────────────────
+const mockAuthValue = {
+  user: null as { id: string } | null,
+  profile: null as { contribution_consent: boolean } | null,
+  subscription: null,
+  session: null,
+  isLoading: false,
+  tier: 'community' as const,
+  isPaid: false,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  refreshProfile: vi.fn(),
+  markWalkthroughComplete: vi.fn(),
+};
+
+vi.mock('@/lib/auth/auth-context', () => ({
+  useAuth: vi.fn(() => mockAuthValue),
+}));
+
 import { DataContribution } from '@/components/dashboard/data-contribution';
 
 // ── Helpers ─────────────────────────────────────────────────
@@ -88,6 +107,9 @@ describe('DataContribution', () => {
     storage.clear();
     sessionStore.clear();
     vi.clearAllMocks();
+    // Reset auth mock to default (no user)
+    mockAuthValue.user = null;
+    mockAuthValue.profile = null;
     // Stats endpoint — always return 0 to avoid social proof noise in tests
     fetchMock.mockResolvedValue({
       ok: true,

--- a/__tests__/waveform-api-route.test.ts
+++ b/__tests__/waveform-api-route.test.ts
@@ -13,6 +13,14 @@ vi.mock('@sentry/nextjs', () => ({
 }));
 
 vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseServer: vi.fn(() => Promise.resolve({
+    auth: {
+      getUser: vi.fn(() => Promise.resolve({
+        data: { user: { id: 'test-user-id' } },
+        error: null,
+      })),
+    },
+  })),
   getSupabaseAdmin: vi.fn(() => ({
     storage: {
       from: () => ({

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -99,7 +99,8 @@ function AnalyzePageInner() {
   const sdFilesRef = useRef<File[]>([]);
   const oxFilesRef = useRef<File[]>([]);
   const oxInputRef = useRef<HTMLInputElement>(null);
-  const contributeOptInRef = useRef(
+  // Legacy localStorage opt-in (still read as fallback during transition)
+  const legacyOptInRef = useRef(
     typeof window !== 'undefined' && (() => { try { return localStorage.getItem('airwaylab_contribute_optin') === '1'; } catch { return false; } })()
   );
   const [oximetryJustAdded, setOximetryJustAdded] = useState(false);
@@ -115,9 +116,11 @@ function AnalyzePageInner() {
   const [isNewUser, setIsNewUser] = useState(false);
   const [analyzeAuthModalOpen, setAnalyzeAuthModalOpen] = useState(false);
   const [engineUpgraded, setEngineUpgraded] = useState(false);
-  const { user } = useAuth();
+  const { user, profile } = useAuth();
   const userRef = useRef(user);
+  const profileRef = useRef(profile);
   useEffect(() => { userRef.current = user; }, [user]);
+  useEffect(() => { profileRef.current = profile; }, [profile]);
   const hasTriggeredAutoUpload = useRef(false);
 
   // Warn before closing/refreshing while analysis is in progress
@@ -264,18 +267,24 @@ function AnalyzePageInner() {
           }),
         }).catch(() => { /* non-critical */ });
 
-        // Contribute data: auto if opted in, show nudge if first time
+        // Contribute data: auto if authenticated + consented, or legacy opt-in
         const contributedDates: string[] = JSON.parse(
           safeGetItem('airwaylab_contributed_dates') || '[]'
         );
         const contributedSet = new Set(contributedDates);
         const newNights = newState.nights.filter((n) => !contributedSet.has(n.dateStr));
 
-        if (contributeOptInRef.current && newNights.length > 0) {
+        // Auth-based consent: auto-contribute if user is authenticated and has contribution_consent
+        const hasConsent = userRef.current
+          ? (profileRef.current?.contribution_consent ?? true)
+          : legacyOptInRef.current;
+
+        if (hasConsent && userRef.current && newNights.length > 0) {
           setAutoSubmitCount(newNights.length);
           submitContribution(newNights);
-        } else if (!contributeOptInRef.current && contributedDates.length === 0) {
-          // Only show nudge if user has never contributed before
+        } else if (!userRef.current && !legacyOptInRef.current && contributedDates.length === 0) {
+          // Only show nudge for unauthenticated users who have never contributed
+          // (authenticated users auto-contribute via consent; nudge not needed)
           pendingNightsRef.current = newState.nights;
           setShowContributeNudge(true);
         }
@@ -381,7 +390,7 @@ function AnalyzePageInner() {
 
   const handleNudgeContribute = useCallback(() => {
     // Store opt-in so future analyses auto-contribute without re-prompting
-    contributeOptInRef.current = true;
+    legacyOptInRef.current = true;
     try { localStorage.setItem('airwaylab_contribute_optin', '1'); } catch { /* noop */ }
     submitContribution(pendingNightsRef.current);
     setShowContributeNudge(false);

--- a/app/api/contribute-data/route.ts
+++ b/app/api/contribute-data/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { z } from 'zod';
-import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { getSupabaseServer, getSupabaseAdmin } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import { exceedsPayloadLimit } from '@/lib/api/payload-guard';
@@ -9,7 +9,7 @@ import type { NightResult } from '@/lib/types';
 import { sendAlert, formatGrowthEmbed } from '@/lib/discord-webhook';
 import { isValidDeviceMode } from '@/lib/device-capabilities';
 
-const limiter = new RateLimiter({ windowMs: 3_600_000, max: 30 });
+const limiter = new RateLimiter({ windowMs: 3_600_000, max: 100 });
 
 // ── Validation ───────────────────────────────────────────────
 const MAX_NIGHTS_PER_CHUNK = 1000; // max nights per request (client chunks larger datasets)
@@ -236,6 +236,16 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    // Auth required — contributions must be linked to a user
+    const supabaseAuth = await getSupabaseServer();
+    if (!supabaseAuth) {
+      return NextResponse.json({ error: 'Auth not configured' }, { status: 503 });
+    }
+    const { data: { user: authUser }, error: authError } = await supabaseAuth.auth.getUser();
+    if (authError || !authUser) {
+      return NextResponse.json({ error: 'Authentication required to contribute data.' }, { status: 401 });
+    }
+
     const ip = getRateLimitKey(request);
     if (await limiter.isLimited(ip)) {
       console.error('[contribute-data] 429 rate limited', { ip });
@@ -327,6 +337,7 @@ export async function POST(request: NextRequest) {
         has_oximetry: anonymised.some((n) => n.oximetry !== null),
         device_model: anonymised[0]?.settings.deviceModel || 'Unknown',
         pap_mode: anonymised[0]?.settings.papMode || 'Unknown',
+        user_id: authUser.id,
       });
 
       if (error) {

--- a/app/api/contribute-oximetry-trace/route.ts
+++ b/app/api/contribute-oximetry-trace/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
-import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { getSupabaseServer, getSupabaseAdmin } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import { exceedsPayloadLimit } from '@/lib/api/payload-guard';
 
-const limiter = new RateLimiter({ windowMs: 3_600_000, max: 20 });
+const limiter = new RateLimiter({ windowMs: 3_600_000, max: 100 });
 const MAX_BODY_BYTES = 2 * 1024 * 1024; // 2 MB
 
 export async function POST(request: NextRequest) {
@@ -14,6 +14,16 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    // Auth required — contributions must be linked to a user
+    const supabaseAuth = await getSupabaseServer();
+    if (!supabaseAuth) {
+      return NextResponse.json({ error: 'Auth not configured' }, { status: 503 });
+    }
+    const { data: { user: authUser }, error: authError } = await supabaseAuth.auth.getUser();
+    if (authError || !authUser) {
+      return NextResponse.json({ error: 'Authentication required to contribute data.' }, { status: 401 });
+    }
+
     const ip = getRateLimitKey(request);
     if (await limiter.isLimited(ip)) {
       return NextResponse.json(
@@ -114,6 +124,7 @@ export async function POST(request: NextRequest) {
       device_model: deviceModel,
       pap_mode: papMode,
       oximetry_results: oximetryResults,
+      user_id: authUser.id,
     });
 
     if (dbError) {

--- a/app/api/contribute-symptoms/route.ts
+++ b/app/api/contribute-symptoms/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { z } from 'zod';
-import { getSupabaseServiceRole } from '@/lib/supabase/server';
+import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import { validateOrigin } from '@/lib/csrf';
 
-/** Rate limit: 30 requests per hour per IP */
+/** Rate limit: 100 requests per hour per IP (relaxed for authenticated users) */
 const symptomRateLimiter = new RateLimiter({
   windowMs: 3_600_000,
-  max: 30,
+  max: 100,
 });
 
 const PayloadSchema = z.object({
@@ -26,6 +26,10 @@ const PayloadSchema = z.object({
   pap_mode: z.string().max(50),
   device_model: z.string().max(100),
   duration_hours: z.number().min(0).max(24),
+  // Night date for user-based dedup (YYYY-MM-DD)
+  night_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  // Engine version for ML dataset versioning
+  engine_version: z.string().max(50).optional(),
   // Enhanced fields (optional for backward compat)
   hypopnea_index: z.number().min(0).optional(),
   amplitude_cv: z.number().min(0).optional(),
@@ -50,6 +54,16 @@ export async function POST(request: NextRequest) {
   // CSRF protection
   if (!validateOrigin(request)) {
     return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
+  }
+
+  // Auth required — contributions must be linked to a user
+  const supabaseAuth = await getSupabaseServer();
+  if (!supabaseAuth) {
+    return NextResponse.json({ error: 'Auth not configured' }, { status: 503 });
+  }
+  const { data: { user: authUser }, error: authError } = await supabaseAuth.auth.getUser();
+  if (authError || !authUser) {
+    return NextResponse.json({ error: 'Authentication required to contribute data.' }, { status: 401 });
   }
 
   // Rate limiting
@@ -78,39 +92,71 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    // Generate a dedup hash from IP + metrics (prevents same user re-submitting same data)
-    const dedupInput = `${ip}|${payload.ifl_risk}|${payload.glasgow_overall}|${payload.fl_score}|${payload.ned_mean}|${payload.symptom_rating}`;
-    const dedupHash = await sha256(dedupInput);
+    const rowData = {
+      user_id: authUser.id,
+      symptom_rating: payload.symptom_rating,
+      ifl_risk: payload.ifl_risk,
+      glasgow_overall: payload.glasgow_overall,
+      fl_score: payload.fl_score,
+      ned_mean: payload.ned_mean,
+      regularity: payload.regularity,
+      eai: payload.eai,
+      rera_index: payload.rera_index,
+      combined_fl_pct: payload.combined_fl_pct,
+      pressure_bucket: payload.pressure_bucket,
+      pap_mode: payload.pap_mode,
+      device_model: payload.device_model,
+      duration_hours: payload.duration_hours,
+      night_date: payload.night_date ?? null,
+      engine_version: payload.engine_version ?? null,
+      // Enhanced fields (nullable — backward compatible)
+      hypopnea_index: payload.hypopnea_index ?? null,
+      amplitude_cv: payload.amplitude_cv ?? null,
+      unstable_epoch_pct: payload.unstable_epoch_pct ?? null,
+      tidal_volume_cv: payload.tidal_volume_cv ?? null,
+      trigger_delay_median_ms: payload.trigger_delay_median_ms ?? null,
+      ie_ratio: payload.ie_ratio ?? null,
+    };
 
-    // Upsert — if the same hash exists, update the symptom rating
-    const { error } = await adminClient
-      .from('symptom_contributions')
-      .upsert(
-        {
-          dedup_hash: dedupHash,
-          symptom_rating: payload.symptom_rating,
-          ifl_risk: payload.ifl_risk,
-          glasgow_overall: payload.glasgow_overall,
-          fl_score: payload.fl_score,
-          ned_mean: payload.ned_mean,
-          regularity: payload.regularity,
-          eai: payload.eai,
-          rera_index: payload.rera_index,
-          combined_fl_pct: payload.combined_fl_pct,
-          pressure_bucket: payload.pressure_bucket,
-          pap_mode: payload.pap_mode,
-          device_model: payload.device_model,
-          duration_hours: payload.duration_hours,
-          // Enhanced fields (nullable — backward compatible)
-          hypopnea_index: payload.hypopnea_index ?? null,
-          amplitude_cv: payload.amplitude_cv ?? null,
-          unstable_epoch_pct: payload.unstable_epoch_pct ?? null,
-          tidal_volume_cv: payload.tidal_volume_cv ?? null,
-          trigger_delay_median_ms: payload.trigger_delay_median_ms ?? null,
-          ie_ratio: payload.ie_ratio ?? null,
-        },
-        { onConflict: 'dedup_hash' }
-      );
+    // User-based dedup: if night_date is present, upsert on (user_id, night_date)
+    // using the unique index idx_symptom_contributions_user_night.
+    // Legacy anonymous rows still use dedup_hash — not affected.
+    let error;
+    if (payload.night_date) {
+      // Use raw SQL upsert via the unique index on (user_id, night_date)
+      // Since Supabase JS client doesn't support partial index conflict,
+      // we first try to find an existing row, then insert or update.
+      const { data: existing } = await adminClient
+        .from('symptom_contributions')
+        .select('id')
+        .eq('user_id', authUser.id)
+        .eq('night_date', payload.night_date)
+        .maybeSingle();
+
+      if (existing) {
+        const { error: updateError } = await adminClient
+          .from('symptom_contributions')
+          .update(rowData)
+          .eq('id', existing.id);
+        error = updateError;
+      } else {
+        // Also generate a dedup_hash for backward compatibility (column may have NOT NULL)
+        const dedupInput = `${authUser.id}|${payload.night_date}|${payload.symptom_rating}`;
+        const dedupHash = await sha256(dedupInput);
+        const { error: insertError } = await adminClient
+          .from('symptom_contributions')
+          .insert({ ...rowData, dedup_hash: dedupHash });
+        error = insertError;
+      }
+    } else {
+      // No night_date — fallback to hash-based dedup
+      const dedupInput = `${authUser.id}|${payload.ifl_risk}|${payload.glasgow_overall}|${payload.fl_score}|${payload.ned_mean}|${payload.symptom_rating}`;
+      const dedupHash = await sha256(dedupInput);
+      const { error: upsertError } = await adminClient
+        .from('symptom_contributions')
+        .upsert({ ...rowData, dedup_hash: dedupHash }, { onConflict: 'dedup_hash' });
+      error = upsertError;
+    }
 
     if (error) {
       console.error('[contribute-symptoms] DB error:', error.message);

--- a/app/api/contribute-waveforms/route.ts
+++ b/app/api/contribute-waveforms/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
-import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { getSupabaseServer, getSupabaseAdmin } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import { exceedsPayloadLimit } from '@/lib/api/payload-guard';
 
-const limiter = new RateLimiter({ windowMs: 3_600_000, max: 20 });
+const limiter = new RateLimiter({ windowMs: 3_600_000, max: 100 });
 const MAX_BODY_BYTES = 5 * 1024 * 1024; // 5 MB
 
 export async function POST(request: NextRequest) {
@@ -14,6 +14,16 @@ export async function POST(request: NextRequest) {
   }
 
   try {
+    // Auth required — contributions must be linked to a user
+    const supabaseAuth = await getSupabaseServer();
+    if (!supabaseAuth) {
+      return NextResponse.json({ error: 'Auth not configured' }, { status: 503 });
+    }
+    const { data: { user: authUser }, error: authError } = await supabaseAuth.auth.getUser();
+    if (authError || !authUser) {
+      return NextResponse.json({ error: 'Authentication required to contribute data.' }, { status: 401 });
+    }
+
     const ip = getRateLimitKey(request);
     if (await limiter.isLimited(ip)) {
       return NextResponse.json(
@@ -132,6 +142,7 @@ export async function POST(request: NextRequest) {
       channel_count: channelCount,
       format_version: formatVersion,
       has_pressure: hasPressure,
+      user_id: authUser.id,
     });
 
     if (dbError) {

--- a/components/auth/auth-modal.tsx
+++ b/components/auth/auth-modal.tsx
@@ -20,6 +20,7 @@ export function AuthModal({ open, onClose }: Props) {
   const [sent, setSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [consentChecked, setConsentChecked] = useState(false);
+  const [contributionConsent, setContributionConsent] = useState(true);
   const [emailOptIn, setEmailOptIn] = useState(true);
   const focusTrapRef = useFocusTrap(open);
 
@@ -47,6 +48,16 @@ export function AuthModal({ open, onClose }: Props) {
         }
       }
 
+      // Persist contribution consent preference for post-auth pickup
+      try {
+        localStorage.setItem(
+          'airwaylab_contribution_consent_pending',
+          contributionConsent ? '1' : '0'
+        );
+      } catch {
+        // noop
+      }
+
       const { error: signInError } = await signIn(trimmed);
       setLoading(false);
 
@@ -68,7 +79,7 @@ export function AuthModal({ open, onClose }: Props) {
       setSent(true);
       events.authMagicLinkSent();
     },
-    [email, emailOptIn, signIn]
+    [email, emailOptIn, contributionConsent, signIn]
   );
 
   const handleClose = useCallback(() => {
@@ -77,6 +88,7 @@ export function AuthModal({ open, onClose }: Props) {
     setSent(false);
     setError(null);
     setConsentChecked(false);
+    setContributionConsent(true);
     setEmailOptIn(true);
     onClose();
   }, [onClose]);
@@ -159,6 +171,20 @@ export function AuthModal({ open, onClose }: Props) {
                   <a href="/privacy" target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2 hover:text-primary/80">
                     Privacy Policy
                   </a>
+                </span>
+              </label>
+
+              {/* Contribution consent checkbox (default checked) */}
+              <label className="flex cursor-pointer items-start gap-2.5 px-3 py-1">
+                <input
+                  type="checkbox"
+                  checked={contributionConsent}
+                  onChange={(e) => setContributionConsent(e.target.checked)}
+                  data-testid="contribution-consent-checkbox"
+                  className="mt-0.5 h-4 w-4 shrink-0 rounded border-border accent-primary"
+                />
+                <span className="text-xs leading-snug text-muted-foreground">
+                  Help improve sleep analysis for everyone. Your pseudonymised analysis data will be used to build better models. You can withdraw anytime via Account Settings.
                 </span>
               </label>
 

--- a/components/dashboard/data-contribution.tsx
+++ b/components/dashboard/data-contribution.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect } from 'react';
 import * as Sentry from '@sentry/nextjs';
 import { Users, Loader2, X, Shield, Heart, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useAuth } from '@/lib/auth/auth-context';
 import { events } from '@/lib/analytics';
 import { contributeNights, trackContributedDates } from '@/lib/contribute';
 import { getConsentState, setConsentState } from '@/components/upload/contribution-consent-utils';
@@ -23,12 +24,11 @@ interface Props {
 }
 
 /**
- * Opt-in anonymous data contribution banner.
- * Shown after analysis completes. Dismissible, remembers choice.
+ * Data contribution status display.
  *
- * For opted-in users (airwaylab_contribute_optin === '1'), the banner
- * shows auto-contribution status instead of a manual submit button.
- * The manual UI is only shown for users who haven't opted in.
+ * For authenticated users with contribution_consent, shows auto-sync status.
+ * For unauthenticated users or those without consent, shows nothing (contribution
+ * requires authentication since Phase 1 of ML data maximisation).
  */
 export function DataContribution({
   nights,
@@ -36,6 +36,11 @@ export function DataContribution({
   autoSubmitStatus = 'idle',
   autoSubmitCount = 0,
 }: Props) {
+  const { user, profile } = useAuth();
+  // Determine if user has contribution consent from their profile (auth-based)
+  // Falls back to legacy localStorage-based opt-in for backward compat during transition
+  const hasProfileConsent = profile?.contribution_consent ?? false;
+
   // Initialize all browser-dependent state to safe defaults to match SSR.
   // Actual values are loaded in the useEffect below to avoid hydration mismatches.
   const [dismissed, setDismissed] = useState(false);
@@ -48,7 +53,8 @@ export function DataContribution({
     try {
       if (sessionStorage.getItem(DISMISS_KEY) === '1') setDismissed(true);
     } catch { /* noop */ }
-    setIsOptedIn(getConsentState());
+    // Auth-based consent takes priority over localStorage
+    setIsOptedIn(user ? hasProfileConsent : getConsentState());
     try {
       const raw = localStorage.getItem('airwaylab_contributed_dates');
       if (raw) {
@@ -56,7 +62,7 @@ export function DataContribution({
         if (Array.isArray(parsed)) setContributedDates(parsed);
       }
     } catch { /* noop */ }
-  }, []);
+  }, [user, hasProfileConsent]);
 
   const [status, setStatus] = useState<'idle' | 'sending' | 'success' | 'error'>('idle');
   const [expanded, setExpanded] = useState(false);

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -18,6 +18,7 @@ interface Profile {
   email_opt_in: boolean;
   discord_id: string | null;
   discord_username: string | null;
+  contribution_consent: boolean;
 }
 
 interface Subscription {
@@ -61,7 +62,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // M1: Handle query errors instead of swallowing them
     const { data: profileData, error: profileError } = await supabase
       .from('profiles')
-      .select('id, email, display_name, tier, stripe_customer_id, show_on_supporters, walkthrough_completed, email_opt_in, discord_id, discord_username')
+      .select('id, email, display_name, tier, stripe_customer_id, show_on_supporters, walkthrough_completed, email_opt_in, discord_id, discord_username, contribution_consent')
       .eq('id', userId)
       .single();
 
@@ -93,6 +94,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         email_opt_in: profileData.email_opt_in ?? false,
         discord_id: profileData.discord_id ?? null,
         discord_username: profileData.discord_username ?? null,
+        contribution_consent: profileData.contribution_consent ?? true,
       });
     }
 
@@ -204,6 +206,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 credentials: 'same-origin',
                 body: JSON.stringify({ opt_in: true }),
               }).catch(() => { /* non-critical */ });
+            }
+          } catch { /* localStorage unavailable */ }
+
+          // Check if user signed up with contribution consent preference
+          try {
+            const consentPending = localStorage.getItem('airwaylab_contribution_consent_pending');
+            if (consentPending !== null) {
+              localStorage.removeItem('airwaylab_contribution_consent_pending');
+              const consentValue = consentPending === '1';
+              // Update profiles table with consent preference (fire-and-forget)
+              if (supabase) {
+                void (async () => {
+                  const { error: consentErr } = await supabase
+                    .from('profiles')
+                    .update({ contribution_consent: consentValue })
+                    .eq('id', initialSession.user.id);
+                  if (consentErr) {
+                    console.error('[auth-context] Failed to update contribution consent:', consentErr.message);
+                  }
+                })();
+              }
             }
           } catch { /* localStorage unavailable */ }
         }).finally(() => setIsLoading(false));

--- a/lib/contribute-oximetry-trace.ts
+++ b/lib/contribute-oximetry-trace.ts
@@ -1,7 +1,8 @@
 // ============================================================
 // AirwayLab — Oximetry Trace Contribution
 // Compresses HR/SpO2 timeseries and uploads to the research
-// dataset. Runs silently in the background — no UI feedback,
+// dataset. Requires authentication — contributions are linked
+// to user_id. Runs silently in the background — no UI feedback,
 // failures logged to Sentry only.
 // ============================================================
 
@@ -166,6 +167,7 @@ export async function contributeOximetryTraceBackground(
           'x-pap-mode': night.settings.papMode || 'Unknown',
           'x-oximetry-results': JSON.stringify(anonymiseOximetry(night)),
         },
+        credentials: 'same-origin',
         body: compressed,
       });
 

--- a/lib/contribute-symptoms.ts
+++ b/lib/contribute-symptoms.ts
@@ -1,11 +1,13 @@
 // ============================================================
 // AirwayLab — Symptom Contribution Client
-// Builds and submits anonymised symptom rating payloads.
+// Builds and submits pseudonymised symptom rating payloads.
+// Requires authentication — contributions are linked to user_id.
 // ============================================================
 
 import * as Sentry from '@sentry/nextjs';
 import type { NightResult } from './types';
 import { computeIFLRisk } from './ifl-risk';
+import { ENGINE_VERSION } from './engine-version';
 
 /** Bucket a pressure value into a privacy-preserving range string. */
 export function bucketPressure(pressure: number): string {
@@ -31,6 +33,8 @@ interface SymptomContributionPayload {
   pap_mode: string;
   device_model: string;
   duration_hours: number;
+  night_date: string;
+  engine_version: string;
   // Enhanced fields (v0.7.0+)
   hypopnea_index?: number;
   amplitude_cv?: number;
@@ -59,6 +63,8 @@ export function buildContributionPayload(
     pap_mode: night.settings.papMode,
     device_model: night.settings.deviceModel,
     duration_hours: Math.round(night.durationHours * 100) / 100,
+    night_date: night.dateStr,
+    engine_version: ENGINE_VERSION,
   };
 
   // Enhanced fields — only include when available
@@ -91,7 +97,8 @@ export async function contributeSymptoms(
     const res = await fetch('/api/contribute-symptoms', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ consent: true, ...payload }),
+      credentials: 'same-origin',
+      body: JSON.stringify(payload),
       signal,
     });
     return res.ok;

--- a/lib/contribute-waveforms.ts
+++ b/lib/contribute-waveforms.ts
@@ -1,7 +1,8 @@
 // ============================================================
 // AirwayLab — Waveform Data Contribution
 // Extracts flow data from raw EDF files, compresses with gzip,
-// and uploads to the research dataset. Runs silently in the
+// and uploads to the research dataset. Requires authentication —
+// contributions are linked to user_id. Runs silently in the
 // background — no UI feedback, failures logged to Sentry only.
 // ============================================================
 
@@ -282,6 +283,7 @@ async function uploadWaveform(
     const res = await fetch('/api/contribute-waveforms', {
       method: 'POST',
       headers,
+      credentials: 'same-origin',
       body: compressedData,
     });
 

--- a/lib/contribute.ts
+++ b/lib/contribute.ts
@@ -1,6 +1,7 @@
 // ============================================================
 // AirwayLab — Data Contribution Client
-// Submits anonymised analysis results in chunks.
+// Submits pseudonymised analysis results in chunks.
+// Requires authentication — contributions are linked to user_id.
 // No night count cap — large datasets are chunked automatically.
 // ============================================================
 
@@ -87,7 +88,8 @@ interface ContributionResult {
 }
 
 /**
- * Contribute anonymised night data to the community dataset.
+ * Contribute pseudonymised night data to the community dataset.
+ * Requires authentication — server will reject unauthenticated requests (401).
  * Automatically chunks large datasets into multiple requests
  * sharing a single contributionId for grouping.
  * Night context (structured enums from night notes) is included when available.
@@ -120,6 +122,7 @@ export async function contributeNights(
       const res = await fetch('/api/contribute-data', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
         body: JSON.stringify({
           nights: chunk,
           contributionId,
@@ -130,6 +133,11 @@ export async function contributeNights(
       if (res.ok) {
         success = true;
         break;
+      }
+
+      // Not authenticated — bail immediately, don't retry
+      if (res.status === 401) {
+        throw new Error('Authentication required to contribute data.');
       }
 
       // Retry with exponential backoff on rate limit

--- a/supabase/migrations/037_ml_data_maximisation.sql
+++ b/supabase/migrations/037_ml_data_maximisation.sql
@@ -1,0 +1,31 @@
+-- Phase 1: Auth-required contribution foundation
+-- Adds user_id to contribution tables, contribution_consent to profiles,
+-- and indexes for user-based queries.
+
+-- Add user_id to existing contribution tables (nullable for legacy anonymous data)
+ALTER TABLE data_contributions ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+ALTER TABLE symptom_contributions ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+ALTER TABLE waveform_contributions ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+ALTER TABLE oximetry_trace_contributions ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+
+-- Add contribution_consent to profiles (default TRUE, backfill all existing users)
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS contribution_consent BOOLEAN DEFAULT TRUE;
+UPDATE profiles SET contribution_consent = TRUE WHERE contribution_consent IS NULL;
+
+-- Add engine_version to symptom_contributions (needed for ML dataset versioning)
+ALTER TABLE symptom_contributions ADD COLUMN IF NOT EXISTS engine_version TEXT;
+
+-- Add night_date to symptom_contributions (needed for user-based dedup)
+ALTER TABLE symptom_contributions ADD COLUMN IF NOT EXISTS night_date DATE;
+
+-- Indexes for user-based queries
+CREATE INDEX IF NOT EXISTS idx_data_contributions_user ON data_contributions(user_id) WHERE user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_symptom_contributions_user ON symptom_contributions(user_id) WHERE user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_waveform_contributions_user ON waveform_contributions(user_id) WHERE user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_oxtrace_contributions_user ON oximetry_trace_contributions(user_id) WHERE user_id IS NOT NULL;
+
+-- Unique constraint for user-based dedup on symptom_contributions
+-- (user_id + night_date replaces IP-based dedup_hash for authenticated users)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_symptom_contributions_user_night
+  ON symptom_contributions(user_id, night_date)
+  WHERE user_id IS NOT NULL AND night_date IS NOT NULL;


### PR DESCRIPTION
## Summary
Foundation for ML data maximisation. Shifts from anonymous opt-in to auth-required auto-contribution.

- **Migration 037**: Adds `user_id` (nullable FK) to all 4 contribution tables, `contribution_consent` (default TRUE, backfilled) to profiles, `engine_version` + `night_date` to symptom_contributions, user-based indexes
- **Auth context**: `contribution_consent` exposed via `useAuth()`, fetched with profile
- **4 API routes updated**: contribute-data, contribute-waveforms, contribute-symptoms, contribute-oximetry-trace all require auth, pass user_id, rate limits raised to 100/hr
- **Dedup switched**: symptom_contributions uses `(user_id, night_date)` instead of IP hash
- **Client libraries**: All 4 contribution clients pass `credentials: 'same-origin'`
- **Signup flow**: Pre-checked consent checkbox with pseudonymised data disclosure
- **Auto-contribution**: Uses profile-based consent instead of localStorage flag
- **No nudge for existing users**: Migration backfills `contribution_consent = TRUE`

Part of ML Data Maximisation initiative. See `specs/ml-data-maximisation.md`.

**IMPORTANT**: Migration 037 must be applied to Supabase BEFORE merging this PR.

## Test plan
- [ ] New signup shows contribution consent checkbox (pre-checked)
- [ ] Unchecking consent at signup persists to profile
- [ ] Existing users auto-contribute without being asked
- [ ] Unauthenticated POST to /api/contribute-data returns 401
- [ ] Authenticated user's contributions include user_id in DB
- [ ] Duplicate symptom contribution (same user + night) upserts
- [ ] AI insights still work (contribution is non-blocking)
- [ ] Legacy localStorage consent still works for unauthenticated users

## Pre-merge checklist
- [x] Full pipeline passes (lint, typecheck, test, build -- 1550 tests pass)
- [x] No new dependencies
- [x] No protected module changes
- [x] Migration file created (037_ml_data_maximisation.sql)
- [ ] Migration applied to Supabase (BEFORE merge)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked

Generated with [Claude Code](https://claude.com/claude-code)