### PR TITLE
fix: align email template copy with content guidelines (AIR-41)

### DIFF
--- a/components/common/email-opt-in.tsx
+++ b/components/common/email-opt-in.tsx
@@ -106,7 +106,7 @@ export function EmailOptIn({ variant, source }: EmailOptInProps) {
         </p>
         <p className="mb-3 text-[11px] text-muted-foreground">
           Enter your email and we&apos;ll send a sign-in link. No password needed.
-          You&apos;ll also get occasional therapy tips by email (unsubscribe anytime).
+          You&apos;ll also get occasional tips on reading your data by email (unsubscribe anytime).
         </p>
         <form onSubmit={handleSubmit} className="flex flex-col gap-2 sm:flex-row">
           <input
@@ -136,7 +136,7 @@ export function EmailOptIn({ variant, source }: EmailOptInProps) {
   if (variant === 'post-analysis') {
     return (
       <div className="rounded-xl border border-border/50 bg-card p-4 sm:p-6">
-        <p className="mb-1 text-sm font-medium">Save your results and get therapy tips by email</p>
+        <p className="mb-1 text-sm font-medium">Save your results and get tips on reading your data by email</p>
         <p className="mb-3 text-xs text-muted-foreground sm:mb-4">
           Create a free account to keep your analysis history. We&apos;ll send a sign-in link to
           your email, plus occasional tips on reading your data. Unsubscribe anytime.
@@ -206,7 +206,7 @@ export function EmailOptIn({ variant, source }: EmailOptInProps) {
         </Button>
       </form>
       <p className="mt-1.5 text-[10px] text-muted-foreground/50">
-        Free account + occasional therapy tips. Unsubscribe anytime.
+        Free account + occasional tips on reading your data. Unsubscribe anytime.
       </p>
       {status === 'error' && (
         <p aria-live="polite" className="mt-1 text-[10px] text-red-400">{errorMsg || 'Something went wrong. Please try again.'}</p>

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -81,7 +81,7 @@ export function postUploadStep1(unsubscribeUrl: string): { subject: string; html
     html: layout(`
       ${heading('Your breathing data has been analysed')}
       ${paragraph('Four research-grade engines just scored your flow limitation, breathing regularity, and airway resistance. Your results are saved in your browser -- no one sees them but you.')}
-      ${paragraph('One night is a snapshot. Upload a few more nights and you\'ll start to see how your therapy is actually trending -- whether pressure changes helped, which nights are worse, and what your clinician should know.')}
+      ${paragraph('One night is a snapshot. Upload a few more nights and you\'ll start to see how your therapy is actually trending -- how your metrics changed after pressure adjustments, which nights are worse, and what your clinician should know.')}
       ${ctaButton('Upload Your Next Night', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=post_upload_1`)}
     `, unsubscribeUrl),
   };
@@ -95,11 +95,11 @@ export function postUploadStep2(unsubscribeUrl: string): { subject: string; html
       ${paragraph('Sleep breathing varies with body position, alcohol, congestion, and stress. A Glasgow Index of 1.2 one night and 2.8 the next is normal. The question isn\'t "what was my score" -- it\'s "is my therapy trending in the right direction?"')}
       ${paragraph('Trends answer that. Each upload adds another data point to the picture your clinician needs:')}
       ${bulletList([
-        'See if a pressure adjustment actually reduced your flow limitation',
-        'Catch gradual worsening before it shows up as daytime symptoms',
-        'First-half vs second-half patterns that reveal positional or REM-related issues',
+        'See how your flow limitation scores changed over time',
+        'Track how your scores change over weeks and months',
+        'First-half vs second-half differences in your scores',
       ])}
-      ${paragraph('Supporters get AI-powered insights that explain what these trends mean for your specific therapy -- plain language, not just numbers.')}
+      ${paragraph('Supporters get AI-powered insights that explain deeper analysis of cross-session correlations in your data -- plain language, not just numbers.')}
       ${ctaButton('Upload Your Next Night', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=post_upload_2`)}
     `, unsubscribeUrl),
   };
@@ -114,7 +114,7 @@ export function postUploadStep3(unsubscribeUrl: string): { subject: string; html
       ${paragraph('AirwayLab measures your airway. Symptom logging measures you. Together, they give your clinician something no AHI printout can: the full picture.')}
       ${paragraph('After each analysis, you can log how you slept on a simple scale. It takes 5 seconds, and it builds a picture of your personal sensitivity over time.')}
       ${ctaButton('Log How You Slept', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=post_upload_3`)}
-      ${paragraph('P.S. AI insights can connect your symptoms to your metrics -- suggesting specific patterns to discuss with your clinician. Available with a <a href="' + BASE_URL + '/pricing?utm_source=email&utm_medium=drip&utm_campaign=post_upload_3_upgrade" style="color:#5eead4;text-decoration:underline;">Supporter subscription</a>.')}
+      ${paragraph('P.S. AI insights can connect your symptoms to your metrics -- highlighting correlations between your symptoms and metrics. Available with a <a href="' + BASE_URL + '/pricing?utm_source=email&utm_medium=drip&utm_campaign=post_upload_3_upgrade" style="color:#5eead4;text-decoration:underline;">Supporter subscription</a>.')}
     `, unsubscribeUrl),
   };
 }
@@ -126,11 +126,11 @@ export function dormancyStep1(unsubscribeUrl: string): { subject: string; html: 
     subject: 'How\'s your therapy going this month?',
     html: layout(`
       ${heading('One upload, one minute, one more data point')}
-      ${paragraph('Sleep therapy is a long game. Night-to-night scores fluctuate -- that\'s normal. But monthly trends reveal whether your pressure settings are actually helping, slowly drifting, or masking a positional issue that only shows up in certain sleep stages.')}
+      ${paragraph('Sleep therapy is a long game. Night-to-night scores fluctuate -- that\'s normal. But monthly trends reveal how your scores have changed over time, whether they\'re gradually shifting, or if there are patterns that differ between sleep positions or stages.')}
       ${paragraph('Your clinician can\'t act on a single night. They need the trend line. Each upload adds to that picture:')}
       ${bulletList([
-        'See if last month\'s pressure change actually reduced flow limitation',
-        'Catch gradual worsening before it shows up as daytime symptoms',
+        'See how your flow limitation scores changed over time',
+        'Track how your scores change over weeks and months',
         'Build an evidence trail for your next clinic visit',
       ])}
       ${ctaButton('Upload This Month\'s Data', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=dormancy_1`)}
@@ -160,8 +160,8 @@ export function featureEducationStep1(unsubscribeUrl: string): { subject: string
       ${paragraph('AirwayLab\'s four engines give you detailed metrics -- Glasgow Index, FL Score, NED, RERA counts. But what do they mean for <em>your</em> therapy?')}
       ${paragraph('AI insights translate your metrics into plain-language explanations:')}
       ${bulletList([
-        '"Your Glasgow Index of 2.4 suggests moderate flow limitation, primarily in the second half of the night..."',
-        '"Your RERA index of 6.2 is above the normal range, which may explain persistent fatigue despite a low AHI..."',
+        '"Your Glasgow Index of 2.4 -- your clinician can review what this score means in the context of your therapy."',
+        '"Your RERA index of 6.2 is above the typical range. Your clinician can help interpret what this means alongside your symptoms."',
         '"Your clinician can help interpret what these patterns mean for your therapy."',
       ])}
       ${paragraph('Every analysis includes rule-based insights for free. <a href="' + BASE_URL + '/pricing?utm_source=email&utm_medium=drip&utm_campaign=feature_ed_1_upgrade" style="color:#5eead4;text-decoration:underline;">Supporters</a> unlock AI-powered analysis that references your specific pressure settings, compares your patterns to the research literature, and highlights findings to discuss with your clinician. Free users get 3 AI analyses per month to try it.')}
@@ -175,14 +175,14 @@ export function featureEducationStep2(unsubscribeUrl: string): { subject: string
     subject: 'Share your results with your clinician',
     html: layout(`
       ${heading('Objective data for your next appointment')}
-      ${paragraph('Most sleep physicians see AHI and call it done. But you now have flow limitation scores, RERA estimates, and breath-by-breath analysis that tells a much deeper story.')}
+      ${paragraph('Most sleep physicians see AHI and call it done. But you now have flow limitation scores, RERA estimates, and breath-by-breath analysis that provides additional detail beyond standard reports.')}
       ${paragraph('AirwayLab gives you three ways to share:')}
       ${bulletList([
         '<strong style="color:#fff;">PDF report</strong> -- professional format with metric cards, trends, and radar charts. Ready to print or email.',
         '<strong style="color:#fff;">CSV export</strong> -- 67-column dataset for detailed review or import into other tools.',
         '<strong style="color:#fff;">Forum post</strong> -- formatted for ApneaBoard or r/SleepApnea, with traffic-light indicators.',
       ])}
-      ${paragraph('The more data you bring, the better the conversation. Your clinician can\'t act on symptoms alone -- they need objective evidence.')}
+      ${paragraph('The more data you bring, the better the conversation. Objective data can complement your clinician\'s assessment.')}
       ${paragraph('For deeper analysis, <a href="' + BASE_URL + '/pricing?utm_source=email&utm_medium=drip&utm_campaign=feature_ed_2_upgrade" style="color:#5eead4;text-decoration:underline;">Supporters</a> get deeper AI analysis that identifies patterns across your data and settings. It\'s the difference between seeing the numbers and understanding what they show about your therapy.')}
       ${ctaButton('Export Your Report', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=feature_ed_2`)}
     `, unsubscribeUrl),
@@ -203,7 +203,7 @@ function activationStep1(unsubscribeUrl: string): { subject: string; html: strin
         '<strong style="color:#fff;">Select the DATALOG folder</strong> -- AirwayLab will find and parse all the EDF files automatically',
       ])}
       ${paragraph('Everything runs in your browser. Your data never leaves your device unless you choose to share it.')}
-      ${paragraph('Within seconds, you\'ll see scores from four research-grade engines: flow limitation patterns your machine\'s AHI doesn\'t capture, breathing regularity, airway resistance, and arousal indicators. These are the metrics that explain why you might still feel tired despite "normal" numbers.')}
+      ${paragraph('Within seconds, you\'ll see scores from four research-grade engines: flow limitation patterns that complement your machine\'s standard reports, breathing regularity, airway resistance, and arousal indicators. These metrics show aspects of your breathing that standard AHI doesn\'t measure.')}
       ${ctaButton('Upload Your SD Card', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=activation_1`)}
       ${paragraph('Having trouble? Reply to this email and we\'ll help you get started.')}
     `, unsubscribeUrl),
@@ -215,7 +215,7 @@ function activationStep2(unsubscribeUrl: string): { subject: string; html: strin
     subject: 'Your CPAP data has insights waiting to be found',
     html: layout(`
       ${heading('What one upload reveals')}
-      ${paragraph('AirwayLab users who upload a week of SD card data typically discover patterns their AHI never showed -- subtle flow limitation, periodic breathing, and arousal patterns that explain why they still feel tired despite "normal" numbers.')}
+      ${paragraph('When you upload a week of SD card data, AirwayLab shows additional metrics alongside your machine\'s standard reports -- subtle flow limitation, periodic breathing, and arousal patterns that standard reports don\'t show.')}
       ${paragraph('Your machine has been recording detailed flow waveforms every night. AirwayLab\'s four engines analyse those waveforms at the breath level -- something OSCAR and your machine\'s built-in reports can\'t do.')}
       ${ctaButton('Start Your First Analysis', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=activation_2`)}
       ${paragraph('This is the last activation email we\'ll send. If you\'re not ready yet, your account will be here when you are.')}

--- a/lib/email/transactional.ts
+++ b/lib/email/transactional.ts
@@ -49,7 +49,7 @@ export function welcomeEmail(
     subject: `You're in. Here's what's unlocked.`,
     html: transactionalLayout(`
       ${heading('Your analysis just got a lot smarter')}
-      ${paragraph('Every time you upload, you\'ll now get AI-powered insights that explain your metrics in plain language -- what your Glasgow Index means for your therapy, whether your flow limitation is improving, and specific settings adjustments to discuss with your clinician.')}
+      ${paragraph('Every time you upload, you\'ll now get AI-powered insights that explain your metrics in plain language -- what your Glasgow Index shows about your breathing patterns, how your flow limitation scores are trending, and patterns and correlations to review with your clinician.')}
       ${paragraph(`Here's what your ${tierLabel} subscription unlocks:`)}
       ${bulletList(TIER_BENEFITS[tier])}
       ${ctaButton('Upload and Try AI Insights', `${BASE_URL}/analyze?utm_source=email&utm_medium=transactional&utm_campaign=welcome`)}
@@ -104,7 +104,7 @@ export function discordLaunchEmail(
     subject: "You've just unlocked something new",
     html: transactionalLayout(`
       ${heading("We built something the CPAP community has been missing")}
-      ${paragraph("As a " + tierLabel + " subscriber, you now have access to the AirwayLab Discord -- a place where users share analysis insights, ask questions, and help each other get better therapy.")}
+      ${paragraph("As a " + tierLabel + " subscriber, you now have access to the AirwayLab Discord -- a place where users share analysis insights, ask questions, and learn more about their data together.")}
       ${paragraph("Here's what you get:")}
       ${bulletList(DISCORD_TIER_BENEFITS[tier])}
       ${paragraph("Click below to connect your Discord account and get instant access.")}


### PR DESCRIPTION
## Summary

- **5 MUST violations** (deployment blockers): removed diagnostic claims, therapeutic recommendations, and symptom explanations from email copy
- **14 SHOULD violations**: replaced therapy-evaluating language with neutral data-observation framing
- **2 clinical superiority claims**: changed AHI-disparaging copy to complementary positioning
- **3 opt-in copy issues**: replaced "therapy tips" with "tips on reading your data"

All changes move copy from diagnostic/therapeutic framing to informational/educational framing per EU MDR Rule 11.

## Files changed

- `lib/email/templates.ts` -- drip sequence copy (M1, M2, M4, M5, S1-S12, C1, C2)
- `lib/email/transactional.ts` -- welcome + Discord emails (M3, S13, S14)
- `components/common/email-opt-in.tsx` -- signup form copy (O1-O3)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` -- 106 files, 1664 tests pass
- [x] `npm run build` succeeds
- [ ] Verify email rendering in Vercel preview (spot-check welcome, activation, dormancy emails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)