### PR TITLE
fix(e2e): correct 2 test failures blocking merge queue

### DIFF
--- a/e2e/conversion-funnel.spec.ts
+++ b/e2e/conversion-funnel.spec.ts
@@ -373,8 +373,9 @@ test.describe('Conversion Funnel — Pricing Page', () => {
     // Click first "Sign in to get started" button (Supporter)
     await page.getByText('Sign in to get started').first().click();
 
-    const modal = page.getByRole('dialog').filter({ hasText: /sign in to airwaylab/i });
-    await expect(modal).toBeVisible({ timeout: 3_000 });
+    // Pricing context shows "Sign in to complete your upgrade" (auth-modal.tsx:128)
+    const modal = page.getByRole('dialog').filter({ hasText: /sign in to complete your upgrade/i });
+    await expect(modal).toBeVisible({ timeout: 5_000 });
   });
 });
 

--- a/e2e/landing-page.spec.ts
+++ b/e2e/landing-page.spec.ts
@@ -56,8 +56,9 @@ test.describe('Landing Page', () => {
   });
 
   test('header navigation links work', async ({ page }) => {
-    await page.locator('nav a[href="/analyze"]').first().click({ force: true });
-    await expect(page).toHaveURL('/analyze');
+    await page.waitForLoadState('networkidle');
+    await page.locator('nav a[href="/analyze"]').first().click();
+    await expect(page).toHaveURL('/analyze', { timeout: 10_000 });
   });
 
   test('privacy shield message is visible', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Fix conversion-funnel.spec.ts:376 — auth modal text mismatch ("Sign in to AirwayLab" vs actual "Sign in to complete your upgrade")
- Fix landing-page.spec.ts:58 — nav click race condition (removed force:true, added waitForLoadState)

From [AIR-349](https://github.com/airwaylab-app/airwaylab/issues/349). 10 lines changed.

## Test plan

- [ ] E2E tests pass (both fixed assertions)
- [ ] No other test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)