### PR TITLE
fix: align insight string copy with content guidelines

### DIFF
--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -90,7 +90,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'ifl-risk-good',
       type: 'positive',
       title: 'Low flow limitation symptom risk',
-      body: `Your IFL Symptom Risk of ${fmt(iflRisk)}% is low — your airway appears to be functioning well during therapy.`,
+      body: `Your IFL Symptom Risk of ${fmt(iflRisk)}% is low, with flow limitation metrics in the low range across analysis engines.`,
       category: 'ned',
     });
   }
@@ -123,14 +123,14 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'glasgow-good',
       type: 'positive',
       title: 'Glasgow Index in healthy range',
-      body: `Score of ${fmt(n.glasgow.overall)} indicates minimal flow limitation — current therapy appears effective.`,
+      body: `Score of ${fmt(n.glasgow.overall)} indicates minimal flow limitation. Your metrics are in the typical range.`,
       category: 'glasgow',
     });
   } else if (gl === 'bad') {
     insights.push({
       id: 'glasgow-bad',
       type: 'warning',
-      title: 'Significant flow limitation detected',
+      title: 'Elevated breath-shape scores',
       body: `Glasgow Index of ${fmt(n.glasgow.overall)} indicates elevated breath-shape scores across analysis engines. Review your flow waveforms for visual confirmation and discuss with your clinician.`,
       category: 'glasgow',
     });
@@ -164,7 +164,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'regularity-bad',
       type: 'warning',
       title: 'Highly repetitive breathing pattern',
-      body: `Regularity score of ${Math.round(n.wat.regularityScore)}% indicates very predictable breathing cycles. During PAP therapy, this may signal persistent flow limitation with uniform effort.`,
+      body: `Regularity score of ${Math.round(n.wat.regularityScore)}% indicates very predictable breathing cycles. High regularity during PAP therapy is associated with uniform breathing effort.`,
       category: 'wat',
     });
   } else if (regL === 'good') {
@@ -172,7 +172,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'regularity-good',
       type: 'positive',
       title: 'Healthy breathing variability',
-      body: `Regularity score of ${Math.round(n.wat.regularityScore)}% shows natural breath-to-breath variability — a sign of unobstructed breathing.`,
+      body: `Regularity score of ${Math.round(n.wat.regularityScore)}% shows natural breath-to-breath variability, consistent with typical breathing patterns.`,
       category: 'wat',
     });
   }
@@ -185,7 +185,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'eai-high',
       type: 'info',
       title: 'Elevated respiratory disruption markers',
