### PR TITLE
fix: rewrite flow limitation blog post with approved content

### DIFF
--- a/app/blog/posts/understanding-flow-limitation.tsx
+++ b/app/blog/posts/understanding-flow-limitation.tsx
@@ -1,191 +1,324 @@
 import Link from 'next/link';
-import { Wind, AlertTriangle, TrendingDown, Waves, ArrowRight, Lightbulb, BookOpen } from 'lucide-react';
+import { Wind, AlertTriangle, Waves, Search, BarChart3, BookOpen, ArrowRight } from 'lucide-react';
 
 export default function UnderstandingFlowLimitationPost() {
   return (
     <article>
       <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
-        You check your PAP machine every morning. AHI: 1.2. The app says &quot;Great night!&quot;
-        with a smiley face. But you still wake up exhausted, foggy, and reaching for your third
-        coffee by 10 AM. Sound familiar? The culprit might be something your machine tracks but
-        never tells you about: <strong className="text-foreground">flow limitation</strong>.
+        Your PAP machine shows AHI: 0.8. The app gives you a thumbs up. But you still drag
+        yourself out of bed feeling like you barely slept. If this sounds familiar, you&apos;re
+        not alone &mdash; and the answer might be hiding in something called{' '}
+        <strong className="text-foreground">flow limitation</strong>.
+      </p>
+      <p className="mt-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+        Flow limitation is a partial narrowing of your upper airway that changes the shape of
+        each breath without fully blocking airflow. It happens below the thresholds your machine
+        uses to score events. That means your data contains evidence of it, but the summary
+        screen never shows it.
+      </p>
+      <p className="mt-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+        This guide explains what cpap flow limitation is, how it differs from the events your
+        machine does count, and how tools like AirwayLab can make it visible in your own
+        breathing data.
       </p>
 
       {/* What Is Flow Limitation? */}
       <section className="mt-10">
         <div className="flex items-center gap-2.5">
           <Wind className="h-5 w-5 text-blue-400" />
-          <h2 className="text-xl font-bold sm:text-2xl">What Is Flow Limitation, Exactly?</h2>
+          <h2 className="text-xl font-bold sm:text-2xl">What Is Flow Limitation?</h2>
         </div>
         <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
           <p>
-            During normal breathing, air flows freely through your upper airway. The flow signal
-            looks like a smooth, rounded wave — air in, air out, nice and symmetrical. But when
-            your airway starts to narrow (without fully collapsing), the flow pattern changes.
-            Instead of a smooth curve, you get a flattened top — as if someone put a lid on your
-            breath.
+            During normal breathing, air flows through your upper airway in a smooth, rounded
+            wave &mdash; in and out, symmetrical. When your airway starts to narrow, the shape of
+            that waveform changes. Instead of a smooth curve, the top flattens out, as if someone
+            pressed down on a garden hose without fully stepping on it.
           </p>
           <p>
-            This partial narrowing is flow limitation. Your airway hasn&apos;t collapsed enough to
-            count as an apnea (complete blockage) or even a hypopnea (significant reduction with
-            oxygen drop). But it&apos;s working harder than it should, and your body notices.
+            That flattened waveform is <strong className="text-foreground">flow limitation</strong>.
+            Air still moves, but it&apos;s restricted. Your body has to work harder to pull the same
+            volume of air through a narrower passage.
           </p>
           <div className="rounded-xl border border-blue-500/20 bg-blue-500/5 p-5">
-            <p className="text-sm font-medium text-blue-400">Think of it like a garden hose</p>
+            <p className="text-sm font-medium text-blue-400">Think of it like breathing through a straw</p>
             <p className="mt-1 text-sm text-muted-foreground">
-              An apnea is when someone steps on the hose completely — no water flows. A hypopnea
-              is a partial step — water trickles. Flow limitation? That&apos;s a kink in the hose.
-              Water still flows, but the pressure pattern changes. Your sprinkler (or in this case,
-              your body) knows something is off.
+              With a normal-sized straw, breathing is easy. Now imagine switching to a cocktail
+              straw. Air still flows, but every breath requires more effort. You&apos;d notice it
+              quickly while awake. During sleep, your conscious awareness is off &mdash; but your
+              nervous system still responds to the extra work, often with micro-arousals that
+              fragment your sleep architecture without you ever knowing.
             </p>
           </div>
+          <p>
+            The clinical literature calls this{' '}
+            <strong className="text-foreground">inspiratory flow limitation (IFL)</strong>, and
+            it&apos;s the underlying mechanism behind{' '}
+            <Link href="/glossary#rera" className="text-primary hover:text-primary/80">
+              Respiratory Effort-Related Arousals (RERAs)
+            </Link>{' '}
+            and Upper Airway Resistance Syndrome (UARS).
+          </p>
         </div>
       </section>
 
-      {/* Why AHI Misses It */}
+      {/* How Flow Limitation Differs */}
       <section className="mt-10">
         <div className="flex items-center gap-2.5">
           <AlertTriangle className="h-5 w-5 text-amber-400" />
-          <h2 className="text-xl font-bold sm:text-2xl">Why Your AHI Says You&apos;re Fine</h2>
+          <h2 className="text-xl font-bold sm:text-2xl">
+            How Flow Limitation Differs from Apneas and Hypopneas
+          </h2>
         </div>
         <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
           <p>
-            The Apnea-Hypopnea Index only counts events that meet specific criteria: a breathing
-            pause of at least 10 seconds (apnea) or a 30%+ airflow reduction accompanied by an
-            oxygen desaturation of 3-4% (hypopnea). Flow limitation fits neatly into neither
-            category.
+            Your PAP machine reports three types of events that make up the Apnea-Hypopnea Index:
+          </p>
+          <ul className="ml-4 space-y-2">
+            <li className="flex gap-2">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400" />
+              <span>
+                <strong className="text-foreground">Apnea:</strong> Complete cessation of airflow
+                for at least 10 seconds. The airway fully collapses.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400" />
+              <span>
+                <strong className="text-foreground">Hypopnea:</strong> Airflow drops by 30% or
+                more for at least 10 seconds, typically accompanied by an oxygen desaturation of
+                3-4%.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400" />
+              <span>
+                <strong className="text-foreground">AHI:</strong> The combined count of apneas
+                and hypopneas per hour of recorded time.
+              </span>
+            </li>
+          </ul>
+          <p>
+            Flow limitation is fundamentally different. It&apos;s a{' '}
+            <strong className="text-foreground">partial narrowing</strong> that restricts airflow
+            without meeting the duration or severity thresholds that define scored events.
+          </p>
+
+          {/* Comparison table */}
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs sm:text-sm">
+              <thead>
+                <tr className="border-b border-border/50">
+                  <th className="pb-2 pr-4 text-left font-semibold text-foreground" />
+                  <th className="pb-2 pr-4 text-left font-semibold text-foreground">Apnea</th>
+                  <th className="pb-2 pr-4 text-left font-semibold text-foreground">Hypopnea</th>
+                  <th className="pb-2 text-left font-semibold text-foreground">Flow Limitation</th>
+                </tr>
+              </thead>
+              <tbody className="text-muted-foreground">
+                <tr className="border-b border-border/30">
+                  <td className="py-2 pr-4 font-medium text-foreground">Airflow reduction</td>
+                  <td className="py-2 pr-4">100% (complete stop)</td>
+                  <td className="py-2 pr-4">&ge;30%</td>
+                  <td className="py-2">Partial (variable)</td>
+                </tr>
+                <tr className="border-b border-border/30">
+                  <td className="py-2 pr-4 font-medium text-foreground">Minimum duration</td>
+                  <td className="py-2 pr-4">10 seconds</td>
+                  <td className="py-2 pr-4">10 seconds</td>
+                  <td className="py-2">No minimum</td>
+                </tr>
+                <tr className="border-b border-border/30">
+                  <td className="py-2 pr-4 font-medium text-foreground">O&#8322; desaturation</td>
+                  <td className="py-2 pr-4">Often present</td>
+                  <td className="py-2 pr-4">Usually required (3-4%)</td>
+                  <td className="py-2">Typically absent</td>
+                </tr>
+                <tr className="border-b border-border/30">
+                  <td className="py-2 pr-4 font-medium text-foreground">Counted by AHI</td>
+                  <td className="py-2 pr-4">Yes</td>
+                  <td className="py-2 pr-4">Yes</td>
+                  <td className="py-2 font-semibold text-amber-400">No</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-medium text-foreground">Detection method</td>
+                  <td className="py-2 pr-4">Threshold-based</td>
+                  <td className="py-2 pr-4">Threshold-based</td>
+                  <td className="py-2 font-semibold text-blue-400">Breath shape analysis</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p>
+            A person can have hundreds of flow-limited breaths per hour while maintaining an AHI
+            of zero. Research from the Sleep Heart Health Study and others has shown that this
+            pattern &mdash; low AHI with significant flow limitation &mdash; is associated with
+            daytime sleepiness, unrefreshing sleep, and cognitive difficulties that mirror
+            untreated sleep apnea.
           </p>
           <p>
-            Research published in the <em>European Respiratory Journal</em> has shown that patients
-            can have significant flow limitation throughout the night with a perfectly normal AHI.
-            These patients often report symptoms identical to those with untreated sleep apnea:
-            daytime sleepiness, unrefreshing sleep, morning headaches, and cognitive fog.
-          </p>
-          <p>
-            The clinical term for these events is{' '}
-            <Link href="/glossary#rera" className="text-primary hover:text-primary/80">
-              Respiratory Effort-Related Arousals (RERAs)
-            </Link>
-            . They&apos;re breathing disturbances that cause brief awakenings — enough to fragment
-            your sleep architecture — but don&apos;t show up in the AHI. Some sleep physicians use
-            the Respiratory Disturbance Index (RDI), which includes RERAs, but your PAP machine
-            doesn&apos;t report this.
+            This is why cpap flow limitation matters: your machine&apos;s headline number may tell
+            you therapy looks adequate, while the underlying data tells a more nuanced story.
           </p>
         </div>
       </section>
 
-      {/* How to Detect It */}
+      {/* Why Your Machine Doesn't Report It */}
       <section className="mt-10">
         <div className="flex items-center gap-2.5">
-          <Waves className="h-5 w-5 text-emerald-400" />
-          <h2 className="text-xl font-bold sm:text-2xl">Detecting Flow Limitation in Your Data</h2>
+          <Search className="h-5 w-5 text-rose-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            Why Your Machine Doesn&apos;t Report It
+          </h2>
         </div>
         <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
           <p>
-            The good news: your ResMed machine already records the data needed to detect flow
-            limitation. It&apos;s stored on your SD card in detailed flow waveforms. The machine
-            just doesn&apos;t analyze it for you in a meaningful way.
+            PAP machines from ResMed and other manufacturers record detailed breath-by-breath
+            flow waveforms on the SD card. This data contains everything needed to detect flow
+            limitation patterns. But the machine&apos;s built-in reporting doesn&apos;t surface it.
           </p>
           <p>
-            Researchers have developed several approaches to quantify flow limitation from these
-            waveforms:
+            There are practical reasons for this. Flow limitation scoring requires{' '}
+            <strong className="text-foreground">breath shape analysis</strong> &mdash; examining
+            the contour of each inspiratory waveform for flattening, skewing, and other distortion
+            patterns. The AHI algorithm uses simpler threshold logic: did airflow drop by X% for
+            Y seconds? Flow limitation is a shape problem, not a threshold problem.
           </p>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">
-                <Link href="/glossary#glasgow-index" className="hover:text-primary">Glasgow Index</Link>
+          <p>
+            Some machines do flag flow limitation events internally, but these flags don&apos;t
+            appear in the companion app or on the summary screen you check each morning. They&apos;re
+            stored in the detailed EDF data files on the SD card, accessible only through
+            third-party analysis software.
+          </p>
+        </div>
+      </section>
+
+      {/* Glasgow Index and NED */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Waves className="h-5 w-5 text-emerald-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            Glasgow Index and NED: Making Flow Limitation Measurable
+          </h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            Two key approaches have emerged from clinical research for quantifying cpap flow
+            limitation from waveform data:
+          </p>
+
+          <div className="space-y-4">
+            <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-5">
+              <p className="text-sm font-semibold text-emerald-400">
+                <Link href="/glossary#glasgow-index" className="hover:text-emerald-300">
+                  Glasgow Index
+                </Link>
               </p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Developed at the University of Glasgow, this index scores breath shapes on a 0-1
-                scale. A score above 0.3 suggests significant flow limitation. It detects flattened
-                tops, skewed peaks, and other distortion patterns.
-              </p>
+              <div className="mt-2 space-y-2 text-sm text-muted-foreground">
+                <p>
+                  Developed by researchers at the University of Glasgow, this index examines the
+                  shape of each inspiratory breath and scores it across{' '}
+                  <strong className="text-foreground">nine components</strong>. Each component
+                  captures a different aspect of waveform distortion:
+                </p>
+                <ul className="ml-4 space-y-1">
+                  <li className="flex gap-2">
+                    <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
+                    <span>
+                      <strong className="text-foreground">Flatness:</strong> Is the top of the
+                      breath waveform flattened, indicating resistance?
+                    </span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
+                    <span>
+                      <strong className="text-foreground">Skewness:</strong> Is the peak flow
+                      shifted earlier in the breath, suggesting increased effort?
+                    </span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
+                    <span>
+                      <strong className="text-foreground">Multi-peak patterns:</strong> Does the
+                      waveform show multiple peaks, a sign of airway instability?
+                    </span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
+                    <span>
+                      <strong className="text-foreground">Amplitude variability:</strong> How much
+                      does breath size vary across sequences of breaths?
+                    </span>
+                  </li>
+                </ul>
+                <p>
+                  Each component scores between 0 and 1, and the overall Glasgow Index ranges from{' '}
+                  <strong className="text-foreground">0 to 9</strong>. Higher scores indicate more
+                  breath shape distortion consistent with flow limitation. You can track this across
+                  weeks to see whether your breathing patterns are stable, improving, or elevated.
+                </p>
+              </div>
             </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">
-                <Link href="/glossary#ned" className="hover:text-primary">NED (Negative Effort Dependence)</Link>
+
+            <div className="rounded-xl border border-blue-500/20 bg-blue-500/5 p-5">
+              <p className="text-sm font-semibold text-blue-400">
+                <Link href="/glossary#ned" className="hover:text-blue-300">
+                  NED (Negative Effort Dependence)
+                </Link>
               </p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Measures whether increasing breathing effort actually decreases airflow — a
-                hallmark of a narrowed airway. Higher NED values indicate more severe limitation.
-              </p>
+              <div className="mt-2 space-y-2 text-sm text-muted-foreground">
+                <p>
+                  NED measures something specific: whether increasing breathing effort actually{' '}
+                  <strong className="text-foreground">decreases</strong> airflow. In a healthy,
+                  open airway, breathing harder produces more airflow. In a flow-limited airway,
+                  the relationship reverses &mdash; your airway narrows further under the increased
+                  negative pressure of harder inhalation.
+                </p>
+                <p>
+                  This paradoxical response is a hallmark of upper airway narrowing. Elevated NED
+                  values in your data indicate breaths where effort and airflow moved in opposite
+                  directions &mdash; a direct sign of obstruction that wouldn&apos;t appear in any
+                  event count.
+                </p>
+              </div>
             </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Flatness Index</p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Compares the peak flow to the mean flow of each breath. A perfectly round breath
-                has a specific ratio; flattened breaths deviate from this, signaling obstruction.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">RERA Detection</p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                By combining flow shape analysis with patterns of breathing effort and arousal
-                signatures, it&apos;s possible to estimate RERA events from PAP flow data alone.
-              </p>
+
+            <div className="rounded-xl border border-border/50 p-5">
+              <p className="text-sm font-semibold text-foreground">Estimated RERAs</p>
+              <div className="mt-2 space-y-2 text-sm text-muted-foreground">
+                <p>
+                  By combining flow shape analysis with patterns of breathing effort and waveform
+                  recovery, it&apos;s possible to estimate where Respiratory Effort-Related Arousals
+                  occurred during the night. These are sequences of flow-limited breaths that end
+                  with a sudden return to normal airflow &mdash; suggesting a brief arousal restored
+                  airway patency.
+                </p>
+                <p>
+                  RERAs are the link between flow limitation and daytime symptoms. Each RERA is a
+                  mini-awakening that fragments sleep without leaving a trace in your AHI. A high
+                  estimated RERA count alongside elevated Glasgow and NED values paints a picture of
+                  sleep disruption that the AHI completely misses.
+                </p>
+              </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* What Causes It */}
+      {/* How to See Flow Limitation in Your Data */}
       <section className="mt-10">
         <div className="flex items-center gap-2.5">
-          <TrendingDown className="h-5 w-5 text-rose-400" />
-          <h2 className="text-xl font-bold sm:text-2xl">What Causes Flow Limitation on PAP?</h2>
+          <BarChart3 className="h-5 w-5 text-violet-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            How to See Flow Limitation in Your Data
+          </h2>
         </div>
         <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
           <p>
-            If flow limitation is happening despite PAP therapy, it usually points to one of a few
-            issues:
-          </p>
-          <ul className="ml-4 space-y-2">
-            <li className="flex gap-2">
-              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-400" />
-              <span>
-                <strong className="text-foreground">Pressure too low:</strong> The most common
-                cause. Your prescribed pressure may not be enough to fully splint the airway open,
-                especially during REM sleep when muscles relax further.
-              </span>
-            </li>
-            <li className="flex gap-2">
-              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-400" />
-              <span>
-                <strong className="text-foreground">EPR too high:</strong> Expiratory Pressure
-                Relief (EPR) reduces pressure during exhalation for comfort. But if set too high
-                (e.g., EPR 3), the lower expiratory pressure may allow airway narrowing.
-              </span>
-            </li>
-            <li className="flex gap-2">
-              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-400" />
-              <span>
-                <strong className="text-foreground">Positional factors:</strong> Sleeping supine
-                (on your back) increases gravitational collapse of the airway. Flow limitation
-                often worsens in certain positions.
-              </span>
-            </li>
-            <li className="flex gap-2">
-              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-rose-400" />
-              <span>
-                <strong className="text-foreground">Mask leak:</strong> Significant mask leak
-                reduces effective pressure delivery, which can allow the airway to narrow even
-                when the set pressure would otherwise be adequate.
-              </span>
-            </li>
-          </ul>
-        </div>
-      </section>
-
-      {/* What You Can Do */}
-      <section className="mt-10">
-        <div className="flex items-center gap-2.5">
-          <Lightbulb className="h-5 w-5 text-amber-400" />
-          <h2 className="text-xl font-bold sm:text-2xl">What You Can Do About It</h2>
-        </div>
-        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
-          <p>
-            Understanding your flow limitation profile is the first step. Here&apos;s a practical
-            approach:
+            If you have a ResMed machine with an SD card, the detailed waveform data for flow
+            limitation analysis is already being recorded every night. Here&apos;s how to make it
+            visible:
           </p>
           <div className="space-y-3">
             <div className="flex gap-3 rounded-xl border border-border/50 p-4">
@@ -193,10 +326,13 @@ export default function UnderstandingFlowLimitationPost() {
                 1
               </span>
               <div>
-                <p className="text-sm font-medium text-foreground">Analyze your actual data</p>
+                <p className="text-sm font-medium text-foreground">
+                  Get your data off the SD card
+                </p>
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  Tools like AirwayLab can read your SD card and calculate Glasgow Index, NED, and
-                  estimated RERA counts — metrics your machine&apos;s app won&apos;t show you.
+                  Remove the SD card from your machine and connect it to your computer. You&apos;ll
+                  find folders containing <code>.edf</code> files &mdash; these are the raw waveform
+                  recordings from each session.
                 </p>
               </div>
             </div>
@@ -205,10 +341,14 @@ export default function UnderstandingFlowLimitationPost() {
                 2
               </span>
               <div>
-                <p className="text-sm font-medium text-foreground">Look at trends, not single nights</p>
+                <p className="text-sm font-medium text-foreground">
+                  Use a flow limitation analysis tool
+                </p>
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  Everyone has occasional flow-limited breaths. What matters is the pattern across
-                  weeks. Consistently high Glasgow scores (&gt;0.3) warrant attention.
+                  AirwayLab reads those EDF files directly in your browser. Drag your SD card folder
+                  into the app, and it computes the Glasgow Index, NED, FL Score, and estimated RERA
+                  count for each session. Your data stays on your device &mdash; nothing is uploaded
+                  to any server.
                 </p>
               </div>
             </div>
@@ -217,15 +357,89 @@ export default function UnderstandingFlowLimitationPost() {
                 3
               </span>
               <div>
-                <p className="text-sm font-medium text-foreground">Discuss with your sleep physician</p>
+                <p className="text-sm font-medium text-foreground">
+                  Look at patterns, not single nights
+                </p>
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  Bring your flow limitation data to your next appointment. Many physicians are
-                  receptive to adjusting pressure, EPR, or mode settings when presented with
-                  objective evidence.
+                  Everyone has occasional flow-limited breaths. A single night with slightly elevated
+                  Glasgow scores isn&apos;t necessarily meaningful. What matters is the trend across
+                  weeks and months. Consistently elevated scores across multiple sessions are worth
+                  discussing with your clinician.
+                </p>
+              </div>
+            </div>
+            <div className="flex gap-3 rounded-xl border border-border/50 p-4">
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 font-mono text-xs font-bold text-primary">
+                4
+              </span>
+              <div>
+                <p className="text-sm font-medium text-foreground">
+                  Bring it to your next appointment
+                </p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Flow limitation data gives your sleep physician additional information beyond what
+                  the machine&apos;s app provides. Many clinicians appreciate having objective
+                  breath-shape data when reviewing therapy.
                 </p>
               </div>
             </div>
           </div>
+          <p>
+            If you use OSCAR to view your raw waveform data, AirwayLab complements that workflow
+            by adding automated breath shape scoring. OSCAR shows you the waveforms visually.
+            AirwayLab quantifies the patterns across entire sessions and nights.
+          </p>
+        </div>
+      </section>
+
+      {/* What Your Flow Limitation Profile Shows */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Wind className="h-5 w-5 text-blue-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            What Your Flow Limitation Profile Shows
+          </h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            When you look at your flow limitation data, you&apos;re looking at a deeper layer of
+            what&apos;s happening during sleep. Key patterns to observe:
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Glasgow Index trend</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Stable, improving, or elevated over time? Consistently elevated values suggest
+                your airway may be partially narrowing during sleep.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">NED values</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Elevated NED across sessions indicates persistent flow-limited breathing patterns.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Estimated RERA count</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                A high count suggests frequent brief arousals that may be fragmenting sleep
+                architecture without affecting AHI.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Session-to-session variability</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Large swings in flow limitation scores between nights can indicate variable
+                factors worth tracking.
+              </p>
+            </div>
+          </div>
+          <p className="text-xs italic text-muted-foreground/80">
+            These metrics are informational. They show patterns in your breathing data that help
+            you and your clinician understand what&apos;s happening at a deeper level than AHI
+            alone. They do not constitute a diagnosis or indicate whether any specific change to
+            therapy is needed.
+          </p>
         </div>
       </section>
 
@@ -233,7 +447,7 @@ export default function UnderstandingFlowLimitationPost() {
       <section className="mt-10">
         <div className="flex items-center gap-2.5">
           <BookOpen className="h-5 w-5 text-muted-foreground" />
-          <h2 className="text-xl font-bold sm:text-2xl">Further Reading</h2>
+          <h2 className="text-xl font-bold sm:text-2xl">References</h2>
         </div>
         <div className="mt-4 space-y-2 text-sm text-muted-foreground">
           <p>
@@ -248,25 +462,39 @@ export default function UnderstandingFlowLimitationPost() {
             Clark et al. (2017). &quot;Automated detection of inspiratory flow limitation from
             CPAP devices.&quot; <em>Journal of Clinical Sleep Medicine</em>, 13(2).
           </p>
+          <p>
+            Mann et al. (2020). &quot;The relationship between inspiratory flow limitation and
+            sleep fragmentation.&quot; <em>Sleep Medicine</em>, 74.
+          </p>
+          <p>
+            Berry et al. (2012). &quot;Rules for Scoring Respiratory Events in Sleep.&quot;{' '}
+            <em>Journal of Clinical Sleep Medicine</em>, 8(5), 597-619.
+          </p>
           <div className="mt-4 border-t border-border/30 pt-4">
             <p className="mb-2 text-xs font-semibold text-foreground">Related articles</p>
             <p>
               <Link href="/blog/beyond-ahi" className="text-primary hover:text-primary/80">
                 Beyond AHI: Why Your Sleep Apnea Score Might Be Misleading You
               </Link>{' '}
-              -- the research case against relying on AHI alone.
+              &mdash; the research case against relying on AHI alone.
             </p>
             <p className="mt-1">
-              <Link href="/blog/ahi-normal-still-tired" className="text-primary hover:text-primary/80">
+              <Link
+                href="/blog/ahi-normal-still-tired"
+                className="text-primary hover:text-primary/80"
+              >
                 Your AHI Is Normal But You&apos;re Still Exhausted
               </Link>{' '}
-              -- a practical guide to investigating persistent fatigue.
+              &mdash; a practical guide to investigating persistent fatigue.
             </p>
             <p className="mt-1">
-              <Link href="/blog/flow-limitation-and-sleepiness" className="text-primary hover:text-primary/80">
+              <Link
+                href="/blog/flow-limitation-and-sleepiness"
+                className="text-primary hover:text-primary/80"
+              >
                 Does Flow Limitation Drive Sleepiness?
               </Link>{' '}
-              -- evidence linking flow limitation directly to daytime symptoms.
+              &mdash; evidence linking flow limitation directly to daytime symptoms.
             </p>
           </div>
         </div>
@@ -274,26 +502,34 @@ export default function UnderstandingFlowLimitationPost() {
 
       {/* CTA */}
       <section className="mt-10 rounded-xl border border-primary/20 bg-primary/5 p-6 text-center">
-        <h3 className="text-lg font-bold">Ready to See Your Flow Limitation Data?</h3>
+        <h3 className="text-lg font-bold">Start Analysing Your Breathing Patterns</h3>
         <p className="mt-2 text-sm text-muted-foreground">
-          AirwayLab analyzes your ResMed SD card data for flow limitation, RERAs, and breathing
-          patterns — all in your browser, with nothing uploaded to any server.
+          Your PAP machine already records the data. AirwayLab makes it visible &mdash; for free,
+          in your browser, with nothing uploaded to any server.
         </p>
         <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
           <Link
             href="/analyze"
             className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-glow transition-colors hover:bg-primary/90"
           >
-            Analyze Your Data <ArrowRight className="h-4 w-4" />
+            Analyse Your Data <ArrowRight className="h-4 w-4" />
           </Link>
           <Link
-            href="/about/flow-limitation"
+            href="/glossary/flow-limitation"
             className="inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
           >
-            Learn About Our Methodology
+            Learn More in the Glossary
           </Link>
         </div>
       </section>
+
+      {/* Medical Disclaimer */}
+      <p className="mt-8 text-xs italic text-muted-foreground/60">
+        AirwayLab is a free, open-source analysis tool. It is not a medical device and does not
+        provide medical advice, diagnosis, or treatment recommendations. All analysis is
+        informational &mdash; always discuss your breathing data and therapy with a qualified
+        sleep specialist. Your data never leaves your browser.
+      </p>
     </article>
   );
 }

--- a/lib/blog-posts.ts
+++ b/lib/blog-posts.ts
@@ -183,26 +183,26 @@ export const blogPosts: BlogPost[] = [
   },
   {
     slug: 'understanding-flow-limitation',
-    title: 'Understanding Flow Limitation: What Your PAP Machine Doesn\'t Tell You',
+    title: 'Understanding Flow Limitation in Your PAP Data: The Hidden Metric Beyond AHI',
     description:
-      'Flow limitation is the subtle breathing restriction your AHI score completely ignores. Learn what it is, why it matters, and how to detect it in your own PAP data.',
+      'What is cpap flow limitation and why does your machine miss it? Learn how flow limitation differs from apneas, how the Glasgow Index scores it, and how to find it in your breathing data.',
     date: '2026-03-06',
-    readTime: '8 min read',
-    tags: ['Flow Limitation', 'PAP', 'Sleep Apnea'],
+    readTime: '9 min read',
+    tags: ['Flow Limitation', 'PAP', 'AHI', 'Glasgow Index', 'NED', 'RERAs', 'Getting Started'],
     ogDescription:
-      'Your AHI might be low, but flow limitation could still be disrupting your sleep. Learn what flow limitation is and why it matters for PAP therapy.',
+      'What is cpap flow limitation and why does your machine miss it? Learn how flow limitation differs from apneas, how the Glasgow Index scores it, and how to find it in your breathing data.',
     faqItems: [
       {
         question: 'What is flow limitation and why does my AHI miss it?',
-        answer: 'Flow limitation is partial airway narrowing that restricts airflow during inspiration without causing a complete collapse. AHI only counts apneas (complete stops) and hypopneas (significant reductions with oxygen drops). Flow limitation falls below these thresholds, so AHI stays low while your airway is still significantly narrowed.',
+        answer: 'Flow limitation is partial airway narrowing that restricts airflow during inspiration without fully blocking it. AHI only counts apneas (complete stops) and hypopneas (significant reductions with oxygen drops). Flow limitation falls below these thresholds, so AHI stays low while the underlying breathing pattern shows airway narrowing.',
       },
       {
-        question: 'What causes flow limitation on PAP therapy?',
-        answer: 'Common causes include: pressure set too low (the most common cause), EPR (Expiratory Pressure Relief) set too high, sleeping on your back (supine position increases gravitational airway collapse), and significant mask leak that reduces effective pressure delivery.',
+        question: 'How is flow limitation detected in PAP data?',
+        answer: 'Flow limitation is detected through breath shape analysis of the waveform data recorded on your PAP machine SD card. Key scoring methods include the Glasgow Index (9-component breath shape score, range 0-9), NED (Negative Effort Dependence, measuring whether increased effort decreases airflow), and estimated RERA detection. These require dedicated analysis software that reads the raw EDF files.',
       },
       {
-        question: 'How do I detect flow limitation in my CPAP data?',
-        answer: 'Your ResMed SD card contains detailed flow waveforms that can be analysed for flow limitation patterns. Key metrics include the Glasgow Index (breath shape score), NED (Negative Effort Dependence), Flatness Index, and estimated RERA count. Tools like AirwayLab compute these automatically from your SD card data.',
+        question: 'What is the Glasgow Index?',
+        answer: 'The Glasgow Index is a breath shape scoring system developed at the University of Glasgow. It examines nine components of each inspiratory waveform -- including flatness, skewness, multi-peak patterns, and amplitude variability -- scoring each from 0 to 1 for an overall range of 0 to 9. Higher scores indicate more waveform distortion consistent with flow limitation.',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Replaces the `understanding-flow-limitation` blog post with the Content Writer's approved draft from AIR-21
- Removes MDR-violating content: "causes" section listing specific PAP settings (pressure, EPR), FAQ about pressure/EPR adjustments
- Adds comparison table (apnea vs hypopnea vs flow limitation), expanded Glasgow Index/NED explanations, two additional academic references
- Fixes broken CTA link: `/about/flow-limitation` -> `/glossary/flow-limitation`
- Updates metadata in `blog-posts.ts`: title, description, tags (7 tags), readTime (9 min), MDR-compliant FAQ items

## MDR compliance

- [x] No therapeutic recommendations
- [x] No diagnostic claims
- [x] No predictive claims
- [x] No clinical effectiveness judgments
- [x] Medical disclaimer included
- [x] Point-of-use disclaimer present

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (106 files, 1664 tests)
- [x] `npm run build` passes
- [ ] Verify on Vercel preview: `/blog/understanding-flow-limitation` renders correctly
- [ ] Verify comparison table renders on mobile viewport
- [ ] Verify glossary link (`/glossary/flow-limitation`) resolves
- [ ] Verify related posts section shows correct related articles

Resolves AIR-39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)