### PR TITLE
fix: refine clinical language in seven content areas (AIR-151)

### DIFF
--- a/__tests__/metric-explanations.test.ts
+++ b/__tests__/metric-explanations.test.ts
@@ -13,7 +13,7 @@ describe('getGlasgowExplanation', () => {
   it('returns healthy explanation for good values', () => {
     const text = getGlasgowExplanation(0.5, threshold);
     expect(text).toContain('0.5');
-    expect(text).toContain('healthy');
+    expect(text).toContain('lower range');
     expect(text).toContain('minimal flow limitation');
   });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,7 +81,7 @@ const engines = [
   {
     icon: BarChart3,
     title: 'NED Analysis',
-    desc: 'Identifies effort-dependent airway collapse \u2014 a key marker of upper airway resistance that correlates with arousals.',
+    desc: 'Measures negative effort dependence \u2014 a flow pattern associated with upper airway resistance in published research.',
     metrics: ['NED Mean', 'Flatness Index', 'M-Shape', 'RERA Index'],
     example: '6.2',
     unit: 'RERA/hr',

--- a/app/providers/page.tsx
+++ b/app/providers/page.tsx
@@ -50,7 +50,7 @@ const engines = [
   {
     icon: BarChart3,
     title: 'NED Effort Dependence',
-    desc: 'Identifies effort-dependent airway collapse \u2014 a key marker of upper airway resistance that correlates with arousals and persistent symptoms.',
+    desc: 'Measures negative effort dependence \u2014 a flow pattern associated with upper airway resistance in published research.',
     color: 'text-amber-400',
     bg: 'bg-amber-500/10',
     border: 'border-amber-500/20',

--- a/components/dashboard/flow-analysis-tab.tsx
+++ b/components/dashboard/flow-analysis-tab.tsx
@@ -362,7 +362,7 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
           </div>
           <p className="mt-3 text-[11px] leading-relaxed text-muted-foreground/70">
             REM-predominant flow limitation typically worsens in H2 as REM density increases.
-            A significant H2 rise (&gt;3%) may indicate positional or REM-related obstruction.
+            A significant H2 rise (&gt;3%) is a common pattern in the second half of the night, associated with positional changes or REM sleep.
           </p>
         </CardContent>
       </Card>

--- a/components/dashboard/settings-tab.tsx
+++ b/components/dashboard/settings-tab.tsx
@@ -286,8 +286,8 @@ export function SettingsTab({ selectedNight, previousNight, nights = [] }: Props
             Trigger metrics measure how quickly the machine detects your inspiration.
             Cycle metrics measure whether it stays at full pressure long enough.
             Ventilation metrics track the volume of air you receive.
-            Together, they help identify which specific setting may need adjustment &mdash;
-            so you can have a targeted conversation with your clinician instead of guessing.
+            Together, they show how your machine responded to your breathing &mdash;
+            information your clinician can use to review your settings.
           </p>
           <p className="mt-2 text-[11px] text-muted-foreground/70">
             Discuss settings changes with your sleep physician before adjusting your machine.

--- a/lib/clinician-questions.ts
+++ b/lib/clinician-questions.ts
@@ -100,7 +100,7 @@ const SINGLE_NIGHT_RULES: QuestionRule[] = [
       if (light === 'good') return null;
       return {
         id: 'ned-mean',
-        stem: 'My flow data shows negative effort dependence — could this indicate upper airway narrowing?',
+        stem: 'My flow data shows negative effort dependence \u2014 can you help me understand what this means for my current therapy?',
         rationale: `Your NED of ${fmt(n.ned.nedMean)}% suggests mid-inspiratory flow reduction consistent with effort-dependent airway narrowing.`,
         category: 'flow-limitation',
         urgency: light,

--- a/lib/glossary-data.ts
+++ b/lib/glossary-data.ts
@@ -1002,7 +1002,7 @@ export const GLOSSARY_TERMS: GlossaryTerm[] = [
       {
         question: 'How much time below 90% SpO2 is concerning?',
         answer:
-          'On PAP therapy, less than 5% of time below 90% is considered good. Between 5-15% is borderline. Above 15% indicates significant nocturnal hypoxemia that warrants clinical discussion about therapy adjustments.',
+          'On PAP therapy, less than 5% of time below 90% is considered good. Between 5-15% is borderline. Above 15% is a level your clinician would typically want to review, as it shows extended time with lower blood oxygen.',
       },
     ],
     category: 'oximetry',

--- a/lib/metric-explanations.ts
+++ b/lib/metric-explanations.ts
@@ -118,7 +118,7 @@ export const SETTINGS_METHODOLOGIES = {
 export function getGlasgowExplanation(value: number, threshold: ThresholdDef): string {
   const light = getTrafficLight(value, threshold);
   if (light === 'good') {
-    return `Your Glasgow Index of ${fmt(value)} is in the healthy range. Your breathing shows minimal flow limitation — your airway appears to be staying open well during sleep.`;
+    return `Your Glasgow Index of ${fmt(value)} is in the lower range, consistent with minimal flow limitation across breath-shape characteristics.`;
   }
   if (light === 'warn') {
     return `Your Glasgow Index of ${fmt(value)} is in the borderline range. Your breathing shows some signs of flow limitation — your airway may be partially narrowing during sleep, even though it's not fully closing. Consider discussing this with your clinician.`;
@@ -155,7 +155,7 @@ export function getNEDExplanation(nedMean: number, reraIndex: number, nedThresho
 export function getIFLRiskExplanation(value: number, threshold: ThresholdDef): string {
   const light = getTrafficLight(value, threshold);
   if (light === 'good') {
-    return 'Your flow limitation composite is low. Your airway appears to be functioning well during therapy.';
+    return 'Your IFL composite score is in the lower range.';
   }
   if (light === 'warn') {
     return 'Moderate flow limitation detected across multiple metrics. Individual sensitivity varies \u2014 this level of FL may be contributing to symptoms in some people. Discuss these findings with your clinician.';


### PR DESCRIPTION
## Summary

- Replaced 7 MODERATE (P2) MDR-violating phrases with observational, data-descriptive language
- Also fixed the same violation in `app/providers/page.tsx` (same phrase as landing page)
- Updated test assertion for Glasgow explanation to match new copy

### Files changed
- `app/page.tsx` -- NED description
- `app/providers/page.tsx` -- NED description (same phrase)
- `components/dashboard/settings-tab.tsx` -- settings interpretation text
- `components/dashboard/flow-analysis-tab.tsx` -- H2 rise interpretation
- `lib/metric-explanations.ts` -- Glasgow and IFL explanations (2 violations)
- `lib/clinician-questions.ts` -- NED clinician question stem
- `lib/glossary-data.ts` -- T<90% FAQ answer
- `__tests__/metric-explanations.test.ts` -- assertion update

**Compliance review required:** This PR touches `lib/clinician-questions.ts` (mandatory compliance review path).

## Verification

- `npx tsc --noEmit` -- pass
- `npm run lint` -- pass
- `npm test` -- 1677 tests pass
- `npm run build` -- pass

## Test plan

- [ ] Verify all 7 original violating phrases are gone (grep confirms)
- [ ] Verify no new MDR violations introduced
- [ ] Head of Compliance sign-off on `lib/clinician-questions.ts` change
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)