-      body: `RDI of ${fmt(eaiVal)}/hr indicates a high rate of recovery breaths following flow-limited breathing. Areas to investigate: EPR/PS level, positional factors. Get personalised suggestions with AI Analysis.`,
+      body: `RDI of ${fmt(eaiVal)}/hr indicates a high rate of recovery breaths following flow-limited breathing. Multiple factors can contribute to this pattern. Get personalised observations with AI Analysis.`,
       category: 'ned',
     });
   } else if (eaiL === 'good' && eaiVal > 0) {
@@ -204,8 +204,8 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
     insights.push({
       id: 'sensitization-mismatch',
       type: 'actionable',
-      title: 'Low FL but high disruptions — investigate further',
-      body: `Glasgow Index of ${fmt(glasgowVal)} shows mild flow limitation, but RDI of ${fmt(eaiVal)}/hr indicates frequent disruptions. This mismatch indicates non-respiratory factors may be worth investigating: check for mask leak, pressure comfort (EPR/ramp), nasal congestion, caffeine timing, or stress. Log your night context to track patterns. If this persists, discuss CNS sensitization with your clinician.`,
+      title: 'Low FL scores but high disruption index',
+      body: `Glasgow Index of ${fmt(glasgowVal)} shows mild flow limitation, but RDI of ${fmt(eaiVal)}/hr indicates frequent disruptions. When flow limitation is low but disruptions are high, non-respiratory factors such as congestion, caffeine timing, or stress may be involved. Logging your night context can help identify patterns. Your clinician can help interpret these findings in context.`,
       category: 'ned',
       link: { text: 'Learn more about this pattern', href: '/blog/what-is-cns-sensitization' },
     });
@@ -218,7 +218,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'metric-divergence-wat-high',
       type: 'info',
       title: 'WAT FL elevated despite low Glasgow/NED',
-      body: `WAT FL Score of ${Math.round(n.wat.flScore)}% detects inspiratory flow shape flattening that Glasgow (${fmt(n.glasgow.overall)}) and NED (${fmt(n.ned.nedMean)}%) did not flag. These tools measure different aspects of flow limitation — WAT focuses on waveform flatness, while Glasgow and NED use other criteria. This divergence between analysis engines is a common pattern worth noting.`,
+      body: `WAT FL Score of ${Math.round(n.wat.flScore)}% measures inspiratory flow shape flattening that Glasgow (${fmt(n.glasgow.overall)}) and NED (${fmt(n.ned.nedMean)}%) did not flag. These tools measure different aspects of flow limitation. WAT focuses on waveform flatness, while Glasgow and NED use other criteria. This divergence between analysis engines is a common pattern worth noting.`,
       category: 'wat',
     });
   } else if ((gl === 'bad' || nedL === 'bad') && watFLL === 'good') {
@@ -236,7 +236,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
     insights.push({
       id: 'periodicity-high',
       type: 'warning',
-      title: 'Periodic breathing detected',
+      title: 'Elevated periodicity index',
       body: `Periodicity index of ${fmt(n.wat.periodicityIndex)}% indicates repetitive breathing cycles (30–100s period). Cyclical breathing patterns observed in the 30-100 second range.`,
       category: 'wat',
     });
@@ -251,7 +251,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'event-control-residual-fl',
       type: 'info',
       title: 'Strong event control with residual flow limitation',
-      body: 'Your therapy effectively controls respiratory events. Red flow limitation metrics show room for further optimisation, not treatment failure. Discuss with your clinician.',
+      body: 'Respiratory event counts are low while flow limitation metrics remain elevated. This combination is a common pattern. Your clinician can help interpret these findings in context.',
       category: 'therapy',
     });
   }
@@ -270,7 +270,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'ned-good',
       type: 'positive',
       title: 'Low flow limitation on NED analysis',
-      body: `NED mean of ${fmt(n.ned.nedMean)}% with only ${fmt(n.ned.reraIndex)} RERAs/hr — breathing effort looks well-controlled.`,
+      body: `NED mean of ${fmt(n.ned.nedMean)}% with only ${fmt(n.ned.reraIndex)} RERAs/hr. These metrics are in the typical range.`,
       category: 'ned',
     });
   }
@@ -282,7 +282,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'ned-h1h2',
       type: 'info',
       title: `Flow limitation worse in ${worse} half`,
-      body: `H1 NED ${fmt(n.ned.h1NedMean)}% vs H2 NED ${fmt(n.ned.h2NedMean)}%. ${worse === 'second' ? 'This may relate to REM-dominant obstruction in the latter part of the night.' : 'Early-night obstruction may improve as therapy stabilises.'}`,
+      body: `H1 NED ${fmt(n.ned.h1NedMean)}% vs H2 NED ${fmt(n.ned.h2NedMean)}%. ${worse === 'second' ? 'Flow limitation metrics are higher in the latter part of the night.' : 'Flow limitation metrics are higher in the earlier part of the night.'}`,
       category: 'ned',
     });
   }
@@ -310,7 +310,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'boi-high',
       type: 'warning',
       title: 'High brief obstruction rate',
-      body: `Brief obstruction rate of ${fmt(boiVal)}/hr means your airway is briefly narrowing roughly every ${interval} minutes. These events are too short for standard detection but may fragment sleep. They often do not respond to pressure changes alone — possible causes include swallowing, positional shifts, or epiglottic flutter. Track your sleep position and note patterns. Discuss with your clinician.`,
+      body: `Brief obstruction rate of ${fmt(boiVal)}/hr means your airway is briefly narrowing roughly every ${interval} minutes. These events are too short for standard detection but may fragment sleep. Possible contributing factors include swallowing, positional shifts, or epiglottic flutter. Tracking your sleep position may help identify patterns. Your clinician can help interpret these findings in context.`,
       category: 'ned',
     });
   }
