### PR TITLE
fix(pricing): remove duplicate 90-day history entry from Supporter features

### DIFF
--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -34,7 +34,6 @@ const SUPPORTER_FEATURES = [
   '6-10 deep AI insights per analysis (unlimited)',
   '90-day analysis history with AI re-analysis',
   'Cloud sync across devices',
-  '90-day analysis history',
   'PDF clinician reports',
   'Enhanced export with annotations',
   'Detailed metric explanations',


### PR DESCRIPTION
## Summary

- Removes standalone `'90-day analysis history'` from `SUPPORTER_FEATURES` array in `app/pricing/page.tsx`
- The combined entry `'90-day analysis history with AI re-analysis'` already covers this
- Closes AIR-230 (from UX audit AIR-226, Rec 3)

## Acceptance criteria

- [x] Supporter feature list has no duplicate 90-day history entries
- [x] Remaining entry is `'90-day analysis history with AI re-analysis'`
- [x] No other features removed
- [x] TypeScript passes (`tsc --noEmit` exit 0)
- [x] ESLint clean on changed file
- [x] All 1707 tests pass

## Test plan

- [ ] Navigate to `/pricing` and verify Supporter column shows one 90-day entry
- [ ] Confirm no other features are missing from the Supporter list

🤖 Generated with [Claude Code](https://claude.ai/claude-code)