### PR TITLE
fix: remove 4 MUST MDR violations in insights and metric explanations

### DIFF
--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -81,7 +81,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
       id: 'ifl-risk-high',
       type: 'warning',
       title: 'Elevated flow limitation across multiple metrics',
-      body: `Your IFL Symptom Risk of ${fmt(iflRisk)}% shows elevated scores across multiple flow limitation metrics. Research shows this level of FL correlates with fatigue independently of arousals, though individual sensitivity varies. Discuss these findings with your clinician at your next review.`,
+      body: `Your IFL Symptom Risk of ${fmt(iflRisk)}% shows elevated scores across multiple flow limitation metrics. Your clinician can help interpret these findings in context.`,
       category: 'ned',
       link: { text: 'Read: Does Flow Limitation Drive Sleepiness?', href: '/blog/flow-limitation-and-sleepiness' },
     });
@@ -350,7 +350,7 @@ function singleNightInsights(n: NightResult, prev: NightResult | null, symptomRa
         id: 'symptom-fl-correlation',
         type: 'warning',
         title: 'Elevated flow limitation correlates with symptom rating',
-        body: `Your IFL Symptom Risk of ${fmt(iflRisk)}% is elevated and you rated this night as ${ratingLabel}. This pattern shows elevated flow limitation correlating with your reported experience. Discuss these findings with your clinician.`,
+        body: `Your IFL Symptom Risk of ${fmt(iflRisk)}% is elevated and you rated this night as ${ratingLabel}. Your flow limitation scores are elevated alongside your subjective rating of this night. Your clinician can help interpret these findings in context.`,
         category: 'ned',
       });
     } else if (iflRisk > 45 && symptomRating >= 4) {
@@ -684,7 +684,7 @@ function trendInsights(
       id: 'trend-glasgow-improving',
       type: 'positive',
       title: 'Glasgow Index trending down over time',
-      body: `Flow limitation scores are improving across ${nights.length} nights (${fmt(glasgowVals[0]!)} → ${fmt(glasgowVals[glasgowVals.length - 1]!)}).`,
+      body: `Flow limitation scores are trending lower across ${nights.length} nights (${fmt(glasgowVals[0]!)} → ${fmt(glasgowVals[glasgowVals.length - 1]!)}).`,
       category: 'trend',
     });
   } else if (gTrend === 'worsening') {

--- a/lib/metric-explanations.ts
+++ b/lib/metric-explanations.ts
@@ -158,7 +158,7 @@ export function getIFLRiskExplanation(value: number, threshold: ThresholdDef): s
     return 'Your IFL composite score is in the lower range.';
   }
   if (light === 'warn') {
-    return 'Moderate flow limitation detected across multiple metrics. Individual sensitivity varies \u2014 this level of FL may be contributing to symptoms in some people. Discuss these findings with your clinician.';
+    return 'Moderate flow limitation detected across multiple metrics. Individual sensitivity to this level of flow limitation varies. Your clinician can help interpret these findings in context.';
   }
   return 'Multiple flow limitation metrics are elevated. Individual experiences vary. Discuss with your clinician if you have concerns.';
 }


### PR DESCRIPTION
## Summary

- Removes predictive claim (research citation applying population findings to user data) in `lib/insights.ts:84`
- Removes diagnostic correlation (causal language linking algorithm output to symptoms) in `lib/insights.ts:353`
- Removes effectiveness judgment ("improving" → "trending lower") in `lib/insights.ts:687`
- Removes diagnostic causality ("may be contributing to symptoms") in `lib/metric-explanations.ts:161`
- Standardizes disclaimer to passive "Your clinician can help interpret these findings in context"

## MDR Compliance Checklist

- [x] No therapeutic recommendations
- [x] No diagnostic claims
- [x] No predictive claims
- [x] No clinical effectiveness judgments
- [x] AI system prompts describe data only
- [x] Disclaimer language updated to passive form

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 1740/1740 pass
- [x] `npm run build` — passes
- [ ] Verify insight text on Vercel preview with FL-heavy data

Fixes: AIR-296
Parent: AIR-295

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>