### PR TITLE
fix: preserve tier selection through magic-link auth flow (AIR-228)

### DIFF
--- a/__tests__/pricing-upgrade-intent.test.ts
+++ b/__tests__/pricing-upgrade-intent.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for AIR-228: preserve tier selection through magic-link auth flow.
+ *
+ * Verifies that the pricing page stores upgrade intent in sessionStorage
+ * before opening the auth modal, then auto-triggers checkout when the
+ * user returns authenticated.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..');
+
+function readSource(filePath: string): string {
+  return fs.readFileSync(path.join(ROOT, filePath), 'utf-8');
+}
+
+const pricingSrc = readSource('app/pricing/page.tsx');
+
+// ── Constant ──────────────────────────────────────────────────
+describe('UPGRADE_INTENT_KEY constant', () => {
+  it('defines the constant with the correct airwaylab_ prefix', () => {
+    expect(pricingSrc).toContain("const UPGRADE_INTENT_KEY = 'airwaylab_upgrade_intent'");
+  });
+});
+
+// ── Intent storage on unauthenticated checkout ─────────────────
+describe('handleCheckout: stores intent before auth modal', () => {
+  it('calls sessionStorage.setItem with UPGRADE_INTENT_KEY before setAuthModalOpen', () => {
+    expect(pricingSrc).toContain('sessionStorage.setItem(UPGRADE_INTENT_KEY, priceId)');
+  });
+
+  it('wraps sessionStorage.setItem in try/catch so storage failure is non-critical', () => {
+    // The setItem call must be inside a try block
+    const setItemIndex = pricingSrc.indexOf('sessionStorage.setItem(UPGRADE_INTENT_KEY');
+    const tryBeforeSetItem = pricingSrc.lastIndexOf('try {', setItemIndex);
+    const catchAfterSetItem = pricingSrc.indexOf('} catch', setItemIndex);
+    expect(tryBeforeSetItem).toBeGreaterThan(-1);
+    expect(catchAfterSetItem).toBeGreaterThan(setItemIndex);
+  });
+
+  it('still calls setAuthModalOpen(true) after storing intent', () => {
+    const setItemIndex = pricingSrc.indexOf('sessionStorage.setItem(UPGRADE_INTENT_KEY');
+    const modalOpenIndex = pricingSrc.indexOf('setAuthModalOpen(true)', setItemIndex);
+    expect(modalOpenIndex).toBeGreaterThan(setItemIndex);
+  });
+});
+
+// ── Intent pickup on auth ──────────────────────────────────────
+describe('useEffect: auto-triggers checkout when user authenticates', () => {
+  it('reads the stored intent from sessionStorage on user auth', () => {
+    expect(pricingSrc).toContain('sessionStorage.getItem(UPGRADE_INTENT_KEY)');
+  });
+
+  it('removes the intent from sessionStorage after reading', () => {
+    expect(pricingSrc).toContain('sessionStorage.removeItem(UPGRADE_INTENT_KEY)');
+  });
+
+  it('calls handleCheckout with the stored priceId', () => {
+    expect(pricingSrc).toContain('handleCheckout(pendingPriceId)');
+  });
+
+  it('guards the effect with !user early return so it only fires when authenticated', () => {
+    expect(pricingSrc).toContain('if (!user) return;');
+  });
+
+  it('dependency array is [user] so effect fires on authentication', () => {
+    // Verify the intent effect uses [user] as its dependency
+    const getItemIndex = pricingSrc.indexOf('sessionStorage.getItem(UPGRADE_INTENT_KEY)');
+    const depsAfter = pricingSrc.indexOf('}, [user]);', getItemIndex);
+    expect(depsAfter).toBeGreaterThan(getItemIndex);
+  });
+
+  it('wraps sessionStorage access in try/catch so storage failure is safe', () => {
+    const getItemIndex = pricingSrc.indexOf('sessionStorage.getItem(UPGRADE_INTENT_KEY)');
+    const tryBefore = pricingSrc.lastIndexOf('try {', getItemIndex);
+    const catchAfter = pricingSrc.indexOf('} catch', getItemIndex);
+    expect(tryBefore).toBeGreaterThan(-1);
+    expect(catchAfter).toBeGreaterThan(getItemIndex);
+  });
+});
+
+// ── No regression for authenticated users ─────────────────────
+describe('handleCheckout: authenticated users bypass auth modal', () => {
+  it('proceeds to fetch /api/create-checkout-session when user is set', () => {
+    // The fetch call must come AFTER the !user guard, not before
+    const userGuardIndex = pricingSrc.indexOf('if (!user) {');
+    const fetchIndex = pricingSrc.indexOf("fetch('/api/create-checkout-session'");
+    expect(fetchIndex).toBeGreaterThan(userGuardIndex);
+  });
+
+  it('does not store intent when user is already authenticated (setItem inside !user block)', () => {
+    // The sessionStorage.setItem must be inside the if (!user) block, not outside
+    const userGuardStart = pricingSrc.indexOf('if (!user) {');
+    const userGuardEnd = pricingSrc.indexOf('\n    }', userGuardStart);
+    const setItemIndex = pricingSrc.indexOf('sessionStorage.setItem(UPGRADE_INTENT_KEY', userGuardStart);
+    expect(setItemIndex).toBeGreaterThan(userGuardStart);
+    expect(setItemIndex).toBeLessThan(userGuardEnd);
+  });
+});

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -9,6 +9,8 @@ import { useAuth } from '@/lib/auth/auth-context';
 import { AuthModal } from '@/components/auth/auth-modal';
 import { CommunityCounter } from '@/components/common/community-counter';
 
