### PR TITLE
feat: AIR-263 — implement 3 SEO blog posts for Clusters 2 & 5

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -25,8 +25,14 @@ import WhatIsGlasgowIndexCPAP from '../posts/what-is-glasgow-index-cpap';
 import WhatIsWATScoreCPAP from '../posts/what-is-wat-score-cpap';
 import WhatIsNEDSleepApnea from '../posts/what-is-ned-sleep-apnea';
 import CPAPFlowLimitationScore05Meaning from '../posts/cpap-flow-limitation-score-0-5-meaning';
+import ResMedSDCardBrowserAnalysis from '../posts/resmed-sd-card-browser-analysis';
+import CPAPDataAnalysisBrowserNoDownload from '../posts/cpap-data-analysis-browser-no-download';
+import BiPAPDataAnalysisAirCurve10 from '../posts/bipap-data-analysis-aircurve-10';
 
 const postComponents: Record<string, React.ComponentType> = {
+  'resmed-sd-card-browser-analysis': ResMedSDCardBrowserAnalysis,
+  'cpap-data-analysis-browser-no-download': CPAPDataAnalysisBrowserNoDownload,
+  'bipap-data-analysis-aircurve-10': BiPAPDataAnalysisAirCurve10,
   'v1-2-2-your-data-explained-not-judged': V122YourDataExplained,
   'how-to-read-cpap-data': HowToReadCPAPData,
   'v121-clearer-language': V121ClearerLanguage,

--- a/app/blog/posts/bipap-data-analysis-aircurve-10.tsx
+++ b/app/blog/posts/bipap-data-analysis-aircurve-10.tsx
@@ -54,8 +54,12 @@ export default function BiPAPDataAnalysisAirCurve10Post() {
             <li className="flex gap-2">
               <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
               <span>
-                <strong className="text-foreground">Flow limitation</strong> &mdash; a description
-                of partial upper airway narrowing during inspiration
+                <strong className="text-foreground">
+                  <Link href="/glossary/flow-limitation" className="text-foreground hover:text-primary">
+                    Flow limitation
+                  </Link>
+                </strong>{' '}
+                &mdash; a description of partial upper airway narrowing during inspiration
               </span>
             </li>
             <li className="flex gap-2">
@@ -237,6 +241,27 @@ export default function BiPAPDataAnalysisAirCurve10Post() {
               How to Read Your CPAP Data
             </Link>{' '}
             &mdash; full guide to PAP data metrics.
+          </p>
+        </div>
+        <p className="mb-2 mt-4 text-xs font-semibold text-foreground">Glossary</p>
+        <div className="space-y-1 text-sm text-muted-foreground">
+          <p>
+            <Link href="/glossary/flow-limitation" className="text-primary hover:text-primary/80">
+              Flow limitation
+            </Link>{' '}
+            &mdash; what it means and how AirwayLab measures it.
+          </p>
+          <p>
+            <Link href="/glossary/rera" className="text-primary hover:text-primary/80">
+              RERA
+            </Link>{' '}
+            &mdash; respiratory effort-related arousals explained.
+          </p>
+          <p>
+            <Link href="/glossary/ned-mean" className="text-primary hover:text-primary/80">
+              NED Mean
+            </Link>{' '}
+            &mdash; per-breath negative effort dependence metric.
           </p>
         </div>
       </section>

--- a/app/blog/posts/bipap-data-analysis-aircurve-10.tsx
+++ b/app/blog/posts/bipap-data-analysis-aircurve-10.tsx
@@ -1,0 +1,245 @@
+import Link from 'next/link';
+import { ArrowRight, Activity, FileText, HardDrive, Monitor } from 'lucide-react';
+
+export default function BiPAPDataAnalysisAirCurve10Post() {
+  return (
+    <article>
+      <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
+        Most CPAP analysis guides focus on CPAP and APAP users. If you&apos;re on a BiPAP &mdash;
+        like a ResMed AirCurve 10 ST or VAuto &mdash; you&apos;ve probably noticed that tutorials,
+        forum posts, and tools often don&apos;t quite apply to your device. The data is there on
+        your SD card; it&apos;s just that fewer tools support it.
+      </p>
+      <p className="mt-4 text-base leading-relaxed text-muted-foreground sm:text-lg">
+        AirwayLab supports AirCurve 10 EDF data. Here&apos;s how to use it.
+      </p>
+
+      {/* What data does the AirCurve record */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <HardDrive className="h-5 w-5 text-blue-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            What data does the AirCurve 10 record?
+          </h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            Like ResMed&apos;s CPAP range, the AirCurve 10 family records detailed session data to
+            an SD card in EDF format. That data includes:
+          </p>
+          <ul className="ml-4 space-y-2">
+            <li className="flex gap-2">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
+              <span>
+                <strong className="text-foreground">
+                  Inspiratory and expiratory pressure (IPAP/EPAP)
+                </strong>{' '}
+                &mdash; the two pressure levels your machine delivers
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
+              <span>
+                <strong className="text-foreground">Pressure support</strong> &mdash; the
+                difference between IPAP and EPAP across the session
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
+              <span>
+                <strong className="text-foreground">Flow rate waveform</strong> &mdash; your
+                breathing signal, recorded continuously through the night
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
+              <span>
+                <strong className="text-foreground">Flow limitation</strong> &mdash; a description
+                of partial upper airway narrowing during inspiration
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
+              <span>
+                <strong className="text-foreground">Respiratory events</strong> &mdash; including
+                hypopneas and central events where applicable in your data
+              </span>
+            </li>
+          </ul>
+          <p>
+            Because BiPAP delivers two pressures, the waveform and pressure data look different
+            from a standard CPAP trace &mdash; but the underlying EDF format is the same, and
+            AirwayLab parses it.
+          </p>
+        </div>
+      </section>
+
+      {/* How to load */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Monitor className="h-5 w-5 text-emerald-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">How to load your AirCurve 10 data</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <div className="space-y-3">
+            {[
+              'Power off your AirCurve 10 and remove the SD card.',
+              'Insert the card into your computer using an SD card reader or adapter.',
+              <span key="s3">
+                Go to{' '}
+                <Link href="/analyze" className="text-primary hover:text-primary/80">
+                  airwaylab.app/analyze
+                </Link>
+                .
+              </span>,
+              <span key="s4">
+                Drag and drop your SD card folder &mdash; or individual{' '}
+                <code className="rounded bg-border/40 px-1.5 py-0.5 text-xs font-mono text-foreground">
+                  .edf
+                </code>{' '}
+                files &mdash; into the drop zone.
+              </span>,
+              'AirwayLab processes the files entirely in your browser. Nothing is uploaded.',
+            ].map((step, i) => (
+              <div key={i} className="flex gap-3">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-xs font-bold text-emerald-400">
+                  {i + 1}
+                </span>
+                <span className="pt-0.5">{step}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* What you'll see */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Activity className="h-5 w-5 text-primary" />
+          <h2 className="text-xl font-bold sm:text-2xl">What you&apos;ll see</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>Once loaded, AirwayLab displays:</p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              {
+                label: 'Session overview',
+                desc: 'Date, duration, and a top-line AHI summary.',
+              },
+              {
+                label: 'Pressure support',
+                desc: 'How inspiratory support varied across the night.',
+              },
+              {
+                label: 'Flow limitation',
+                desc: 'Described as a frequency measure across the session.',
+              },
+              {
+                label: 'Flow waveform',
+                desc: 'Your full breathing signal, scrollable night-by-night.',
+              },
+              {
+                label: 'RERA patterns',
+                desc: 'Respiratory effort-related arousals displayed as a visual timeline.',
+              },
+            ].map(({ label, desc }) => (
+              <div key={label} className="rounded-xl border border-border/50 p-4">
+                <p className="text-sm font-semibold text-foreground">{label}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{desc}</p>
+              </div>
+            ))}
+          </div>
+          <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+            <p className="text-sm text-muted-foreground">
+              Everything shown is informational. AirwayLab describes what&apos;s in your EDF data
+              &mdash; it doesn&apos;t interpret whether your BiPAP settings are appropriate for
+              your needs, and it doesn&apos;t make therapeutic recommendations. If you see patterns
+              that concern you, or want to understand what the numbers mean for your therapy,
+              discuss them with your clinician or sleep specialist. They have the clinical context
+              that the data alone can&apos;t provide.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Free, open, in your browser */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <FileText className="h-5 w-5 text-muted-foreground" />
+          <h2 className="text-xl font-bold sm:text-2xl">Free, open, and in your browser</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            AirwayLab is free and always will be. Core analysis runs in your browser with no data
+            leaving your device. The source code is open under GPL-3.0, so you can see exactly how
+            the parsing and analysis work. No account, no subscription, no cloud upload required.
+          </p>
+          <p>
+            If you&apos;ve been looking for a tool that actually reads BiPAP EDF files rather than
+            defaulting to CPAP-only data, give it a try.
+          </p>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="mt-10 rounded-xl border border-primary/20 bg-primary/5 p-6 text-center">
+        <h3 className="text-lg font-bold">Read your AirCurve 10 data free</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Drag in your SD card and see flow limitation, pressure support, and RERA patterns in your
+          browser. No download, no account.
+        </p>
+        <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+          <Link
+            href="/analyze"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-glow transition-colors hover:bg-primary/90"
+          >
+            Analyze Your Data <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </section>
+
+      {/* Disclaimer */}
+      <p className="mt-8 rounded-xl border border-border/30 bg-muted/20 p-4 text-xs text-muted-foreground">
+        <em>
+          AirwayLab is informational only. Nothing displayed constitutes a clinical diagnosis or
+          therapeutic recommendation. Always discuss your therapy data with your clinician for
+          clinical interpretation.
+        </em>
+      </p>
+
+      {/* Related reading */}
+      <section className="mt-8 border-t border-border/30 pt-6">
+        <p className="mb-2 text-xs font-semibold text-foreground">Related reading</p>
+        <div className="space-y-1 text-sm text-muted-foreground">
+          <p>
+            <Link
+              href="/blog/resmed-sd-card-browser-analysis"
+              className="text-primary hover:text-primary/80"
+            >
+              How to Read Your ResMed SD Card Data in Your Browser
+            </Link>{' '}
+            &mdash; step-by-step guide to finding and opening EDF files.
+          </p>
+          <p>
+            <Link
+              href="/blog/cpap-data-analysis-browser-no-download"
+              className="text-primary hover:text-primary/80"
+            >
+              Analyse CPAP Data in Your Browser — No Download, No Cloud, No Account
+            </Link>{' '}
+            &mdash; how AirwayLab protects your privacy.
+          </p>
+          <p>
+            <Link
+              href="/blog/how-to-read-cpap-data"
+              className="text-primary hover:text-primary/80"
+            >
+              How to Read Your CPAP Data
+            </Link>{' '}
+            &mdash; full guide to PAP data metrics.
+          </p>
+        </div>
+      </section>
+    </article>
+  );
+}

--- a/app/blog/posts/cpap-data-analysis-browser-no-download.tsx
+++ b/app/blog/posts/cpap-data-analysis-browser-no-download.tsx
@@ -160,8 +160,19 @@ export default function CPAPDataAnalysisBrowserNoDownloadPost() {
         </div>
         <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
           <p>
-            AirwayLab&apos;s core analysis &mdash; including flow limitation, RERAs, Glasgow Index,
-            and the full flow waveform &mdash; is free and always will be. Premium supports
+            AirwayLab&apos;s core analysis &mdash; including{' '}
+            <Link href="/glossary/flow-limitation" className="text-primary hover:text-primary/80">
+              flow limitation
+            </Link>
+            ,{' '}
+            <Link href="/glossary/rera" className="text-primary hover:text-primary/80">
+              RERAs
+            </Link>
+            ,{' '}
+            <Link href="/glossary/glasgow-index" className="text-primary hover:text-primary/80">
+              Glasgow Index
+            </Link>
+            , and the full flow waveform &mdash; is free and always will be. Premium supports
             continued development and adds some conveniences, but it doesn&apos;t gate the analysis
             that most users are here for.
           </p>
@@ -231,6 +242,33 @@ export default function CPAPDataAnalysisBrowserNoDownloadPost() {
               Beyond AHI
             </Link>{' '}
             &mdash; why AHI alone doesn&apos;t tell the whole story.
+          </p>
+        </div>
+        <p className="mb-2 mt-4 text-xs font-semibold text-foreground">Glossary</p>
+        <div className="space-y-1 text-sm text-muted-foreground">
+          <p>
+            <Link href="/glossary/glasgow-index" className="text-primary hover:text-primary/80">
+              Glasgow Index
+            </Link>{' '}
+            &mdash; the 9-component breath shape scoring system.
+          </p>
+          <p>
+            <Link href="/glossary/fl-score" className="text-primary hover:text-primary/80">
+              FL Score
+            </Link>{' '}
+            &mdash; population-level flow limitation measure from the WAT engine.
+          </p>
+          <p>
+            <Link href="/glossary/ned-mean" className="text-primary hover:text-primary/80">
+              NED Mean
+            </Link>{' '}
+            &mdash; per-breath negative effort dependence metric.
+          </p>
+          <p>
+            <Link href="/glossary/rera" className="text-primary hover:text-primary/80">
+              RERA
+            </Link>{' '}
+            &mdash; respiratory effort-related arousals explained.
           </p>
         </div>
       </section>

--- a/app/blog/posts/cpap-data-analysis-browser-no-download.tsx
+++ b/app/blog/posts/cpap-data-analysis-browser-no-download.tsx
@@ -1,0 +1,239 @@
+import Link from 'next/link';
+import { ArrowRight, BarChart3, Lock, Shield, Cpu, BookOpen } from 'lucide-react';
+
+export default function CPAPDataAnalysisBrowserNoDownloadPost() {
+  return (
+    <article>
+      <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
+        If you&apos;ve tried to analyse your CPAP data, you&apos;ve probably run into the same
+        friction: most tools ask you to either install desktop software or upload your health data
+        to a cloud service. Installation means setup, dependencies, and a machine you can reliably
+        use for it. Cloud upload means your breathing data leaving your device &mdash; which, for a
+        lot of people, isn&apos;t something they want.
+      </p>
+      <p className="mt-4 text-base leading-relaxed text-muted-foreground sm:text-lg">
+        AirwayLab does neither.
+      </p>
+
+      {/* How it works */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Cpu className="h-5 w-5 text-blue-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">How it works</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            AirwayLab runs entirely in your browser. When you drag in your SD card files, the
+            analysis happens locally using Web Workers &mdash; background threads that process your
+            EDF data without touching a server. Your breathing data stays on your device throughout
+            the session. When you close the tab, nothing persists anywhere except your own machine.
+          </p>
+          <p>
+            There&apos;s no account to create. No email address required. Open the page, load your
+            files, see your data.
+          </p>
+        </div>
+      </section>
+
+      {/* What it analyses */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <BarChart3 className="h-5 w-5 text-emerald-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">What it analyses</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            AirwayLab reads the detailed EDF files that ResMed CPAP, APAP, and BiPAP machines
+            record to their SD cards. From those files, it displays:
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              {
+                label: 'AHI',
+                desc: 'Apnea-hypopnea index, broken down by event type.',
+                color: 'blue',
+              },
+              {
+                label: 'Flow limitation',
+                desc: 'A description of partial upper airway narrowing, which may appear in nights with a low AHI.',
+                color: 'blue',
+              },
+              {
+                label: 'RERAs',
+                desc: 'Respiratory effort-related arousals, shown as a timeline alongside the flow waveform.',
+                color: 'emerald',
+              },
+              {
+                label: 'Glasgow Index',
+                desc: 'A composite score summarising breathing quality across the session.',
+                color: 'emerald',
+              },
+              {
+                label: 'Full flow waveform',
+                desc: 'The raw breathing signal from the EDF file, scrollable and zoomable.',
+                color: 'primary',
+              },
+            ].map(({ label, desc }) => (
+              <div key={label} className="rounded-xl border border-border/50 p-4">
+                <p className="text-sm font-semibold text-foreground">{label}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{desc}</p>
+              </div>
+            ))}
+          </div>
+          <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+            <p className="text-sm text-muted-foreground">
+              All of this is informational. AirwayLab describes what&apos;s in your data. It
+              doesn&apos;t interpret what the numbers mean for your therapy, and it doesn&apos;t
+              suggest changes. Bring a screenshot of what you see to your next appointment and
+              discuss it with your clinician &mdash; they have the clinical context to make sense
+              of it.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* OSCAR comparison */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <BookOpen className="h-5 w-5 text-amber-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">How AirwayLab relates to OSCAR</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            If you&apos;re already using{' '}
+            <a
+              href="https://www.sleepfiles.com/OSCAR/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:text-primary/80"
+            >
+              OSCAR
+            </a>{' '}
+            for detailed analysis, you don&apos;t need to stop. OSCAR is excellent, well-maintained,
+            and handles desktop workflows very well. AirwayLab is useful for a different scenario:
+            when you want a quick look at your data in a browser without a full install, when
+            you&apos;re on a second machine, or when you&apos;d rather not add another application
+            to your system. They&apos;re complementary &mdash; same data, different surfaces.
+          </p>
+          <p>
+            Read the full comparison:{' '}
+            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+              AirwayLab vs OSCAR: How They Complement Each Other
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+
+      {/* Privacy */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Lock className="h-5 w-5 text-emerald-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">Privacy you can verify</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            The core analysis in AirwayLab is designed to run with zero data transmission. No
+            waveform data, no event data, no session metadata is sent to any server. The source
+            code is on GitHub under GPL-3.0 &mdash; which means you can read exactly how it works
+            and verify that claim yourself. You don&apos;t have to take our word for it.
+          </p>
+          <p>
+            The optional AI insights feature &mdash; if you choose to enable it &mdash; requires
+            explicit, informed consent before any data is sent. It&apos;s entirely opt-in.
+          </p>
+          <p>
+            Learn more about{' '}
+            <Link href="/blog/pap-data-privacy" className="text-primary hover:text-primary/80">
+              PAP data privacy and your rights
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+
+      {/* Free tier */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Shield className="h-5 w-5 text-primary" />
+          <h2 className="text-xl font-bold sm:text-2xl">The free tier is complete</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            AirwayLab&apos;s core analysis &mdash; including flow limitation, RERAs, Glasgow Index,
+            and the full flow waveform &mdash; is free and always will be. Premium supports
+            continued development and adds some conveniences, but it doesn&apos;t gate the analysis
+            that most users are here for.
+          </p>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="mt-10 rounded-xl border border-primary/20 bg-primary/5 p-6 text-center">
+        <h3 className="text-lg font-bold">Try it — nothing to install</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Drag in your SD card files. No account, no cloud upload, no download required.
+        </p>
+        <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+          <Link
+            href="/analyze"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-glow transition-colors hover:bg-primary/90"
+          >
+            Analyze Your Data <ArrowRight className="h-4 w-4" />
+          </Link>
+          <a
+            href="https://github.com/airwaylab/airwaylab"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            View Source on GitHub
+          </a>
+        </div>
+      </section>
+
+      {/* Disclaimer */}
+      <p className="mt-8 rounded-xl border border-border/30 bg-muted/20 p-4 text-xs text-muted-foreground">
+        <em>
+          AirwayLab is informational only. Nothing displayed constitutes a clinical diagnosis or
+          therapeutic recommendation. Always discuss your therapy data with your clinician for
+          clinical interpretation.
+        </em>
+      </p>
+
+      {/* Related reading */}
+      <section className="mt-8 border-t border-border/30 pt-6">
+        <p className="mb-2 text-xs font-semibold text-foreground">Related reading</p>
+        <div className="space-y-1 text-sm text-muted-foreground">
+          <p>
+            <Link
+              href="/blog/resmed-sd-card-browser-analysis"
+              className="text-primary hover:text-primary/80"
+            >
+              How to Read Your ResMed SD Card Data in Your Browser
+            </Link>{' '}
+            &mdash; step-by-step guide to finding and opening EDF files.
+          </p>
+          <p>
+            <Link
+              href="/blog/bipap-data-analysis-aircurve-10"
+              className="text-primary hover:text-primary/80"
+            >
+              BiPAP Data Analysis: How to Read Your AirCurve 10 Data for Free
+            </Link>{' '}
+            &mdash; AirCurve 10 ST and VAuto support.
+          </p>
+          <p>
+            <Link
+              href="/blog/beyond-ahi"
+              className="text-primary hover:text-primary/80"
+            >
+              Beyond AHI
+            </Link>{' '}
+            &mdash; why AHI alone doesn&apos;t tell the whole story.
+          </p>
+        </div>
+      </section>
+    </article>
+  );
+}

--- a/app/blog/posts/resmed-sd-card-browser-analysis.tsx
+++ b/app/blog/posts/resmed-sd-card-browser-analysis.tsx
@@ -1,0 +1,273 @@
+import Link from 'next/link';
+import { ArrowRight, FileText, FolderOpen, HardDrive, Monitor, Cpu } from 'lucide-react';
+
+export default function ResMedSDCardBrowserAnalysisPost() {
+  return (
+    <article>
+      <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
+        Most ResMed CPAP and APAP machines keep a detailed record of every night&apos;s therapy on
+        a small SD card. That card holds EDF (European Data Format) files &mdash; binary logs of
+        your breathing patterns, pressure levels, and respiratory events. Until recently, reading
+        those files meant installing desktop software. With AirwayLab, you can open them directly
+        in your browser, with nothing to install.
+      </p>
+
+      {/* What's on the SD card */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <HardDrive className="h-5 w-5 text-blue-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">What&apos;s on your ResMed SD card?</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>Your ResMed machine stores two types of data on its SD card:</p>
+          <ul className="ml-4 space-y-2">
+            <li className="flex gap-2">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
+              <span>
+                <strong className="text-foreground">Summary data</strong> &mdash; nightly AHI,
+                mask leak, and usage hours, similar to what the device screen shows
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-400" />
+              <span>
+                <strong className="text-foreground">Detailed EDF files</strong> &mdash; continuous
+                waveforms of your breathing patterns, flow rate, pressure, and respiratory events
+                recorded at higher resolution throughout the night
+              </span>
+            </li>
+          </ul>
+          <p>
+            The EDF files are where the detail lives. They contain the flow signal that makes it
+            possible to look at things like flow limitation and RERA patterns &mdash; aspects of
+            your breathing that a headline AHI score doesn&apos;t capture.
+          </p>
+        </div>
+      </section>
+
+      {/* Finding your files */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <FolderOpen className="h-5 w-5 text-amber-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">Finding your files</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <div className="space-y-3">
+            {[
+              'Power off your ResMed machine.',
+              'Remove the SD card from the slot on the side or back of the device.',
+              'Insert it into your computer using an SD card reader or adapter.',
+              <span key="step4">
+                Open the card. You&apos;ll find a folder structure like{' '}
+                <code className="rounded bg-border/40 px-1.5 py-0.5 text-xs font-mono text-foreground">
+                  DATALOG/
+                </code>{' '}
+                containing{' '}
+                <code className="rounded bg-border/40 px-1.5 py-0.5 text-xs font-mono text-foreground">
+                  .edf
+                </code>{' '}
+                files organised by year and month.
+              </span>,
+              "You don't need to move, rename, or modify anything.",
+            ].map((step, i) => (
+              <div key={i} className="flex gap-3">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-amber-500/10 text-xs font-bold text-amber-400">
+                  {i + 1}
+                </span>
+                <span className="pt-0.5">{step}</span>
+              </div>
+            ))}
+          </div>
+          <p>
+            Most ResMed AirSense 10 and AirSense 11 machines use this same folder structure. If
+            you&apos;re not sure whether your device records detailed data, check that the SD card
+            slot is present and the card has been in the machine during recent sessions.
+          </p>
+        </div>
+      </section>
+
+      {/* Opening in AirwayLab */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Monitor className="h-5 w-5 text-emerald-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">Opening your data in AirwayLab</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <div className="space-y-3">
+            {[
+              <span key="s1">
+                Go to{' '}
+                <Link href="/analyze" className="text-primary hover:text-primary/80">
+                  airwaylab.app/analyze
+                </Link>
+                .
+              </span>,
+              <span key="s2">
+                Drag and drop your SD card folder &mdash; or individual{' '}
+                <code className="rounded bg-border/40 px-1.5 py-0.5 text-xs font-mono text-foreground">
+                  .edf
+                </code>{' '}
+                files &mdash; into the drop zone. You can also click to browse.
+              </span>,
+              'AirwayLab processes the files entirely in your browser using Web Workers. Nothing is uploaded — your data never leaves your device.',
+              'Within a few seconds, your sessions appear.',
+            ].map((step, i) => (
+              <div key={i} className="flex gap-3">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-xs font-bold text-emerald-400">
+                  {i + 1}
+                </span>
+                <span className="pt-0.5">{step}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* What you'll see */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <FileText className="h-5 w-5 text-primary" />
+          <h2 className="text-xl font-bold sm:text-2xl">What you&apos;ll see</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>Once your data is loaded, AirwayLab displays:</p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              {
+                label: 'Session list',
+                desc: 'Each night as a separate entry with date, total duration, and AHI.',
+              },
+              {
+                label: 'AHI summary',
+                desc: 'Broken down by obstructive, central, and hypopnea counts per hour.',
+              },
+              {
+                label: 'Flow limitation index',
+                desc: 'Describes the frequency of partial upper airway narrowing across the night.',
+              },
+              {
+                label: 'RERA timeline',
+                desc: 'Respiratory effort-related arousals displayed as a visual pattern alongside the flow waveform.',
+              },
+              {
+                label: 'Breathing waveform',
+                desc: 'The full flow signal from your EDF file, scrollable night-by-night.',
+              },
+            ].map(({ label, desc }) => (
+              <div key={label} className="rounded-xl border border-border/50 p-4">
+                <p className="text-sm font-semibold text-foreground">{label}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{desc}</p>
+              </div>
+            ))}
+          </div>
+          <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+            <p className="text-sm text-muted-foreground">
+              AirwayLab shows you what&apos;s in your data. It doesn&apos;t tell you what your
+              numbers mean clinically, and it doesn&apos;t make recommendations about your therapy.
+              For clinical interpretation of what you see, discuss it with your clinician or sleep
+              specialist.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Why people use it */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Cpu className="h-5 w-5 text-muted-foreground" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            Why people use it alongside existing tools
+          </h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            Tools like OSCAR have long been the go-to for detailed CPAP data analysis on the
+            desktop, and rightly so. AirwayLab is useful for a different case: when you want a
+            quick browser-based look without setting up a full desktop environment, when you&apos;re
+            on a machine where you can&apos;t install software, or when you want to share a link to
+            your session data easily. There&apos;s no competition here &mdash; they complement each
+            other.
+          </p>
+          <p>
+            Read more in{' '}
+            <Link
+              href="/blog/oscar-alternative"
+              className="text-primary hover:text-primary/80"
+            >
+              AirwayLab vs OSCAR: How They Complement Each Other
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="mt-10 rounded-xl border border-primary/20 bg-primary/5 p-6 text-center">
+        <h3 className="text-lg font-bold">Read your ResMed data now</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Drag in your SD card files and see your AHI, flow limitation, and RERA data in seconds.
+          No download. No account. 100% private.
+        </p>
+        <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+          <Link
+            href="/analyze"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-glow transition-colors hover:bg-primary/90"
+          >
+            Analyze Your Data <ArrowRight className="h-4 w-4" />
+          </Link>
+          <a
+            href="https://github.com/airwaylab/airwaylab"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            View Source on GitHub
+          </a>
+        </div>
+      </section>
+
+      {/* Disclaimer */}
+      <p className="mt-8 rounded-xl border border-border/30 bg-muted/20 p-4 text-xs text-muted-foreground">
+        <em>
+          AirwayLab is informational only. Nothing displayed constitutes a clinical diagnosis or
+          therapeutic recommendation. Always discuss your therapy data with your clinician for
+          clinical interpretation.
+        </em>
+      </p>
+
+      {/* Related reading */}
+      <section className="mt-8 border-t border-border/30 pt-6">
+        <p className="mb-2 text-xs font-semibold text-foreground">Related reading</p>
+        <div className="space-y-1 text-sm text-muted-foreground">
+          <p>
+            <Link
+              href="/blog/how-to-read-cpap-data"
+              className="text-primary hover:text-primary/80"
+            >
+              How to Read Your CPAP Data
+            </Link>{' '}
+            &mdash; a full guide to CPAP metrics beyond AHI.
+          </p>
+          <p>
+            <Link
+              href="/blog/oscar-alternative"
+              className="text-primary hover:text-primary/80"
+            >
+              AirwayLab vs OSCAR
+            </Link>{' '}
+            &mdash; how AirwayLab and OSCAR complement each other.
+          </p>
+          <p>
+            <Link
+              href="/blog/cpap-data-analysis-browser-no-download"
+              className="text-primary hover:text-primary/80"
+            >
+              Analyse CPAP Data in Your Browser
+            </Link>{' '}
+            &mdash; no download, no cloud, no account.
+          </p>
+        </div>
+      </section>
+    </article>
+  );
+}

--- a/app/blog/posts/resmed-sd-card-browser-analysis.tsx
+++ b/app/blog/posts/resmed-sd-card-browser-analysis.tsx
@@ -39,8 +39,15 @@ export default function ResMedSDCardBrowserAnalysisPost() {
           </ul>
           <p>
             The EDF files are where the detail lives. They contain the flow signal that makes it
-            possible to look at things like flow limitation and RERA patterns &mdash; aspects of
-            your breathing that a headline AHI score doesn&apos;t capture.
+            possible to look at things like{' '}
+            <Link href="/glossary/flow-limitation" className="text-primary hover:text-primary/80">
+              flow limitation
+            </Link>{' '}
+            and{' '}
+            <Link href="/glossary/rera" className="text-primary hover:text-primary/80">
+              RERA patterns
+            </Link>{' '}
+            &mdash; aspects of your breathing that a headline AHI score doesn&apos;t capture.
           </p>
         </div>
       </section>
@@ -265,6 +272,27 @@ export default function ResMedSDCardBrowserAnalysisPost() {
               Analyse CPAP Data in Your Browser
             </Link>{' '}
             &mdash; no download, no cloud, no account.
+          </p>
+        </div>
+        <p className="mb-2 mt-4 text-xs font-semibold text-foreground">Glossary</p>
+        <div className="space-y-1 text-sm text-muted-foreground">
+          <p>
+            <Link href="/glossary/flow-limitation" className="text-primary hover:text-primary/80">
+              Flow limitation
+            </Link>{' '}
+            &mdash; what it means and how AirwayLab measures it.
+          </p>
+          <p>
+            <Link href="/glossary/rera" className="text-primary hover:text-primary/80">
+              RERA (Respiratory Effort-Related Arousal)
+            </Link>{' '}
+            &mdash; how RERAs differ from apneas and why they matter.
+          </p>
+          <p>
+            <Link href="/glossary/glasgow-index" className="text-primary hover:text-primary/80">
+              Glasgow Index
+            </Link>{' '}
+            &mdash; the 9-component breath shape scoring system.
           </p>
         </div>
       </section>

--- a/lib/blog-posts.ts
+++ b/lib/blog-posts.ts
@@ -17,6 +17,88 @@ export interface BlogPost {
 
 export const blogPosts: BlogPost[] = [
   {
+    slug: 'resmed-sd-card-browser-analysis',
+    title: 'How to Read Your ResMed SD Card Data in Your Browser — No Download Needed',
+    seoTitle: 'How to Read Your ResMed SD Card Data in Your Browser — No Download Needed',
+    description:
+      'Your ResMed SD card holds detailed EDF files with your full breathing waveform. Open them directly in your browser with AirwayLab — no software to install, no data uploaded.',
+    date: '2026-04-09',
+    readTime: '5 min read',
+    tags: ['ResMed', 'SD Card', 'EDF', 'Getting Started', 'CPAP'],
+    ogDescription:
+      'Read your ResMed SD card EDF files directly in your browser with AirwayLab. No download, no cloud upload. See your AHI, flow limitation, and RERA data instantly.',
+    faqItems: [
+      {
+        question: 'Can I read my ResMed SD card data without installing software?',
+        answer:
+          'Yes. AirwayLab runs entirely in your browser. Drag your SD card files into the drop zone and your sessions load instantly — no software installation required.',
+      },
+      {
+        question: 'What EDF files does my ResMed machine record?',
+        answer:
+          'ResMed AirSense 10 and AirSense 11 machines record detailed EDF files in the DATALOG/ folder on your SD card, organised by year and month. These files contain your full flow waveform, pressure data, and respiratory events.',
+      },
+      {
+        question: 'Is my data uploaded when I use AirwayLab?',
+        answer:
+          'No. AirwayLab processes all EDF files locally in your browser using Web Workers. Your breathing data never leaves your device.',
+      },
+    ],
+  },
+  {
+    slug: 'cpap-data-analysis-browser-no-download',
+    title: 'Analyse CPAP Data in Your Browser — No Download, No Cloud, No Account',
+    seoTitle: 'Analyse CPAP Data in Your Browser — No Download, No Cloud, No Account',
+    description:
+      'AirwayLab analyses your CPAP data entirely in your browser. No software to install, no cloud upload, no account needed. See AHI, flow limitation, RERAs, and the Glasgow Index free.',
+    date: '2026-04-09',
+    readTime: '5 min read',
+    tags: ['CPAP', 'Privacy', 'OSCAR', 'Getting Started', 'Browser'],
+    ogDescription:
+      'Analyse your CPAP data without installing anything. AirwayLab runs entirely in your browser — no cloud upload, no account. See AHI, flow limitation, and RERAs free.',
+    faqItems: [
+      {
+        question: 'Do I need to install anything to use AirwayLab?',
+        answer:
+          'No. AirwayLab is a web application. Open airwaylab.app/analyze in your browser, drag in your SD card files, and your data loads immediately.',
+      },
+      {
+        question: 'Is AirwayLab an OSCAR alternative?',
+        answer:
+          'AirwayLab and OSCAR complement each other rather than compete. OSCAR is a desktop app with detailed waveform browsing; AirwayLab runs in your browser and adds automated metrics like flow limitation scoring, Glasgow Index, and RERA detection that OSCAR does not compute.',
+      },
+      {
+        question: 'Does AirwayLab upload my CPAP data?',
+        answer:
+          'No. All analysis runs locally in your browser. The optional AI insights feature is fully opt-in and requires explicit consent before any data is sent.',
+      },
+    ],
+  },
+  {
+    slug: 'bipap-data-analysis-aircurve-10',
+    title: 'BiPAP Data Analysis: How to Read Your AirCurve 10 Data for Free',
+    seoTitle: 'BiPAP Data Analysis: How to Read Your AirCurve 10 Data for Free',
+    description:
+      'AirwayLab reads ResMed AirCurve 10 ST and VAuto EDF files in your browser. See IPAP/EPAP pressure support, flow limitation, and breathing patterns — free, no download.',
+    date: '2026-04-09',
+    readTime: '4 min read',
+    tags: ['BiPAP', 'AirCurve 10', 'ResMed', 'EDF', 'Getting Started'],
+    ogDescription:
+      'Analyse your ResMed AirCurve 10 BiPAP data free in your browser. AirwayLab reads ST and VAuto EDF files — see flow limitation and breathing patterns. No download.',
+    faqItems: [
+      {
+        question: 'Does AirwayLab support BiPAP data?',
+        answer:
+          'Yes. AirwayLab reads EDF files from ResMed AirCurve 10 ST and VAuto machines, showing IPAP/EPAP pressure support, flow limitation, and breathing patterns.',
+      },
+      {
+        question: 'What is the difference between CPAP and BiPAP EDF data?',
+        answer:
+          'BiPAP machines deliver two pressures (IPAP and EPAP). The EDF format is the same as CPAP, but the waveform includes pressure support data alongside the flow signal. AirwayLab parses both correctly.',
+      },
+    ],
+  },
+  {
     slug: 'v1-2-2-your-data-explained-not-judged',
     title: 'v1.2.2: Your Data, Explained -- Not Judged',
     description:


### PR DESCRIPTION
## Summary

Implements 3 SEO blog posts from Content Writer drafts (AIR-260) targeting Clusters 2 & 5:

- `/blog/resmed-sd-card-browser-analysis` — How to Read Your ResMed SD Card Data in Your Browser — No Download Needed
- `/blog/cpap-data-analysis-browser-no-download` — Analyse CPAP Data in Your Browser — No Download, No Cloud, No Account
- `/blog/bipap-data-analysis-aircurve-10` — BiPAP Data Analysis: How to Read Your AirCurve 10 Data for Free

## Changes

- 3 new `.tsx` blog post components in `app/blog/posts/`
- 3 entries in `lib/blog-posts.ts` with `seoTitle`, `ogDescription`, and `faqItems` (FAQ JSON-LD schema)
- Imports + `postComponents` map in `app/blog/[slug]/page.tsx`
- Internal glossary links: `/glossary/flow-limitation`, `/glossary/rera`, `/glossary/glasgow-index`, `/glossary/fl-score`, `/glossary/ned-mean` (per AIR-261 SEO notes)
- MDR disclaimer verbatim at end of each post
- CTAs link to `/analyze`
- Cross-links between all 3 new posts and existing blog content

## Checks

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] 1721 tests passed
- [x] `npm run build` clean

Closes AIR-263.