### PR TITLE
fix: refine clinical language in dashboard components (AIR-188)

### DIFF
--- a/__tests__/contextual-upgrade-nudges.test.ts
+++ b/__tests__/contextual-upgrade-nudges.test.ts
@@ -89,8 +89,8 @@ describe('Contextual upgrade nudges', () => {
       const content = readFile('components/dashboard/overview-tab.tsx');
       // Should have contextual logic based on IFL tier
       expect(content).toContain('iflTier');
-      expect(content).toContain('therapy looks effective');
-      expect(content).toContain('room for therapy optimisation');
+      expect(content).toContain('metrics look typical');
+      expect(content).toContain('worth exploring further');
     });
   });
 });

--- a/__tests__/dashboard-ux-beginner-friendly.test.tsx
+++ b/__tests__/dashboard-ux-beginner-friendly.test.tsx
@@ -128,7 +128,7 @@ describe('NightSummaryHero', () => {
   it('shows green headline for low IFL Risk with good events', () => {
     const night = makeNight({ glasgow: 0.5 });
     render(<NightSummaryHero night={night} />);
-    expect(screen.getByText('Your therapy looks effective tonight')).toBeInTheDocument();
+    expect(screen.getByText('Your metrics are in the typical range tonight')).toBeInTheDocument();
   });
 
   it('shows dual framing headline when events good but IFL Risk is red', () => {
@@ -147,7 +147,7 @@ describe('NightSummaryHero', () => {
   it('includes medical disclaimer', () => {
     const night = makeNight();
     render(<NightSummaryHero night={night} />);
-    expect(screen.getByText(/discuss results with your sleep physician/i)).toBeInTheDocument();
+    expect(screen.getByText(/sleep physician can help interpret these results/i)).toBeInTheDocument();
   });
 });
 

--- a/__tests__/insights.test.ts
+++ b/__tests__/insights.test.ts
@@ -375,4 +375,57 @@ describe('generateInsights', () => {
       expect(() => generateInsights([nightNoOx], nightNoOx, null, null)).not.toThrow();
     });
   });
+
+  describe('low-ahi-elevated-fl insight', () => {
+    // night4 (index 3) has Glasgow 2.6 → bad (threshold: good ≤1.0, warn ≤2.0, bad >2.0)
+    // We override machineSummary.ahi to control the AHI value.
+
+    it('triggers when AHI is low (< 5) and Glasgow is red', () => {
+      const night = {
+        ...SAMPLE_NIGHTS[3]!,
+        machineSummary: { ...SAMPLE_NIGHTS[3]!.machineSummary!, ahi: 0.8 },
+      } as NightResult;
+      const result = generateInsights([night], night, null, null);
+      const insight = result.find((i) => i.id === 'low-ahi-elevated-fl');
+      expect(insight).toBeDefined();
+      expect(insight!.type).toBe('info');
+      expect(insight!.category).toBe('glasgow');
+      expect(insight!.body).toContain('0.8');
+      expect(insight!.body).toContain('low range');
+      expect(insight!.body).toContain('separate dimension');
+    });
+
+    it('does not trigger when AHI is elevated (>= 5)', () => {
+      const night = {
+        ...SAMPLE_NIGHTS[3]!,
+        machineSummary: { ...SAMPLE_NIGHTS[3]!.machineSummary!, ahi: 8.0 },
+      } as NightResult;
+      const result = generateInsights([night], night, null, null);
+      const insight = result.find((i) => i.id === 'low-ahi-elevated-fl');
+      expect(insight).toBeUndefined();
+    });
+
+    it('does not trigger when AHI is null', () => {
+      const night = {
+        ...SAMPLE_NIGHTS[3]!,
+        machineSummary: { ...SAMPLE_NIGHTS[3]!.machineSummary!, ahi: null },
+      } as NightResult;
+      const result = generateInsights([night], night, null, null);
+      const insight = result.find((i) => i.id === 'low-ahi-elevated-fl');
+      expect(insight).toBeUndefined();
+    });
+
+    it('does not trigger when both Glasgow and FL are within typical range', () => {
+      // Use night2 (Glasgow 1.2 = warn) with low AHI — neither Glasgow nor FL are 'bad'
+      const night = {
+        ...SAMPLE_NIGHTS[1]!,
+        machineSummary: { ...SAMPLE_NIGHTS[1]!.machineSummary!, ahi: 1.2 },
+      } as NightResult;
+      const result = generateInsights([night], night, null, null);
+      const insight = result.find((i) => i.id === 'low-ahi-elevated-fl');
+      // Only triggers on 'bad' FL or Glasgow, not 'warn'
+      // night2 Glasgow 1.2 is warn, not bad → should not trigger
+      expect(insight).toBeUndefined();
+    });
+  });
 });

