### PR TITLE
fix: align blog post language with content guidelines (AIR-276)

### DIFF
--- a/app/blog/posts/hidden-respiratory-events.tsx
+++ b/app/blog/posts/hidden-respiratory-events.tsx
@@ -207,9 +207,9 @@ export default function HiddenRespiratoryEventsPost() {
               <div>
                 <p className="text-sm font-semibold text-foreground">Check the H1/H2 pattern</p>
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  If brief obstructions increase in the second half of the night, this is consistent
-                  with REM-related airway laxity. Positional therapy or pressure adjustments targeting
-                  REM may help.
+                  If brief obstructions increase in the second half of the night, this pattern is
+                  consistent with REM-related airway laxity. Discuss these findings with your
+                  clinician.
                 </p>
               </div>
             </div>

--- a/app/blog/posts/ifl-symptom-sensitivity.tsx
+++ b/app/blog/posts/ifl-symptom-sensitivity.tsx
@@ -110,10 +110,9 @@ export default function IFLSymptomSensitivityPost() {
                 <p className="text-sm font-semibold text-amber-400">High IFL + Feeling Bad</p>
               </div>
               <p className="mt-1 text-xs text-muted-foreground">
-                Your flow limitation is elevated and you feel it. This is the most actionable
-                pattern: your FL metrics are correlating with your symptoms, which means reducing
-                flow limitation (through pressure adjustments, positional changes, or other
-                interventions) is likely to improve how you feel. Discuss with your clinician.
+                Your flow limitation metrics are correlating with your reported symptoms. This
+                pattern may be worth discussing with your clinician, who can evaluate these
+                findings in your clinical context.
               </p>
             </div>
             <div className="rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">

--- a/app/blog/posts/why-ahi-is-lying.tsx
+++ b/app/blog/posts/why-ahi-is-lying.tsx
@@ -296,7 +296,7 @@ export default function WhyAHIIsLyingPost() {
                 &quot;I still feel tired&quot; is easy for a clinician to dismiss. A report showing
                 elevated Glasgow scores, high FL percentage, and estimated RERAs despite a low AHI is
                 not. Objective data changes the conversation from &quot;your numbers look fine&quot; to
-                &quot;let&apos;s look at pressure adjustments.&quot;
+                &quot;let&apos;s take a closer look at these flow patterns.&quot;
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Emergency bridge per AIR-286 — pushed by board

This PR is part of the **emergency bridge** authorized by the board on 2026-04-12 in response to AIR-286. The fix has been:

- Implemented by CTO agent in agent workspace
- CTO code-reviewed inside the agent sandbox
- Build-verified (MDR MUST)

The board pushed this branch manually as a one-time bridge while the long-term per-org GitHub bot pattern (ADR-005) is being provisioned for autonomous PR creation. Future PRs from this and other engineering agents will flow through agent-side credentials.

**Source ticket:** AIR-276
**Commit:** `8859f9d`
**Origin workspace:** `/home/paperclip/.paperclip/instances/default/workspaces/067e2f15-fe3d-4324-98c0-67c4bbdd8bbf/` (CTO agent workspace on Hetzner)

Branch protection on `main` requires 1 approving review. Reviewer (Demian) please verify the diff is as expected and merge.
