### PR TITLE
fix: refine language in Glasgow and EAI FAQ entries

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -61,7 +61,7 @@ const faqData = [
   {
     question: 'How do I interpret the Glasgow Index?',
     answer:
-      'The Glasgow Index scores each breath on 9 flow limitation characteristics, producing an overall score from 0 to 8 (lower is better). Generally: below 2.0 is considered good therapy, 2.0\u20133.0 suggests moderate flow limitation worth discussing with your clinician, and above 3.0 suggests elevated flow limitation scores. Your clinician can help interpret these findings in context.',
+      'The Glasgow Index scores each breath on 9 flow limitation characteristics, producing an overall score from 0 to 8 (lower is better). Generally: below 2.0 is in the lower range, 2.0\u20133.0 suggests moderate flow limitation scores, and above 3.0 suggests elevated flow limitation scores. Your clinician can help interpret these findings in context.',
   },
   {
     question: 'What is the difference between Glasgow, WAT, and NED?',
@@ -76,7 +76,7 @@ const faqData = [
   {
     question: 'What is the Estimated Arousal Index (EAI) and how is it calculated?',
     answer:
-      'The Estimated Arousal Index (EAI) estimates how many times per hour your brain briefly wakes up during sleep, based on breathing pattern changes. True arousals can only be measured with EEG (brain wave monitoring), but respiratory pattern changes correlate well with cortical arousals. AirwayLab detects arousals by looking for sudden spikes in respiratory rate (>20% above a 120-second rolling baseline) or tidal volume (>30% above baseline). A 15-second refractory period prevents double-counting. An EAI below 10/hr is generally considered normal. Above 15/hr suggests significant sleep fragmentation worth discussing with your clinician.',
+      'The Estimated Arousal Index (EAI) estimates how many times per hour your brain briefly wakes up during sleep, based on breathing pattern changes. True arousals can only be measured with EEG (brain wave monitoring), but respiratory pattern changes correlate well with cortical arousals. AirwayLab detects arousals by looking for sudden spikes in respiratory rate (>20% above a 120-second rolling baseline) or tidal volume (>30% above baseline). A 15-second refractory period prevents double-counting. An EAI below 10/hr is in the lower range. An EAI above 15/hr is elevated -- your clinician can help interpret this pattern in context.',
   },
   {
     question: 'How is the FL Score calculated?',
@@ -489,12 +489,12 @@ export default function AboutPage() {
           <FAQItem question="How do I interpret the Glasgow Index?">
             The Glasgow Index scores each breath on 9 flow limitation
             characteristics, producing an overall score from 0 to 8 (lower is
-            better). Generally: <strong className="text-foreground">below 2.0</strong> is
-            considered good therapy, <strong className="text-foreground">2.0&ndash;3.0</strong>{' '}
-            suggests moderate flow limitation worth discussing with your
-            clinician, and <strong className="text-foreground">above 3.0</strong> indicates
-            significant flow limitation that may warrant pressure or settings
-            adjustment.
+            better). Generally: <strong className="text-foreground">below 2.0</strong> is in the
+            lower range, <strong className="text-foreground">2.0&ndash;3.0</strong>{' '}
+            suggests moderate flow limitation scores, and{' '}
+            <strong className="text-foreground">above 3.0</strong> suggests elevated
+            flow limitation scores. Your clinician can help interpret these
+            findings in context.
           </FAQItem>
 
           <FAQItem question="What is the difference between Glasgow, WAT, and NED?">
@@ -570,8 +570,8 @@ export default function AboutPage() {
               closely spaced events.
             </p>
             <p>
-              An EAI below 10/hr is generally considered normal. Above 15/hr suggests significant sleep
-              fragmentation that may be worth discussing with your clinician, even if your AHI looks fine.
+              An EAI below 10/hr is in the lower range. An EAI above 15/hr is elevated -- your clinician
+              can help interpret this pattern in context, even if your AHI appears low.
             </p>
           </FAQItem>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -177,7 +177,7 @@ const landingFaqData = [
   {
     question: 'What is the Glasgow Index?',
     answer:
-      'The Glasgow Index is a 9-component scoring system that evaluates each breath for flow limitation characteristics including skew, spike, flat top, multi-peak, and variable amplitude. Scores range from 0 to 9 where lower is better. Below 2.0 is generally considered good therapy. It was originally developed by DaveSkvn as an open-source analyser and ported to AirwayLab.',
+      'The Glasgow Index is a 9-component scoring system that evaluates each breath for flow limitation characteristics including skew, spike, flat top, multi-peak, and variable amplitude. Scores range from 0 to 9 where lower is better. Below 2.0 is in the lower range. It was originally developed by DaveSkvn as an open-source analyser and ported to AirwayLab.',
   },
   {
     question: 'How is AirwayLab different from OSCAR?',


### PR DESCRIPTION
## Summary

- Replace effectiveness judgment ("considered good therapy") with observational language ("in the lower range") in Glasgow FAQ across 3 locations
- Remove therapeutic recommendation ("may warrant pressure or settings adjustment") from rendered Glasgow FAQ JSX
- Replace diagnostic language ("generally considered normal") with observational framing in EAI FAQ across 2 locations

Fixes AIR-191 (CRITICAL) and AIR-190 (HIGH) from the April 4 compliance audit (AIR-176).

## Files changed

- `app/about/page.tsx` -- faqData + rendered JSX for both Glasgow and EAI sections (4 fixes)
- `app/page.tsx` -- landing page FAQ Glasgow description (1 fix)

## MDR compliance

- [x] No therapeutic recommendations
- [x] No diagnostic claims
- [x] No predictive claims
- [x] No clinical effectiveness judgments
- [x] Point-of-use disclaimers unaffected

## Pre-merge checklist

- [x] Full pipeline passes (tsc, lint, test 1685/1685, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] Head of Compliance confirms replacement copy is MDR-safe
- [x] PR contains one concern only
- [x] Self-review: no regressions, text-only changes

## Test plan

- [ ] Verify /about page Glasgow FAQ renders with new observational language
- [ ] Verify /about page EAI FAQ renders with new observational language
- [ ] Verify landing page Glasgow FAQ shows "in the lower range" instead of "considered good therapy"
- [ ] Check no other FAQ content was affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)