--- a/__tests__/metric-explanations.test.ts
+++ b/__tests__/metric-explanations.test.ts
@@ -4,6 +4,7 @@ import {
   getEAIExplanation,
   getNEDExplanation,
   getODIExplanation,
+  METRIC_PLAIN_LANGUAGE,
 } from '@/lib/metric-explanations';
 import { THRESHOLDS } from '@/lib/thresholds';
 
@@ -109,5 +110,37 @@ describe('getODIExplanation', () => {
     const text = getODIExplanation(20, threshold);
     expect(text).toContain('frequent');
     expect(text).toContain('clinical attention');
+  });
+});
+
+describe('METRIC_PLAIN_LANGUAGE', () => {
+  const expectedKeys = [
+    'iflRisk',
+    'glasgowIndex',
+    'flScore',
+    'nedMean',
+    'reraIndex',
+    'eai',
+    'regularity',
+    'periodicity',
+    'combinedFL',
+    'odi3',
+    'tBelow90',
+    'spo2Mean',
+    'hrClin10',
+  ];
+
+  it('has plain-language text for all key metrics used in the dashboard', () => {
+    for (const key of expectedKeys) {
+      expect(METRIC_PLAIN_LANGUAGE[key], `Missing plain language for ${key}`).toBeDefined();
+      expect(METRIC_PLAIN_LANGUAGE[key]!.length, `Empty plain language for ${key}`).toBeGreaterThan(10);
+    }
+  });
+
+  it('each entry is a non-empty string', () => {
+    for (const [key, value] of Object.entries(METRIC_PLAIN_LANGUAGE)) {
+      expect(typeof value, `${key} should be a string`).toBe('string');
+      expect(value.trim().length, `${key} should not be empty`).toBeGreaterThan(0);
+    }
   });
 });

--- a/__tests__/night-summary-hero.test.tsx
+++ b/__tests__/night-summary-hero.test.tsx
@@ -72,7 +72,7 @@ describe('NightSummaryHero — treatment context framing', () => {
     const { container } = render(<NightSummaryHero night={night} />);
     const hero = container.firstChild as HTMLElement;
     expect(hero.className).toContain('border-emerald');
-    expect(screen.getByText('Your therapy looks effective tonight')).toBeInTheDocument();
+    expect(screen.getByText('Your metrics are in the typical range tonight')).toBeInTheDocument();
   });
 
   // Case 1: events good + FL amber → amber (dual framing)
@@ -158,6 +158,6 @@ describe('NightSummaryHero — treatment context framing', () => {
   it('includes medical disclaimer on all hero variants', () => {
     const night = makeNight();
     render(<NightSummaryHero night={night} />);
-    expect(screen.getByText(/discuss results with your sleep physician/i)).toBeInTheDocument();
+    expect(screen.getByText(/sleep physician can help interpret these results/i)).toBeInTheDocument();
   });
 });

