### PR TITLE
fix: increase MobileEmailCapture checkbox touch target to 44px (AIR-217)

### DIFF
--- a/__tests__/mobile-email-capture.test.tsx
+++ b/__tests__/mobile-email-capture.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Tests for MobileEmailCapture touch-target and accessibility fixes (AIR-217).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MobileEmailCapture } from '@/components/upload/mobile-email-capture';
+
+// Suppress Next.js router warnings in tests
+vi.mock('next/navigation', () => ({ useRouter: () => ({}) }));
+
+// Mock analytics to prevent noise
+vi.mock('@/lib/analytics', () => ({
+  events: {
+    mobileReminderShown: vi.fn(),
+    mobileReminderSubmitted: vi.fn(),
+    mobileReminderSuccess: vi.fn(),
+    mobileReminderError: vi.fn(),
+  },
+}));
+
+// Suppress localStorage unavailability in jsdom
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+beforeEach(() => {
+  localStorageMock.clear();
+  vi.clearAllMocks();
+});
+
+describe('MobileEmailCapture -- touch target and a11y (AIR-217)', () => {
+  it('renders the consent wrapper as a <label> element for full-row tap target', () => {
+    render(<MobileEmailCapture />);
+    // The checkbox wrapper must be a label (not a div) so the full row is tappable
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.closest('label')).not.toBeNull();
+  });
+
+  it('consent wrapper has min-h-[44px] class for 44px touch target', () => {
+    render(<MobileEmailCapture />);
+    const checkbox = screen.getByRole('checkbox');
+    const wrapper = checkbox.closest('label') as HTMLLabelElement;
+    expect(wrapper.className).toContain('min-h-[44px]');
+  });
+
+  it('checkbox is h-5 w-5 (20px visual, part of 44px label target)', () => {
+    render(<MobileEmailCapture />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.className).toContain('h-5');
+    expect(checkbox.className).toContain('w-5');
+  });
+
+  it('clicking any part of the label row toggles the checkbox', () => {
+    render(<MobileEmailCapture />);
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    const wrapper = checkbox.closest('label') as HTMLLabelElement;
+    expect(checkbox.checked).toBe(false);
+    fireEvent.click(wrapper);
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('submit button has aria-disabled when email is empty', () => {
+    render(<MobileEmailCapture />);
+    const button = screen.getByRole('button', { name: /email me a reminder/i });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('submit button has aria-disabled when consent is unchecked', () => {
+    render(<MobileEmailCapture />);
+    const emailInput = screen.getByPlaceholderText('your@email.com');
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    const button = screen.getByRole('button', { name: /email me a reminder/i });
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('submit button removes aria-disabled when email and consent are valid', () => {
+    render(<MobileEmailCapture />);
+    const emailInput = screen.getByPlaceholderText('your@email.com');
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.click(checkbox);
+    const button = screen.getByRole('button', { name: /email me a reminder/i });
+    expect(button).toHaveAttribute('aria-disabled', 'false');
+  });
+
+  it('no nested <label> elements (HTML spec violation that would break click propagation)', () => {
+    render(<MobileEmailCapture />);
+    const labels = document.querySelectorAll('label label');
+    expect(labels.length).toBe(0);
+  });
+});

--- a/components/upload/mobile-email-capture.tsx
+++ b/components/upload/mobile-email-capture.tsx
@@ -89,22 +89,26 @@ export function MobileEmailCapture({ className }: MobileEmailCaptureProps) {
         disabled={status === 'sending'}
         className="mt-4 h-10 w-full rounded-md border border-border bg-background px-3 text-sm placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-primary/50 disabled:opacity-50"
       />
-      <div className="flex items-start gap-2 mt-3 text-left">
+      <label
+        htmlFor="reminder-consent"
+        className="flex items-center gap-3 mt-3 text-left cursor-pointer min-h-[44px] py-1"
+      >
         <input
           type="checkbox"
           id="reminder-consent"
           checked={consent}
           onChange={(e) => setConsent(e.target.checked)}
           disabled={status === 'sending'}
-          className="mt-0.5 h-4 w-4 shrink-0 accent-primary"
+          className="h-5 w-5 shrink-0 accent-primary"
         />
-        <label htmlFor="reminder-consent" className="text-xs text-muted-foreground cursor-pointer">
+        <span className="text-xs text-muted-foreground">
           I agree to receive a one-time reminder email. No marketing. Unsubscribe any time.
-        </label>
-      </div>
+        </span>
+      </label>
       <Button
         onClick={handleSubmit}
         disabled={!email.includes('@') || !consent || status !== 'idle'}
+        aria-disabled={!email.includes('@') || !consent || status !== 'idle'}
         aria-label={status === 'sending' ? 'Sending reminder...' : undefined}
         className="mt-4 w-full"
       >


### PR DESCRIPTION
## Summary

- Wraps consent checkbox + label text in a single `<label>` with `min-h-[44px]`, making the full row the touch target (was 16px, iOS/Android minimum is 44px)
- Converts inner nested `<label>` to `<span>` to satisfy HTML spec (no nested labels)
- Grows checkbox visual size from `h-4 w-4` to `h-5 w-5`
- Adds `aria-disabled` to the submit button when the form is not submittable
- Ships with 8 new tests in `__tests__/mobile-email-capture.test.tsx` covering all acceptance criteria

Closes AIR-217. Related to AIR-215 (UX review) and AIR-139 (mobile email capture feature).

## Test plan

- [x] `npx tsc --noEmit` -- passes
- [x] `npx vitest run __tests__/mobile-email-capture.test.tsx` -- 8/8 pass
- [x] Full test suite -- 1715/1715 pass
- [x] `npm run build` -- clean
- [ ] Manual: tap checkbox on iOS Safari -- touch target covers full row height
- [ ] Manual: tap checkbox on Android Chrome -- same
- [ ] Manual: desktop view -- no visual regression (component is `sm:hidden`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)