### PR TITLE
fix: refine clinical terminology and AI prompt framing (AIR-183)

### DIFF
--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -372,7 +372,7 @@ export async function POST(request: NextRequest) {
       try {
         const { data: aggStats } = await adminForStats.rpc('get_symptom_aggregate_stats');
         if (aggStats && aggStats.total_ratings >= 100) {
-          systemPrompt += `\n\nCommunity context (${aggStats.total_ratings} self-reported sleep quality ratings across all users):\n- Average rating: ${Number(aggStats.avg_rating).toFixed(1)}/5\n- Users with IFL Risk >45% who rated sleep as Poor/Terrible: ${aggStats.high_ifl_poor_pct ?? 0}%\n- Users with IFL Risk <20% who rated sleep as Good/Great: ${aggStats.low_ifl_good_pct ?? 0}%\nUse this context to frame whether this user's experience is typical or atypical relative to the community.`;
+          systemPrompt += `\n\nCommunity context: average sleep rating ${Number(aggStats.avg_rating).toFixed(1)}/5 across ${aggStats.total_ratings} users.`;
         }
       } catch {
         // Non-critical — proceed without aggregate stats

--- a/components/dashboard/deep-insight-teasers.tsx
+++ b/components/dashboard/deep-insight-teasers.tsx
@@ -49,7 +49,7 @@ export function DeepInsightTeasers({ night }: Props) {
     if (night.wat.flScore > 30) {
       teasers.push({
         title: 'What is driving your flow limitation',
-        desc: `At ${night.wat.flScore.toFixed(0)}% FL Score, individual breath analysis can identify the obstruction type...`,
+        desc: `At ${night.wat.flScore.toFixed(0)}% FL Score, individual breath analysis can reveal patterns in how your breathing effort changes across the night...`,
       });
     }
   }
@@ -59,7 +59,7 @@ export function DeepInsightTeasers({ night }: Props) {
     if (!teasers.some((t) => t.title.includes('Breath Pattern'))) {
       teasers.push({
         title: 'Breath Pattern Classification',
-        desc: 'Individual breath shapes analysed for obstruction type...',
+        desc: 'Individual breath shapes analysed for breathing effort patterns...',
       });
     }
     if (!teasers.some((t) => t.title.includes('Temporal'))) {

--- a/components/dashboard/flow-analysis-tab.tsx
+++ b/components/dashboard/flow-analysis-tab.tsx
@@ -79,7 +79,7 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
             format="pct"
             threshold={THRESHOLDS.watPeriodicity}
             previousValue={p?.wat.periodicityIndex}
-            tooltip="Detects cyclic breathing patterns using FFT on minute ventilation. May indicate periodic breathing or Cheyne-Stokes. Lower is better."
+            tooltip="Detects repeating patterns in airflow. A high score can be worth discussing with your clinician."
             methodology={METRIC_METHODOLOGIES.periodicity}
             onClick={clickable ? () => openMetric('Periodicity', (x) => x.wat.periodicityIndex, { unit: '%', threshold: THRESHOLDS.watPeriodicity }) : undefined}
           />
@@ -361,8 +361,7 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
             </div>
           </div>
           <p className="mt-3 text-[11px] leading-relaxed text-muted-foreground/70">
-            REM-predominant flow limitation typically worsens in H2 as REM density increases.
-            A significant H2 rise (&gt;3%) is a common pattern in the second half of the night, associated with positional changes or REM sleep.
+            A significant H2 rise (&gt;3%) is a pattern worth noting -- your clinician can help assess whether position or sleep stage may be relevant.
           </p>
         </CardContent>
       </Card>

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -526,7 +526,7 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
           threshold={THRESHOLDS.watPeriodicity}
           previousValue={p?.wat.periodicityIndex}
           compact
-          tooltip="Detects repeating patterns in airflow that may indicate periodic breathing or Cheyne-Stokes. Lower is better."
+          tooltip="Detects repeating patterns in airflow. A high score can be worth discussing with your clinician."
           methodology={METRIC_METHODOLOGIES.periodicity}
           onClick={() => openMetric('Periodicity', (x) => x.wat.periodicityIndex, { unit: '%', threshold: THRESHOLDS.watPeriodicity })}
         />


### PR DESCRIPTION
## Summary

Removes 6 MODERATE MDR violations identified in AIR-183, a subtask of the AIR-176 compliance audit.

**Cheyne-Stokes diagnostic naming (3 locations):**
- `flow-analysis-tab.tsx:82` -- removed condition name from Periodicity tooltip
- `flow-analysis-tab.tsx:364-365` -- replaced predictive "typically worsens" copy with clinician-referral language
- `overview-tab.tsx:529` -- removed condition name from Periodicity tooltip

**Obstruction type classification (2 locations):**
- `deep-insight-teasers.tsx:52` -- "identify the obstruction type" -> "reveal patterns in how your breathing effort changes"
- `deep-insight-teasers.tsx:62` -- "obstruction type" -> "breathing effort patterns"

**AI prompt typicality framing (1 location):**
- `app/api/ai-insights/route.ts:375` -- stripped IFL risk stratification percentages and typicality framing instruction; replaced with simple aggregate average

## MDR Compliance Checklist

- [x] No therapeutic recommendations
- [x] No diagnostic claims (Cheyne-Stokes, obstruction type removed)
- [x] No predictive claims ("typically worsens" removed)
- [x] No clinical effectiveness judgments
- [x] AI system prompt describes data only, no action suggestions
- [x] No new MUST violations introduced

## Test plan

- [x] `npx tsc --noEmit` -- passes (exit 0)
- [x] `npm run build` -- passes (exit 0)
- [x] `npm test` -- 109 files, 1707 tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)