@@ -336,7 +336,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'boi-h2-gt-h1',
       type: 'info',
       title: 'Brief obstructions increase in the second half',
-      body: `Brief obstructions are higher in H2 (${fmt(boiH2)}/hr) vs H1 (${fmt(boiH1)}/hr), consistent with REM-related airway changes. These events often do not respond to pressure changes — positional therapy or tracking sleep position may be more informative.`,
+      body: `Brief obstructions are higher in H2 (${fmt(boiH2)}/hr) vs H1 (${fmt(boiH1)}/hr). This half-to-half difference is a common pattern worth noting alongside other second-half metrics.`,
       category: 'ned',
     });
   }
@@ -383,7 +383,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'settings-premature-cycle',
         type: 'warning',
         title: 'Machine cycling off during active inspiration',
-        body: `${fmt(sm.prematureCyclePct, 0)}% of breaths had pressure support withdrawn while you were still inhaling. This can reduce effective ventilation. Cycle timing patterns differ from typical ranges. Discuss with your clinician.`,
+        body: `${fmt(sm.prematureCyclePct, 0)}% of breaths had pressure support withdrawn while you were still inhaling. Cycle timing patterns differ from typical ranges. Your clinician can help interpret these findings in context.`,
         category: 'settings',
       });
     }
@@ -394,7 +394,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'settings-late-cycle',
         type: 'warning',
         title: 'Machine slow to release pressure',
-        body: `${fmt(sm.lateCyclePct, 0)}% of breaths had pressure support continuing into your expiration. This can make exhaling uncomfortable. Short IPAP dwell detected. Discuss with your clinician.`,
+        body: `${fmt(sm.lateCyclePct, 0)}% of breaths had pressure support continuing into your expiration. Pressure support timing into expiration was observed. Your clinician can help interpret these findings in context.`,
         category: 'settings',
       });
     }
@@ -405,7 +405,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'settings-low-ipap-dwell',
         type: 'actionable',
         title: 'Low time at full pressure support',
-        body: `Your machine reaches IPAP but cycles off quickly — only ${fmt(sm.ipapDwellMedianPct, 0)}% of each breath is spent at full pressure. This reduces the effective benefit of your PS setting. Low IPAP dwell time was detected.`,
+        body: `Your machine reaches IPAP but cycles off quickly -- only ${fmt(sm.ipapDwellMedianPct, 0)}% of each breath is spent at full pressure. Low IPAP dwell time means less time at your prescribed pressure support level.`,
         category: 'settings',
       });
     }
@@ -441,7 +441,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
           id: 'settings-pressure-mismatch',
           type: 'warning',
           title: 'Delivered pressure differs from prescribed',
-          body: `Detected EPAP of ${fmt(sm.epapDetected)} cmH₂O differs from your prescribed ${n.settings.epap} cmH₂O by more than 1 cmH₂O. Check for mask leak or machine issues.`,
+          body: `Detected EPAP of ${fmt(sm.epapDetected)} cmH₂O differs from your prescribed ${n.settings.epap} cmH₂O by more than 1 cmH₂O. Your clinician can help interpret this discrepancy.`,
           category: 'settings',
         });
       }
@@ -466,7 +466,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'settings-good',
         type: 'positive',
         title: 'Settings delivering as expected',
-        body: 'Your Trigger, Cycle, and pressure delivery metrics are all within expected ranges — your machine appears well-matched to your breathing pattern.',
+        body: 'Your Trigger, Cycle, and pressure delivery metrics are all within expected ranges.',
         category: 'settings',
       });
     }
@@ -492,7 +492,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'tbelow90-high',
         type: 'warning',
         title: 'Extended time below SpO₂ 90%',
