### PR TITLE
fix: replace effectiveness framing in comparison and blog pages (AIR-277)

### DIFF
--- a/app/blog/posts/oscar-alternative.tsx
+++ b/app/blog/posts/oscar-alternative.tsx
@@ -306,7 +306,7 @@ export default function OSCARAlternativePost() {
               <p className="text-sm font-semibold text-emerald-400">AirwayLab is best if you...</p>
               <ul className="mt-2 space-y-1.5 text-xs text-muted-foreground">
                 <li>Want automated flow limitation analysis</li>
-                <li>Need a quick summary of how your therapy is working</li>
+                <li>Want a quick summary of your breathing patterns and metrics</li>
                 <li>Want metrics that go beyond AHI (Glasgow, NED, RERA)</li>
                 <li>Prefer browser-based tools with no installation</li>
                 <li>Want AI-powered insights about your patterns</li>

--- a/app/compare/oscar/page.tsx
+++ b/app/compare/oscar/page.tsx
@@ -211,8 +211,8 @@ export default function CompareOscarPage() {
               <p className="text-sm font-semibold text-emerald-400">Glasgow Index</p>
               <p className="mt-1 text-xs text-muted-foreground">
                 A 9-component breath shape scoring system that synthesises thousands of breaths into
-                a single actionable score. Track it over time to measure therapy effectiveness
-                objectively.
+                a single actionable score. Track it over time to see how your breathing patterns
+                change across nights.
               </p>
             </div>
             <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">


### PR DESCRIPTION
## Emergency bridge per AIR-286 — pushed by board

This PR is part of the **emergency bridge** authorized by the board on 2026-04-12 in response to AIR-286. The fix has been:

- Implemented by CTO agent in agent workspace
- CTO code-reviewed inside the agent sandbox
- Build-verified (MDR MUST)

The board pushed this branch manually as a one-time bridge while the long-term per-org GitHub bot pattern (ADR-005) is being provisioned for autonomous PR creation. Future PRs from this and other engineering agents will flow through agent-side credentials.

**Source ticket:** AIR-277
**Commit:** `88ea0a7`
**Origin workspace:** `/home/paperclip/.paperclip/instances/default/workspaces/067e2f15-fe3d-4324-98c0-67c4bbdd8bbf/` (CTO agent workspace on Hetzner)

Branch protection on `main` requires 1 approving review. Reviewer (Demian) please verify the diff is as expected and merge.
