### PR TITLE
fix: remove MDR predictive claim from blog OG description

### DIFF
--- a/lib/blog-posts.ts
+++ b/lib/blog-posts.ts
@@ -282,7 +282,7 @@ export const blogPosts: BlogPost[] = [
     readTime: '9 min read',
     tags: ['Flow Limitation', 'Research', 'UARS', 'Sleepiness'],
     ogDescription:
-      'Research shows inspiratory flow limitation predicts sleepiness independent of arousals and AHI. Learn what this means for tracking your PAP therapy.',
+      'Research into inspiratory flow limitation and its relationship to sleepiness. Learn what this means for tracking your PAP data.',
   },
   {
     slug: 'arousals-vs-flow-limitation',


### PR DESCRIPTION
## Summary

- Removes predictive claim ("predicts sleepiness") from the `flow-limitation-and-sleepiness` blog post OG meta description
- Replaces "PAP therapy" with "PAP data" to avoid clinical treatment context
- MDR Rule 3 (Predictive Claim) violation fix from audit AIR-295

## Changes

- `lib/blog-posts.ts:285` — OG description rewritten to neutral language

## MDR Compliance Checklist

- [x] No therapeutic recommendations
- [x] No diagnostic claims
- [x] No predictive claims ("predicts" removed)
- [x] No clinical effectiveness judgments
- [x] No use of "therapy" in meta description

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 1740 tests pass
- [x] `npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)