-        body: `${fmt(ox.tBelow90)}% of the night spent below 90% SpO₂. This warrants clinical attention.`,
+        body: `${fmt(ox.tBelow90)}% of the night spent below 90% SpO₂. Your clinician can help interpret these findings in context.`,
         category: 'oximetry',
       });
     }
@@ -513,7 +513,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'coupled-high',
         type: 'info',
         title: 'Frequent coupled desat + HR surge events',
-        body: `${fmt(ox.coupled3_10)} coupled events/hr — desaturation and heart rate surge occurring within 30 seconds of each other. This indicates a respiratory cause for these specific events. Note: in UARS, most HR surges and desaturations are independent of each other.`,
+        body: `${fmt(ox.coupled3_10)} coupled events/hr -- desaturation and heart rate surge occurring within 30 seconds of each other. Many HR surges and desaturations occur independently, so a high coupling rate is a notable pattern.`,
         category: 'oximetry',
       });
     }
@@ -525,7 +525,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'oxi-h1h2',
         type: 'info',
         title: `Desaturations concentrated in ${worse} half`,
-        body: `H1 ODI-3: ${fmt(ox.h1.odi3)}/hr vs H2: ${fmt(ox.h2.odi3)}/hr. ${worse === 'second' ? 'May indicate REM-related desaturations.' : 'May improve as mask seal stabilises.'}`,
+        body: `H1 ODI-3: ${fmt(ox.h1.odi3)}/hr vs H2: ${fmt(ox.h2.odi3)}/hr. Desaturation frequency differs between the first and second halves of the night.`,
         category: 'oximetry',
       });
     }
@@ -547,7 +547,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'coupling-low',
         type: 'positive',
         title: 'Low arousal coupling',
-        body: `Only ${fmt(cd.couplingPct)}% of your breathing events caused arousals -- your arousal threshold appears well-managed.`,
+        body: `Only ${fmt(cd.couplingPct)}% of your breathing events caused arousals. Low coupling between breathing events and arousals was observed.`,
         category: 'correlation',
       });
     }
@@ -557,7 +557,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'coupling-h2-gap',
         type: 'warning',
         title: 'Arousal coupling increases in second half',
-        body: `Your arousal coupling is ${fmt(cd.h2CouplingPct)}% in the second half vs ${fmt(cd.h1CouplingPct)}% in the first half. This pattern can indicate medication wearing off -- discuss timing with your clinician.`,
+        body: `Your arousal coupling is ${fmt(cd.h2CouplingPct)}% in the second half vs ${fmt(cd.h1CouplingPct)}% in the first half. This increase in coupling over the course of the night was observed. Your clinician can help interpret these findings in context.`,
         category: 'correlation',
       });
     }
@@ -571,7 +571,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'machine-ahi-elevated',
         type: ms.ahi > 10 ? 'warning' : 'actionable',
         title: `Machine AHI is ${fmt(ms.ahi)}`,
-        body: `Your device reported ${fmt(ms.ahi)} apnea/hypopnea events per hour. ${ms.ahi > 10 ? 'This is significantly elevated and indicates your current therapy may not be adequately controlling obstructive events.' : 'This is moderately elevated.'} Discuss with your clinician.`,
+        body: `Your device reported ${fmt(ms.ahi)} apnea/hypopnea events per hour. ${ms.ahi > 10 ? 'This is significantly above the typical range.' : 'This is moderately elevated.'} Your clinician can help interpret these findings in context.`,
         category: 'therapy',
       });
     }
@@ -581,7 +581,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'machine-leak-high',
         type: 'warning',
         title: 'High mask leak detected',
-        body: `95th percentile leak of ${fmt(ms.leak95, 0)} L/min. High leak can reduce therapy effectiveness and make flow data unreliable. Check mask fit and seal.`,
+        body: `95th percentile leak of ${fmt(ms.leak95, 0)} L/min. High leak can make flow data less reliable. Your clinician can help interpret these findings in context.`,
         category: 'therapy',
       });
     }
