### PR TITLE
fix: rewrite data-highlights stems to use descriptive language (AIR-344)

### DIFF
--- a/__tests__/data-highlights.test.ts
+++ b/__tests__/data-highlights.test.ts
@@ -405,12 +405,14 @@ describe('generateDataHighlights', () => {
     const trendHighlights = generateDataHighlights(nights, nights[0]!, nights[1]!, null);
     const allHighlights = [...singleHighlights, ...trendHighlights];
 
-    const forbiddenKeywords = ['adjust', 'settings', 'therapy', 'could', 'should', 'help me', 'review whether'];
+    const forbiddenKeywords = ['adjust', 'settings', 'therapy', 'could', 'should', 'help me', 'review whether', 'suggesting', 'fragmentation'];
 
     for (const h of allHighlights) {
       const stemLower = h.stem.toLowerCase();
+      const rationaleLower = h.rationale.toLowerCase();
       for (const keyword of forbiddenKeywords) {
         expect(stemLower).not.toContain(keyword);
+        expect(rationaleLower).not.toContain(keyword);
       }
     }
   });

--- a/lib/data-highlights.ts
+++ b/lib/data-highlights.ts
@@ -114,11 +114,10 @@ const SINGLE_NIGHT_RULES: HighlightRule[] = [
     evaluate: (n, th) => {
       const light = getTrafficLight(n.ned.reraIndex, th.reraIndex!);
       if (light === 'good') return null;
-      const severity = n.ned.reraIndex > 10 ? 'frequent' : 'moderate';
       return {
         id: 'rera-index',
-        stem: 'Your estimated RERA Index indicates respiratory effort-related arousals beyond what AHI captures.',
-        rationale: `Your estimated RERA Index of ${fmt(n.ned.reraIndex)}/hr indicates ${severity} sleep disruptions beyond what AHI captures.`,
+        stem: 'Your estimated RERA Index is above the typical range.',
+        rationale: `Your estimated RERA Index of ${fmt(n.ned.reraIndex)}/hr is above the typical range for this metric.`,
         category: 'arousals',
         urgency: light,
       };
@@ -133,7 +132,7 @@ const SINGLE_NIGHT_RULES: HighlightRule[] = [
       if (light === 'good') return null;
       return {
         id: 'eai',
-        stem: 'Your Estimated Arousal Index is elevated, suggesting sleep fragmentation.',
+        stem: 'Your Estimated Arousal Index is above the typical range.',
         rationale: `Your Estimated Arousal Index of ${fmt(eai)}/hr is above the typical range for this metric.`,
         category: 'arousals',
         urgency: light,
@@ -183,7 +182,7 @@ const SINGLE_NIGHT_RULES: HighlightRule[] = [
       if (light === 'good') return null;
       return {
         id: 'odi3',
-        stem: 'Your ODI-3 indicates frequent oxygen desaturations during sleep.',
+        stem: 'Your ODI-3 is above the typical range.',
         rationale: `Your ODI-3 of ${fmt(n.oximetry.odi3)}/hr means your oxygen dropped by 3%+ approximately ${Math.round(n.oximetry.odi3)} times per hour.`,
         category: 'oximetry',
         urgency: light,


### PR DESCRIPTION
## Summary

- Rewrites 4 MUST-violation diagnostic phrases in `lib/data-highlights.ts` to observational language per MDR Rule 11
- Expands MDR guard tests to scan **rationale** strings (not just stems) and adds `"suggesting"` / `"fragmentation"` to forbidden keywords

## MUST Fixes

| # | Rule | Before | After |
|---|------|--------|-------|
| 1 | `eai` stem | "suggesting sleep fragmentation" | "is above the typical range" |
| 2 | `rera-index` stem | "indicates respiratory effort-related arousals beyond what AHI captures" | "is above the typical range" |
| 3 | `odi3` stem | "indicates frequent oxygen desaturations during sleep" | "is above the typical range" |
| 4 | `rera-index` rationale | "indicates ${severity} sleep disruptions beyond what AHI captures" | "is above the typical range for this metric" |

## SHOULD Fixes

- MDR guard test now checks **rationale** strings in addition to stems
- Added `"suggesting"` and `"fragmentation"` to forbidden keyword list

## Verification

- `npx tsc --noEmit` ✓
- `npm run lint` ✓
- `npm test` ✓ (1721 tests, including updated MDR guards)
- `npm run build` ✓

## MDR Compliance Checklist

- [x] No therapeutic recommendations
- [x] No diagnostic claims
- [x] No predictive claims
- [x] No clinical effectiveness judgments
- [x] Point-of-use disclaimers present
- [x] Expanded guard tests cover rationale strings

Addresses AIR-344 — P0 compliance blocker for PR #522.