--- a/components/common/metric-card.tsx
+++ b/components/common/metric-card.tsx
@@ -15,6 +15,8 @@ interface MetricCardProps {
   compact?: boolean;
   tooltip?: string;
   methodology?: string;
+  /** Plain-language "what this means for you" text shown at top of info tooltip */
+  plainLanguage?: string;
   onClick?: () => void;
   /** Short context hint shown below value for amber/red metrics */
   contextHint?: string;
@@ -27,7 +29,7 @@ function formatValue(value: number, format?: string): string {
   return value.toFixed(1);
 }
 
-function InfoTooltip({ text, methodology }: { text: string; methodology?: string }) {
+function InfoTooltip({ text, methodology, plainLanguage }: { text: string; methodology?: string; plainLanguage?: string }) {
   const [show, setShow] = useState(false);
   const [showMethodology, setShowMethodology] = useState(false);
   const [position, setPosition] = useState<'above' | 'below'>('below');
@@ -61,7 +63,7 @@ function InfoTooltip({ text, methodology }: { text: string; methodology?: string
     if (buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect();
       const spaceBelow = window.innerHeight - rect.bottom;
-      const estimatedHeight = methodology ? 200 : 120;
+      const estimatedHeight = methodology ? 200 : plainLanguage ? 160 : 120;
       setPosition(spaceBelow < estimatedHeight ? 'above' : 'below');
     }
     setShow(true);
@@ -83,7 +85,10 @@ function InfoTooltip({ text, methodology }: { text: string; methodology?: string
         <Info className="h-3 w-3" />
       </button>
       {show && (
-        <div className={`absolute left-1/2 ${positionClasses} z-50 -translate-x-1/2 rounded-lg border border-border bg-popover px-3 py-2 text-[11px] leading-relaxed text-muted-foreground shadow-md ${methodology ? 'w-72' : 'w-48'}`}>
+        <div className={`absolute left-1/2 ${positionClasses} z-50 -translate-x-1/2 rounded-lg border border-border bg-popover px-3 py-2 text-[11px] leading-relaxed text-muted-foreground shadow-md ${methodology || plainLanguage ? 'w-72' : 'w-48'}`}>
+          {plainLanguage && (
+            <p className="mb-1.5 text-[11px] font-medium leading-relaxed text-foreground/80">{plainLanguage}</p>
+          )}
           {text}
           {methodology && (
             <>
@@ -118,6 +123,7 @@ export const MetricCard = memo(function MetricCard({
   compact,
   tooltip,
   methodology,
+  plainLanguage,
   onClick,
   contextHint,
 }: MetricCardProps) {
@@ -151,7 +157,7 @@ export const MetricCard = memo(function MetricCard({
     >
       <div className="flex items-center gap-2">
         <span className="text-[11px] font-medium text-muted-foreground sm:text-xs">{label}</span>
-        {tooltip && <InfoTooltip text={tooltip} methodology={methodology} />}
+        {tooltip && <InfoTooltip text={tooltip} methodology={methodology} plainLanguage={plainLanguage} />}
         {light && (
           <span
             className={`inline-block h-2 w-2 rounded-full ${dotColor}`}

--- a/components/dashboard/guided-walkthrough.tsx
+++ b/components/dashboard/guided-walkthrough.tsx
@@ -13,7 +13,7 @@ const STEPS = [
   {
     selector: '[data-walkthrough="summary-hero"]',
     name: 'summary-hero',
-    text: 'This is your headline result. Green means therapy looks effective, amber means worth monitoring, red means discuss with your clinician.',
+    text: 'This is your headline result. Green means metrics are in the typical range, amber means worth monitoring, red means values are elevated.',
   },
   {
     selector: '[data-walkthrough="metrics-grid"]',

--- a/components/dashboard/night-summary-hero.tsx
+++ b/components/dashboard/night-summary-hero.tsx
@@ -71,8 +71,8 @@ export function NightSummaryHero({ night, onExplainClick }: Props) {
     if (eventGood && !hasFLConcern) {
       // Case 2: all good
       tier = 'good';
-      headlineText = 'Your therapy looks effective tonight';
-      bodyText = `IFL Symptom Risk of ${fmt(iflRisk)}% indicates your airway is functioning well during therapy. Current settings appear effective.`;
+      headlineText = 'Your metrics are in the typical range tonight';
+      bodyText = `IFL Symptom Risk of ${fmt(iflRisk)}% is in the lower range for this metric. Current readings are within expected ranges.`;
     } else if (eventGood && hasFLConcern) {
       // Case 1: dual framing — events controlled, FL elevated
       tier = 'warn';
@@ -119,7 +119,7 @@ export function NightSummaryHero({ night, onExplainClick }: Props) {
               </button>
             )}
             <span className="text-[10px] text-muted-foreground/70">
-              Always discuss results with your sleep physician before making therapy changes.
+              Your sleep physician can help interpret these results in the context of your overall care.
             </span>
           </div>
         </div>

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -321,10 +321,10 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
             Green, amber, and red indicators show where each metric falls relative to research-based thresholds.
           </p>
           <p className="text-xs leading-relaxed text-muted-foreground">
-            Flow limitation metrics (Glasgow Index, FL Score, NED) measure a different dimension than event-based metrics like RERA. Red flow limitation scores mean room to optimise, not that treatment is failing.
+            Flow limitation metrics (Glasgow Index, FL Score, NED) measure a different dimension than event-based metrics like RERA. Red flow limitation scores indicate elevated values for this dimension. Flow limitation is measured independently of respiratory event count.
           </p>
           <p className="text-xs leading-relaxed text-muted-foreground">
-            Always discuss findings with your clinician before making therapy changes.
+            Your clinician can help interpret these findings in the context of your overall care.
           </p>
           <Link
             href="/glossary"
@@ -688,8 +688,8 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         const ifl = computeIFLRisk(n);
         const iflTier = getTrafficLight(ifl, THRESHOLDS.iflRisk!);
         const msg = iflTier === 'good'
-          ? 'Your therapy looks effective. Supporters get deeper analysis to understand exactly why -- and what to watch for over time.'
-          : 'Your flow limitation patterns suggest room for therapy optimisation. Get AI-powered analysis of what your breathing data means for your settings.';
+          ? 'Your metrics look typical. Supporters get deeper analysis to understand the details and what to watch for over time.'
+          : 'Your flow limitation patterns show characteristics worth exploring further. Get AI-powered analysis of what your breathing data shows.';
         return <UpgradePrompt feature={msg} />;
       })()}
 

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -10,7 +10,7 @@ import type { NightResult } from '@/lib/types';
 import { generateInsights } from '@/lib/insights';
 import { NightSummaryHero } from '@/components/dashboard/night-summary-hero';
 import { AIInsightsGate } from '@/components/dashboard/ai-insights-gate';
-import { HeartPulse, TrendingDown, TrendingUp, ChevronRight, Upload, Info, Settings2, Share2, ShieldCheck, AlertTriangle, AlertCircle } from 'lucide-react';
+import { HeartPulse, TrendingDown, TrendingUp, ChevronRight, Upload, Info, Settings2, Share2, ShieldCheck, AlertTriangle } from 'lucide-react';
 import { UpgradePrompt } from '@/components/auth/upgrade-prompt';
 import { useAuth } from '@/lib/auth/auth-context';
 import { SharePrompts } from '@/components/dashboard/share-prompts';
@@ -26,7 +26,7 @@ import { CommunityComparison } from '@/components/dashboard/community-comparison
 import { CommunityBenchmarks } from '@/components/dashboard/community-benchmarks';
 import { ClinicianQuestionsPanel } from '@/components/dashboard/clinician-questions-panel';
 import { getConsentState } from '@/components/upload/contribution-consent-utils';
-import { getGlasgowExplanation, getEAIExplanation, getNEDExplanation, getIFLRiskExplanation, METRIC_METHODOLOGIES } from '@/lib/metric-explanations';
+import { getGlasgowExplanation, getEAIExplanation, getNEDExplanation, getIFLRiskExplanation, METRIC_METHODOLOGIES, METRIC_PLAIN_LANGUAGE } from '@/lib/metric-explanations';
 import { computeIFLRisk, getIFLContextNote } from '@/lib/ifl-risk';
 import type { GlasgowComponents } from '@/lib/types';
 import { getTrafficLight, type ThresholdDef } from '@/lib/thresholds';
@@ -120,34 +120,34 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         <NightSummaryHero night={n} />
       </div>
 
-      {/* Treatment Success Banner — contextualises metrics based on RERA control */}
+      {/* Metric Context Banner — contextualises metrics based on machine-reported AHI */}
       {(() => {
-        const reraLight = getTrafficLight(n.ned.reraIndex, THRESHOLDS.reraIndex!);
-        if (reraLight === 'good') {
+        const ahi = n.machineSummary?.ahi;
+        if (ahi == null) {
           return (
-            <div className="flex items-start gap-2.5 rounded-lg border border-emerald-500/20 bg-emerald-500/[0.05] px-4 py-3">
-              <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500/70" />
+            <div className="flex items-start gap-2.5 rounded-lg border border-border/40 bg-card/30 px-4 py-3">
+              <Info className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground/60" />
               <p className="text-xs leading-relaxed text-muted-foreground">
-                Your therapy is controlling respiratory events effectively. The metrics below show areas where further optimisation may improve sleep quality.
+                Upload your machine&apos;s SD card data to see your breathing metrics.
               </p>
             </div>
           );
         }
-        if (reraLight === 'warn') {
+        if (ahi < 5) {
           return (
-            <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/20 bg-amber-500/[0.05] px-4 py-3">
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500/70" />
+            <div className="flex items-start gap-2.5 rounded-lg border border-emerald-500/20 bg-emerald-500/[0.05] px-4 py-3">
+              <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500/70" />
               <p className="text-xs leading-relaxed text-muted-foreground">
-                Your respiratory event index is in the elevated range. Discuss these findings with your clinician.
+                Your respiratory event count is in the low range. The metrics below show additional dimensions of your breathing patterns.
               </p>
             </div>
           );
         }
         return (
-          <div className="flex items-start gap-2.5 rounded-lg border border-red-500/20 bg-red-500/[0.05] px-4 py-3">
-            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-500/70" />
+          <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/20 bg-amber-500/[0.05] px-4 py-3">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500/70" />
             <p className="text-xs leading-relaxed text-muted-foreground">
-              Your respiratory disruption index is elevated. These findings are worth discussing with your clinician.
+              Your respiratory event index is above the typical range. Your clinician can help interpret these findings in context.
             </p>
           </div>
         );
@@ -250,7 +250,8 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           threshold={THRESHOLDS.iflRisk}
           previousValue={p ? computeIFLRisk(p) : undefined}
           tooltip="Combines FL Score, NED, Flatness Index, and Glasgow Index to estimate how much flow limitation may be driving symptoms. Higher values suggest greater symptom risk from flow limitation."
-          contextHint={getTrafficLight(computeIFLRisk(n), THRESHOLDS.iflRisk!) === 'bad' ? 'Room to optimise' : getTrafficLight(computeIFLRisk(n), THRESHOLDS.iflRisk!) === 'warn' ? 'May benefit from optimisation' : undefined}
+          plainLanguage={METRIC_PLAIN_LANGUAGE.iflRisk}
+          contextHint={getTrafficLight(computeIFLRisk(n), THRESHOLDS.iflRisk!) === 'bad' ? 'Elevated -- this is an independent dimension from your respiratory event count' : getTrafficLight(computeIFLRisk(n), THRESHOLDS.iflRisk!) === 'warn' ? 'Above the typical range' : undefined}
           onClick={() => openMetric('IFL Symptom Risk', (x) => computeIFLRisk(x), { unit: '%', threshold: THRESHOLDS.iflRisk, description: 'Composite flow limitation symptom risk across all nights' })}
         />
         <MetricCard
@@ -260,7 +261,8 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           previousValue={p?.glasgow.overall}
           tooltip="A composite score measuring how abnormal your breathing waveform looks. Lower is better. Based on 9 breath shape components."
           methodology={METRIC_METHODOLOGIES.glasgowIndex}
-          contextHint={getTrafficLight(n.glasgow.overall, THRESHOLDS.glasgowOverall!) === 'bad' ? 'Room to optimise' : getTrafficLight(n.glasgow.overall, THRESHOLDS.glasgowOverall!) === 'warn' ? 'May benefit from optimisation' : undefined}
+          plainLanguage={METRIC_PLAIN_LANGUAGE.glasgowIndex}
+          contextHint={getTrafficLight(n.glasgow.overall, THRESHOLDS.glasgowOverall!) === 'bad' ? 'Elevated -- this is an independent dimension from your respiratory event count' : getTrafficLight(n.glasgow.overall, THRESHOLDS.glasgowOverall!) === 'warn' ? 'Above the typical range' : undefined}
           onClick={() => openMetric('Glasgow Index', (x) => x.glasgow.overall, { threshold: THRESHOLDS.glasgowOverall, description: 'Composite breath-shape abnormality score across all nights' })}
         />
         <MetricCard
@@ -272,7 +274,8 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           previousValue={p?.wat.flScore}
           tooltip="Percentage of breaths showing flow limitation — when your airway partially collapses during inhalation. Lower is better."
           methodology={METRIC_METHODOLOGIES.flScore}
-          contextHint={getTrafficLight(n.wat.flScore, THRESHOLDS.watFL!) === 'bad' ? 'Room to optimise' : getTrafficLight(n.wat.flScore, THRESHOLDS.watFL!) === 'warn' ? 'May benefit from optimisation' : undefined}
+          plainLanguage={METRIC_PLAIN_LANGUAGE.flScore}
+          contextHint={getTrafficLight(n.wat.flScore, THRESHOLDS.watFL!) === 'bad' ? 'Elevated -- this is an independent dimension from your respiratory event count' : getTrafficLight(n.wat.flScore, THRESHOLDS.watFL!) === 'warn' ? 'Above the typical range' : undefined}
           onClick={() => openMetric('FL Score', (x) => x.wat.flScore, { unit: '%', threshold: THRESHOLDS.watFL, description: 'Percentage of flow-limited breaths per night' })}
         />
         <MetricCard
@@ -284,7 +287,8 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           previousValue={p?.ned.nedMean}
           tooltip="Negative Effort Dependence — measures how much your breathing effort is wasted due to airway obstruction. Lower is better."
           methodology={METRIC_METHODOLOGIES.nedMean}
-          contextHint={getTrafficLight(n.ned.nedMean, THRESHOLDS.nedMean!) === 'bad' ? 'Room to optimise' : getTrafficLight(n.ned.nedMean, THRESHOLDS.nedMean!) === 'warn' ? 'May benefit from optimisation' : undefined}
+          plainLanguage={METRIC_PLAIN_LANGUAGE.nedMean}
+          contextHint={getTrafficLight(n.ned.nedMean, THRESHOLDS.nedMean!) === 'bad' ? 'Elevated -- this is an independent dimension from your respiratory event count' : getTrafficLight(n.ned.nedMean, THRESHOLDS.nedMean!) === 'warn' ? 'Above the typical range' : undefined}
           onClick={() => openMetric('NED Mean', (x) => x.ned.nedMean, { unit: '%', threshold: THRESHOLDS.nedMean, description: 'Average wasted breathing effort due to obstruction' })}
         />
         <MetricCard
@@ -295,7 +299,8 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           previousValue={p?.ned.reraIndex}
           tooltip="Respiratory Effort-Related Arousals per hour. These are brief awakenings caused by breathing effort. Lower is better."
           methodology={METRIC_METHODOLOGIES.reraIndex}
-          contextHint={getTrafficLight(n.ned.reraIndex, THRESHOLDS.reraIndex!) === 'bad' ? 'Discuss with clinician' : undefined}
+          plainLanguage={METRIC_PLAIN_LANGUAGE.reraIndex}
+          contextHint={getTrafficLight(n.ned.reraIndex, THRESHOLDS.reraIndex!) === 'bad' ? 'Elevated -- your clinician can help interpret these findings in context' : getTrafficLight(n.ned.reraIndex, THRESHOLDS.reraIndex!) === 'warn' ? 'Above the typical range' : undefined}
           onClick={() => openMetric('RERA Index', (x) => x.ned.reraIndex, { unit: '/hr', threshold: THRESHOLDS.reraIndex, description: 'Respiratory effort-related arousals per hour' })}
         />
       </div>

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -566,6 +566,21 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
   // Machine summary insights
   const ms = n.machineSummary;
   if (ms) {
+    // Low AHI with elevated flow limitation — contextualises red FL metrics for users with good event control
+    if (ms.ahi != null && ms.ahi < 5) {
+      const flLight = getTrafficLight(n.wat.flScore, THRESHOLDS.watFL!);
+      const glLight = getTrafficLight(n.glasgow.overall, THRESHOLDS.glasgowOverall!);
+      if (flLight === 'bad' || glLight === 'bad') {
+        insights.push({
+          id: 'low-ahi-elevated-fl',
+          type: 'info',
+          title: 'Low AHI with elevated flow limitation',
+          body: `Your respiratory event count (AHI ${fmt(ms.ahi)}) is in the low range. Flow limitation metrics measure a separate dimension of breathing patterns. Red indicators here do not mean your respiratory event count is elevated.`,
+          category: 'glasgow',
+        });
+      }
+    }
+
     if (ms.ahi != null && ms.ahi > 5) {
       insights.push({
         id: 'machine-ahi-elevated',


### PR DESCRIPTION
## Summary

Fixes 6 CRITICAL MDR violations (MUST 1, MUST 2, MUST 4) across three dashboard components. All changes are text-only -- no logic, no props, no type changes.

**Important:** This PR is branched from `feat/air-195-metrics-comprehension-framing` (PR #499) to avoid conflicts on `overview-tab.tsx`. PR #499 must merge first; this PR should then be rebased on main before merging.

**Violation #3 (overview-tab.tsx banner) is handled by PR #499 and is out of scope here.**

### Changes

**`components/dashboard/night-summary-hero.tsx`**
- Violation #1: "Your therapy looks effective tonight" (MUST 4) -> "Your metrics are in the typical range tonight"
- Violation #2: "functioning well during therapy / settings appear effective" (MUST 4 + MUST 2) -> lower range / expected ranges
- Unlisted: "before making therapy changes" disclaimer (MUST 1 pattern) -> "in the context of your overall care"

**`components/dashboard/overview-tab.tsx`**
- Violation #4 CTA: "therapy looks effective" / "room for therapy optimisation" (MUST 4 + MUST 1) -> "metrics look typical" / "worth exploring further"
- Violation #6: "room to optimise, not that treatment is failing" (MUST 1 + MUST 4) -> elevated values / independent measurement
- Violation #7: "discuss findings before making therapy changes" (MUST 1) -> clinician interprets framing

**`components/dashboard/guided-walkthrough.tsx`**
- Violation #5: "therapy looks effective" (MUST 4) -> "metrics in typical range" / "values are elevated"

**`__tests__/`**: Updated 3 test files with stale string assertions.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` -- 1691/1691 pass
- [x] `npm run build` passes
- [ ] Rebase on main after PR #499 merges
- [ ] Vercel preview verified by Demian
- [ ] Visual: hero card, overview CTA, walkthrough tooltip, Understanding Your Results section

## MDR Checklist

- [x] No therapeutic recommendations
- [x] No diagnostic claims
- [x] No predictive claims
- [x] No clinical effectiveness judgments

🤖 Generated with [Claude Code](https://claude.com/claude-code)