@@ -650,7 +650,7 @@ function trendInsights(
       id: 'trend-ifl-improving',
       type: 'positive',
       title: 'IFL Symptom Risk trending down',
-      body: `Your flow limitation composite has been improving over recent nights \u2014 from ${fmt(iflVals[0]!)}% to ${fmt(iflVals[iflVals.length - 1]!)}%. Your current therapy settings appear to be reducing flow limitation.`,
+      body: `Your flow limitation composite has been decreasing over recent nights, from ${fmt(iflVals[0]!)}% to ${fmt(iflVals[iflVals.length - 1]!)}%.`,
       category: 'trend',
     });
   } else if (iflTrend === 'worsening') {
@@ -694,7 +694,7 @@ function trendInsights(
         insights.push({
           id: 'therapy-change-impact',
           type: delta < 0 ? 'positive' : 'warning',
-          title: `Settings change ${delta < 0 ? 'improved' : 'worsened'} flow limitation`,
+          title: `Flow limitation ${delta < 0 ? 'decreased' : 'increased'} after settings change`,
           body: `Average Glasgow Index went from ${fmt(before)} to ${fmt(after)} after settings were changed on ${therapyChangeDate}.`,
           category: 'therapy',
         });
@@ -711,8 +711,8 @@ function trendInsights(
     insights.push({
       id: 'consistent-good',
       type: 'positive',
-      title: 'Consistently good therapy across all nights',
-      body: `All ${nights.length} nights show Glasgow Index in the healthy range. Current settings appear well-optimised.`,
+      title: 'Consistently low flow limitation across all nights',
+      body: `All ${nights.length} nights show Glasgow Index in the typical range.`,
       category: 'trend',
     });
   } else if (allBad) {


### PR DESCRIPTION
## Summary

- Rewrites all user-facing text in `lib/insights.ts` to remove 22+ EU MDR Rule 11 MUST violations
- No logic, threshold, category, priority, or cap changes -- only string content modified
- 31 lines changed (31 insertions, 31 deletions)

### Violations fixed by rule

| Rule | Count | Pattern removed | Replacement |
|------|-------|----------------|-------------|
| R4 (effectiveness) | 12 | "therapy appears effective", "well-optimised", "adequately controlling" | "metrics are in the typical range", "elevated", data descriptions |
| R2 (diagnostic) | 6 | "detected", "signals", "may indicate REM-related", "unobstructed breathing" | "elevated", "measures", directional language |
| R1 (therapeutic) | 4 | "Areas to investigate: EPR/PS level", "Check for mask leak" | "Your clinician can help interpret" |
| R3 (predictive) | 2 | "may improve as therapy stabilises" | Current-state data descriptions |
| Scanner residual | 7 | "good therapy" title, UARS reference, "investigate further", physiological consequence claims | Neutral data language |

### MDR compliance scanner result

Post-rewrite scan found 0 MUST violations. All residual findings (moderate/low) were also fixed.

## Compliance review required

This PR touches `lib/insights.ts` which is on the mandatory compliance review path. @Head of Compliance must review before merge.

Refs: AIR-64 (parent: AIR-5 MDR audit)

## Pre-merge checklist

- [x] Full pipeline passes (tsc, lint, test, build)
- [x] 1682/1682 tests pass (including 33 insights tests)
- [x] MDR compliance scanner run post-rewrite
- [x] No logic changes (only string content)
- [x] PR contains one concern only
- [ ] Vercel preview deploy verified by Demian
- [ ] Head of Compliance sign-off
- [ ] ALL manual QA items checked

## Test plan

- [ ] Upload SD card data on preview deploy
- [ ] Verify insights render correctly on all dashboard tabs
- [ ] Check that insight text is MDR-compliant (no therapeutic recs, no diagnostic claims, no predictions, no effectiveness judgments)
- [ ] Verify positive/warning/actionable/info types still sort correctly
- [ ] Confirm 6-per-night cap still applies

Generated with [Claude Code](https://claude.com/claude-code)