+const UPGRADE_INTENT_KEY = 'airwaylab_upgrade_intent';
+
 const PRICES = {
   supporter: {
     monthly: process.env.NEXT_PUBLIC_STRIPE_SUPPORTER_MONTHLY_PRICE_ID,
@@ -95,6 +97,19 @@ export default function PricingPage() {
     events.pricingViewed();
   }, []);
 
+  useEffect(() => {
+    if (!user) return;
+    let pendingPriceId: string | null = null;
+    try {
+      pendingPriceId = sessionStorage.getItem(UPGRADE_INTENT_KEY);
+      if (pendingPriceId) sessionStorage.removeItem(UPGRADE_INTENT_KEY);
+    } catch { /* storage unavailable */ }
+    if (pendingPriceId) {
+      handleCheckout(pendingPriceId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
   const handleCheckout = async (priceId: string | undefined) => {
     if (!priceId) {
       console.error('[pricing] Missing price ID for checkout — env var not configured');
@@ -105,6 +120,9 @@ export default function PricingPage() {
 
     if (!user) {
       events.authStarted('pricing');
+      try {
+        sessionStorage.setItem(UPGRADE_INTENT_KEY, priceId);
+      } catch { /* storage unavailable -- non-critical */ }
       setAuthModalOpen(true);
       return;
     }


### PR DESCRIPTION
## Summary

- Store `priceId` in `sessionStorage` under `airwaylab_upgrade_intent` before opening auth modal in `handleCheckout`
- On `/pricing` mount with an authenticated user, read + clear the stored intent and auto-trigger `handleCheckout`
- All `sessionStorage` access wrapped in try/catch so storage failures are non-critical
- 12 new tests covering intent storage, pickup, cleanup, and no-regression for authenticated users

Closes [AIR-228](/AIR/issues/AIR-228). Part of [AIR-226](/AIR/issues/AIR-226) UX audit.

## Test plan

- [ ] Unauthenticated user clicks "Get Supporter" -- enters email -- clicks magic link -- lands on `/pricing` -- checkout auto-triggers for Supporter tier
- [ ] Same flow works for Champion tier
- [ ] Authenticated user clicking upgrade still goes directly to checkout (no regression)
- [ ] `npm run build` passes clean
- [ ] 12 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)