### PR TITLE
fix: address three critical content guideline findings

### DIFF
--- a/lib/glossary-data.ts
+++ b/lib/glossary-data.ts
@@ -795,7 +795,7 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
       'AutoSet is ResMed\'s brand name for their auto-adjusting positive airway pressure (APAP) mode. Instead of delivering a single fixed pressure like standard CPAP, AutoSet automatically adjusts the therapeutic pressure within a clinician-set minimum and maximum range based on detected breathing events.\n\nThe AutoSet algorithm increases pressure when it detects flow limitation, snoring, or apneas, and decreases pressure when breathing is stable. This means the pressure tracks your actual needs throughout the night, which can vary with sleep position, sleep stage, alcohol consumption, and other factors.\n\nAutoSet is the default mode on most ResMed AirSense 10 and 11 devices. It provides an effective balance between therapeutic efficacy and comfort, as the average delivered pressure is often lower than the fixed pressure needed to treat the worst-case scenario. AirwayLab can compare the prescribed AutoSet range with the actual delivered pressures to assess whether the range is appropriate.',
     normalRanges: null,
     howAirwayLabMeasures:
-      'AirwayLab reads the prescribed AutoSet pressure range (min/max) from STR.edf and computes the actual delivered pressure from BRP.edf pressure data. Comparing the two shows whether the machine is frequently hitting the pressure ceiling (suggesting the max may need increasing) or staying at the floor (suggesting good control).',
+      'AirwayLab reads the prescribed AutoSet pressure range (min/max) from STR.edf and computes the actual delivered pressure from BRP.edf pressure data. Comparing the two shows whether the machine is frequently hitting the pressure ceiling (the machine is frequently reaching the upper pressure limit) or staying near the floor.',
     relatedTerms: ['cpap', 'epr', 'flow-limitation', 'pressure-support'],
     relatedBlogPosts: [
       { slug: 'how-pap-therapy-works', title: 'How PAP Therapy Actually Works' },
@@ -827,7 +827,7 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
       {
         question: 'Does EPR affect flow limitation?',
         answer:
-          'EPR can affect flow limitation because it creates a pressure drop during the expiration-to-inspiration transition. Higher EPR settings (2-3) mean the airway experiences a brief period of lower pressure at the start of each breath, which can allow the airway to narrow. If you have elevated flow limitation, reducing EPR is one potential adjustment to discuss with your clinician.',
+          'EPR can affect flow limitation because it creates a pressure drop during the expiration-to-inspiration transition. Higher EPR settings (2-3) mean the airway experiences a brief period of lower pressure at the start of each breath, which can allow the airway to narrow. Your clinician can assess whether your current EPR setting is appropriate for your breathing patterns.',
       },
     ],
     category: 'pap-therapy',

--- a/lib/metric-explanations.ts
+++ b/lib/metric-explanations.ts
@@ -141,7 +141,7 @@ export function getEAIExplanation(value: number, threshold: ThresholdDef): strin
 export function getNEDExplanation(nedMean: number, reraIndex: number, nedThreshold: ThresholdDef): string {
   const light = getTrafficLight(nedMean, nedThreshold);
   if (light === 'good' && reraIndex < 5) {
-    return `Your NED mean of ${fmt(nedMean)}% with ${fmt(reraIndex)} RERAs/hr shows well-controlled breathing effort. Your therapy is effectively keeping your airway open.`;
+    return `Your NED mean of ${fmt(nedMean)}% with ${fmt(reraIndex)} RERAs/hr is in the low range, consistent with well-controlled breathing effort.`;
   }
   if (reraIndex >= 10) {
     return `Your RERA index of ${fmt(reraIndex)}/hr means your breathing effort increases frequently before triggering a brief arousal. These events don't show up in AHI but can significantly fragment sleep.`;


### PR DESCRIPTION
## Summary

- **metric-explanations.ts:144** -- Replaced "Your therapy is effectively keeping your airway open" (effectiveness judgment, Rule 4) with data-descriptive: "in the low range, consistent with well-controlled breathing effort"
- **glossary-data.ts:798** -- Replaced "suggesting the max may need increasing" (therapeutic recommendation, Rule 1) with "the machine is frequently reaching the upper pressure limit"
- **glossary-data.ts:830** -- Replaced "reducing EPR is one potential adjustment to discuss with your clinician" (names specific therapy change, Rule 1) with "Your clinician can assess whether your current EPR setting is appropriate"

Fixes AIR-148 (from proactive compliance audit AIR-147, P0 CRITICAL).

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] No new MDR violations introduced
- [x] Self-review: text-only changes, no logic modifications
- [x] PR contains one concern only
- [ ] Vercel preview deploy verified by Demian

## Test plan

- [ ] Verify NED good-case explanation uses new text
- [ ] Verify AutoSet glossary entry uses new text
- [ ] Verify EPR FAQ uses new text

🤖 Generated with [Claude Code](https://claude.com/claude-code)