### PR TITLE
feat: add CPAP tips 5-email drip sequence (AIR-367)

### DIFF
--- a/__tests__/email-templates.test.ts
+++ b/__tests__/email-templates.test.ts
@@ -15,6 +15,7 @@ import {
   SEQUENCES,
   type SequenceName,
 } from '@/lib/email/templates';
+import { WELCOME_SEQUENCE_DAYS } from '@/lib/email/sequences';
 
 const UNSUB_URL = 'https://airwaylab.app/unsubscribe?token=test-token';
 
@@ -87,7 +88,7 @@ describe('Feature education sequence templates', () => {
 // ── CPAP tips sequence templates ───────────────────────────────
 
 describe('CPAP tips sequence templates', () => {
-  it('step 1 (day 3) covers first-week expectations', () => {
+  it('step 1 (~day 10 from signup) covers first-week expectations', () => {
     const { subject, html } = cpapTipsStep1(UNSUB_URL);
     expect(subject).toContain('first week');
     expect(html).toContain('Mask leak');
@@ -95,7 +96,7 @@ describe('CPAP tips sequence templates', () => {
     expect(html).toContain('Upload Your First Session');
   });
 
-  it('step 2 (day 7) explains AHI, leak, usage hours', () => {
+  it('step 2 (~day 14 from signup) explains AHI, leak, usage hours', () => {
     const { subject, html } = cpapTipsStep2(UNSUB_URL);
     expect(subject).toContain('AHI');
     expect(html).toContain('Apnea-Hypopnea');
@@ -103,7 +104,7 @@ describe('CPAP tips sequence templates', () => {
     expect(html).toContain('Open Your Session Dashboard');
   });
 
-  it('step 3 (day 12) covers flow limitation / fatigue with low AHI', () => {
+  it('step 3 (~day 19 from signup) covers flow limitation / fatigue with low AHI', () => {
     const { subject, html } = cpapTipsStep3(UNSUB_URL);
     expect(subject).toContain('Low AHI');
     expect(html).toContain('Flow limitation');
@@ -111,7 +112,7 @@ describe('CPAP tips sequence templates', () => {
     expect(html).toContain('Check Your Flow Limitation Score');
   });
 
-  it('step 4 (day 18) covers five feature highlights', () => {
+  it('step 4 (~day 25 from signup) covers five feature highlights', () => {
     const { subject, html } = cpapTipsStep4(UNSUB_URL);
     expect(subject).toContain('Five things');
     expect(html).toContain('Compare two sessions');
@@ -119,7 +120,7 @@ describe('CPAP tips sequence templates', () => {
     expect(html).toContain('Try Session Comparison');
   });
 
-  it('step 5 (day 25) prepares for clinic visit', () => {
+  it('step 5 (~day 32 from signup) prepares for clinic visit', () => {
     const { subject, html } = cpapTipsStep5(UNSUB_URL);
     expect(subject).toContain('Three weeks');
     expect(html).toContain('Generate a Session Summary');
@@ -232,5 +233,12 @@ describe('SEQUENCES registry', () => {
   it('cpap_tips has 5 steps with delays [3, 7, 12, 18, 25]', () => {
     expect(SEQUENCES.cpap_tips.totalSteps).toBe(5);
     expect(SEQUENCES.cpap_tips.delays).toEqual([3, 7, 12, 18, 25]);
+  });
+
+  it('cpap_tips first email starts after post_upload last email when offset by WELCOME_SEQUENCE_DAYS', () => {
+    const postUploadLastDay = Math.max(...SEQUENCES.post_upload.delays);
+    const cpapTipsFirstDay = Math.min(...SEQUENCES.cpap_tips.delays);
+    const effectiveFirstCpapTipsDay = WELCOME_SEQUENCE_DAYS + cpapTipsFirstDay;
+    expect(effectiveFirstCpapTipsDay).toBeGreaterThan(postUploadLastDay);
   });
 });

--- a/__tests__/email-templates.test.ts
+++ b/__tests__/email-templates.test.ts
@@ -7,6 +7,11 @@ import {
   dormancyStep2,
   featureEducationStep1,
   featureEducationStep2,
+  cpapTipsStep1,
+  cpapTipsStep2,
+  cpapTipsStep3,
+  cpapTipsStep4,
+  cpapTipsStep5,
   SEQUENCES,
   type SequenceName,
 } from '@/lib/email/templates';
@@ -79,6 +84,50 @@ describe('Feature education sequence templates', () => {
   });
 });
 
+// ── CPAP tips sequence templates ───────────────────────────────
+
+describe('CPAP tips sequence templates', () => {
+  it('step 1 (day 3) covers first-week expectations', () => {
+    const { subject, html } = cpapTipsStep1(UNSUB_URL);
+    expect(subject).toContain('first week');
+    expect(html).toContain('Mask leak');
+    expect(html).toContain('clinician');
+    expect(html).toContain('Upload Your First Session');
+  });
+
+  it('step 2 (day 7) explains AHI, leak, usage hours', () => {
+    const { subject, html } = cpapTipsStep2(UNSUB_URL);
+    expect(subject).toContain('AHI');
+    expect(html).toContain('Apnea-Hypopnea');
+    expect(html).toContain('Leak rate');
+    expect(html).toContain('Open Your Session Dashboard');
+  });
+
+  it('step 3 (day 12) covers flow limitation / fatigue with low AHI', () => {
+    const { subject, html } = cpapTipsStep3(UNSUB_URL);
+    expect(subject).toContain('Low AHI');
+    expect(html).toContain('Flow limitation');
+    expect(html).toContain('clinician');
+    expect(html).toContain('Check Your Flow Limitation Score');
+  });
+
+  it('step 4 (day 18) covers five feature highlights', () => {
+    const { subject, html } = cpapTipsStep4(UNSUB_URL);
+    expect(subject).toContain('Five things');
+    expect(html).toContain('Compare two sessions');
+    expect(html).toContain('trend charts');
+    expect(html).toContain('Try Session Comparison');
+  });
+
+  it('step 5 (day 25) prepares for clinic visit', () => {
+    const { subject, html } = cpapTipsStep5(UNSUB_URL);
+    expect(subject).toContain('Three weeks');
+    expect(html).toContain('Generate a Session Summary');
+    expect(html).toContain('clinician');
+    expect(html).toContain('clinical review');
+  });
+});
+
 // ── Structural invariants ──────────────────────────────────────
 
 describe('All templates — structural invariants', () => {
@@ -90,6 +139,11 @@ describe('All templates — structural invariants', () => {
     { name: 'dormancy2', fn: dormancyStep2 },
     { name: 'featureEd1', fn: featureEducationStep1 },
     { name: 'featureEd2', fn: featureEducationStep2 },
+    { name: 'cpapTips1', fn: cpapTipsStep1 },
+    { name: 'cpapTips2', fn: cpapTipsStep2 },
+    { name: 'cpapTips3', fn: cpapTipsStep3 },
+    { name: 'cpapTips4', fn: cpapTipsStep4 },
+    { name: 'cpapTips5', fn: cpapTipsStep5 },
   ];
 
   it.each(allTemplates)('$name has non-empty subject', ({ fn }) => {
@@ -132,7 +186,7 @@ describe('All templates — structural invariants', () => {
 // ── SEQUENCES registry ─────────────────────────────────────────
 
 describe('SEQUENCES registry', () => {
-  const sequenceNames: SequenceName[] = ['post_upload', 'dormancy', 'feature_education', 'activation', 'premium_onboarding'];
+  const sequenceNames: SequenceName[] = ['post_upload', 'dormancy', 'feature_education', 'activation', 'premium_onboarding', 'cpap_tips'];
 
   it.each(sequenceNames)('%s has correct totalSteps matching delays array', (name) => {
     const config = SEQUENCES[name];
@@ -173,5 +227,10 @@ describe('SEQUENCES registry', () => {
   it('premium_onboarding has 3 steps with delays [0, 3, 7]', () => {
     expect(SEQUENCES.premium_onboarding.totalSteps).toBe(3);
     expect(SEQUENCES.premium_onboarding.delays).toEqual([0, 3, 7]);
+  });
+
+  it('cpap_tips has 5 steps with delays [3, 7, 12, 18, 25]', () => {
+    expect(SEQUENCES.cpap_tips.totalSteps).toBe(5);
+    expect(SEQUENCES.cpap_tips.delays).toEqual([3, 7, 12, 18, 25]);
   });
 });

--- a/app/api/cron/cleanup/route.ts
+++ b/app/api/cron/cleanup/route.ts
@@ -95,9 +95,10 @@ export async function GET(request: NextRequest) {
       results.emails_failed = emailResult.failed;
       results.dormancy_scheduled = emailResult.dormancyScheduled;
       results.activation_scheduled = emailResult.activationScheduled;
+      results.cpap_tips_scheduled = emailResult.cpapTipsScheduled;
       results.sunsetted = emailResult.sunsetted;
       console.error(
-        `[cron/cleanup] email drips: sent=${emailResult.sent}, failed=${emailResult.failed}, dormancy=${emailResult.dormancyScheduled}, activation=${emailResult.activationScheduled}, sunsetted=${emailResult.sunsetted}`
+        `[cron/cleanup] email drips: sent=${emailResult.sent}, failed=${emailResult.failed}, dormancy=${emailResult.dormancyScheduled}, activation=${emailResult.activationScheduled}, cpap_tips=${emailResult.cpapTipsScheduled}, sunsetted=${emailResult.sunsetted}`
       );
     } catch (emailErr) {
       console.error('[cron/cleanup] email drip error:', emailErr);

--- a/lib/email/cron-handler.ts
+++ b/lib/email/cron-handler.ts
@@ -19,6 +19,7 @@ import {
   markSent,
   scheduleDormancySequences,
   scheduleActivationSequences,
+  scheduleCpapTipsSequences,
   applySunsetPolicy,
 } from './sequences';
 import { SEQUENCES } from './templates';
@@ -32,6 +33,7 @@ interface CronResult {
   failed: number;
   dormancyScheduled: number;
   activationScheduled: number;
+  cpapTipsScheduled: number;
   sunsetted: number;
 }
 
@@ -41,6 +43,7 @@ export async function processEmailDrips(supabase: SupabaseClient): Promise<CronR
     failed: 0,
     dormancyScheduled: 0,
     activationScheduled: 0,
+    cpapTipsScheduled: 0,
     sunsetted: 0,
   };
 
@@ -48,6 +51,7 @@ export async function processEmailDrips(supabase: SupabaseClient): Promise<CronR
   //    newly discovered users get their first email in this run, not 24h later.
   result.dormancyScheduled = await scheduleDormancySequences(supabase);
   result.activationScheduled = await scheduleActivationSequences(supabase);
+  result.cpapTipsScheduled = await scheduleCpapTipsSequences(supabase);
 
   // 2. Send all pending emails (including freshly scheduled ones from step 1)
   const pendingEmails = await getPendingEmails(supabase);

--- a/lib/email/sequences.ts
+++ b/lib/email/sequences.ts
@@ -254,9 +254,17 @@ export async function scheduleActivationSequences(
 const CPAP_TIPS_LAUNCH_DATE = '2026-04-14';
 
 /**
- * Schedule CPAP tips drip (Days 3/7/12/18/25 from signup) for newly opted-in users.
- * Delays are calculated relative to the user's created_at date.
- * Only schedules users created on or after CPAP_TIPS_LAUNCH_DATE.
+ * Number of days the welcome sequence (post_upload) runs before cpap_tips starts.
+ * CPAP tips baseDate is offset by this value so the two sequences don't overlap.
+ */
+export const WELCOME_SEQUENCE_DAYS = 7;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Schedule CPAP tips drip (Days 3/7/12/18/25 after welcome sequence ends) for
+ * newly opted-in users. The baseDate is offset by WELCOME_SEQUENCE_DAYS from
+ * created_at so the first CPAP tips email (~day 10) starts after the last
+ * welcome email (day 7). Only schedules users created on or after CPAP_TIPS_LAUNCH_DATE.
  */
 export async function scheduleCpapTipsSequences(
   supabase: SupabaseClient
@@ -289,7 +297,9 @@ export async function scheduleCpapTipsSequences(
 
   let scheduled = 0;
   for (const user of candidates) {
-    await scheduleSequence(supabase, user.id, 'cpap_tips', new Date(user.created_at));
+    // Offset baseDate so cpap_tips starts after the welcome sequence completes
+    const welcomeEnd = new Date(new Date(user.created_at).getTime() + WELCOME_SEQUENCE_DAYS * MS_PER_DAY);
+    await scheduleSequence(supabase, user.id, 'cpap_tips', welcomeEnd);
     scheduled++;
   }
 

--- a/lib/email/sequences.ts
+++ b/lib/email/sequences.ts
@@ -20,17 +20,17 @@ export async function scheduleSequence(
   supabase: SupabaseClient,
   userId: string,
   sequenceName: SequenceName,
+  baseDate: Date = new Date(),
 ): Promise<void> {
   const config = SEQUENCES[sequenceName];
   if (!config) return;
 
-  const now = new Date();
   const rows = config.delays.map((delayDays, index) => ({
     user_id: userId,
     sequence_name: sequenceName,
     step: index + 1,
     status: 'pending' as const,
-    scheduled_at: new Date(now.getTime() + delayDays * 24 * 60 * 60 * 1000).toISOString(),
+    scheduled_at: new Date(baseDate.getTime() + delayDays * 24 * 60 * 60 * 1000).toISOString(),
   }));
 
   // upsert to make this idempotent — if sequence already exists, skip
@@ -243,6 +243,53 @@ export async function scheduleActivationSequences(
   let scheduled = 0;
   for (const user of inactiveUsers) {
     await scheduleSequence(supabase, user.id, 'activation');
+    scheduled++;
+  }
+
+  return scheduled;
+}
+
+// Only schedule cpap_tips for users created on or after this date to avoid
+// retroactively flooding existing users whose send windows have already passed.
+const CPAP_TIPS_LAUNCH_DATE = '2026-04-14';
+
+/**
+ * Schedule CPAP tips drip (Days 3/7/12/18/25 from signup) for newly opted-in users.
+ * Delays are calculated relative to the user's created_at date.
+ * Only schedules users created on or after CPAP_TIPS_LAUNCH_DATE.
+ */
+export async function scheduleCpapTipsSequences(
+  supabase: SupabaseClient
+): Promise<number> {
+  // Find users who already have a cpap_tips sequence (any step)
+  const { data: existingCpapTips } = await supabase
+    .from('email_sequences')
+    .select('user_id')
+    .eq('sequence_name', 'cpap_tips');
+
+  const excludeIds = existingCpapTips?.map((r) => r.user_id) ?? [];
+
+  // Find opted-in users created on/after launch date, not yet scheduled
+  let query = supabase
+    .from('profiles')
+    .select('id, created_at')
+    .eq('email_opt_in', true)
+    .gte('created_at', CPAP_TIPS_LAUNCH_DATE);
+
+  if (excludeIds.length > 0) {
+    query = query.not('id', 'in', `(${excludeIds.join(',')})`);
+  }
+
+  const { data: candidates, error } = await query;
+
+  if (error || !candidates) {
+    console.error('[email-sequences] Failed to find cpap_tips candidates:', error?.message);
+    return 0;
+  }
+
+  let scheduled = 0;
+  for (const user of candidates) {
+    await scheduleSequence(supabase, user.id, 'cpap_tips', new Date(user.created_at));
     scheduled++;
   }
 

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -422,7 +422,7 @@ export const SEQUENCES: Record<SequenceName, SequenceConfig> = {
   },
   cpap_tips: {
     totalSteps: 5,
-    delays: [3, 7, 12, 18, 25], // days post-signup; scheduled from user's created_at
+    delays: [3, 7, 12, 18, 25], // days after welcome sequence completes (~days 10/14/19/25/32 from signup)
     getTemplate: (step, url) => {
       if (step === 1) return cpapTipsStep1(url);
       if (step === 2) return cpapTipsStep2(url);

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -265,9 +265,105 @@ function premiumOnboardingStep3(unsubscribeUrl: string): { subject: string; html
   };
 }
 
+// ── Sequence 6: CPAP Tips (Days 3/7/12/18/25 post-signup) ────
+
+export function cpapTipsStep1(unsubscribeUrl: string): { subject: string; html: string } {
+  return {
+    subject: 'Your first week on CPAP -- what\'s normal, what isn\'t',
+    html: layout(`
+      ${heading('Your first week on CPAP')}
+      ${paragraph('If you\'re a few days into CPAP therapy, you might be staring at your numbers wondering if something is wrong.')}
+      ${paragraph('Here\'s the honest answer: probably not. The first week is noisy. Your body is adjusting to sleeping with a mask, your mouth might be drying out, your AHI might look higher than you expected. The first 2--4 weeks are an adjustment period, and single-night numbers during this phase don\'t tell you much on their own.')}
+      ${bulletList([
+        '<strong style="color:#fff;">Mask leak</strong> -- common until you find the right fit and pressure. A small amount of leak is expected (intentional vent leak).',
+        '<strong style="color:#fff;">Mouth breathing</strong> -- if your mouth falls open at night, you\'ll lose pressure and your AHI may spike.',
+        '<strong style="color:#fff;">Aerophagia</strong> -- that bloated, gassy feeling from swallowing air. More common at higher pressures.',
+        '<strong style="color:#fff;">Pressure discomfort</strong> -- feeling like you\'re fighting the machine to exhale.',
+        '<strong style="color:#fff;">AHI fluctuating night to night</strong> -- completely normal early on. Look for trends over a week or more.',
+      ])}
+      ${paragraph('Once you upload your SD card to AirwayLab, you\'ll see a session summary with AHI, leak rate, and usage hours. Even if your first few sessions look rough, that data is valuable.')}
+      ${ctaButton('Upload Your First Session', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=cpap_tips_1`)}
+      ${paragraph('<em>This content is informational only. It is not medical advice. Discuss any concerns with your prescribing clinician or sleep specialist.</em>')}
+    `, unsubscribeUrl),
+  };
+}
+
+export function cpapTipsStep2(unsubscribeUrl: string): { subject: string; html: string } {
+  return {
+    subject: 'AHI, leak rate, usage hours -- what your CPAP data actually means',
+    html: layout(`
+      ${heading('What your CPAP data actually means')}
+      ${paragraph('By now you\'ve got a week of sessions (hopefully). Let\'s talk about what you\'re actually looking at.')}
+      ${paragraph('Most CPAP data apps give you three headline numbers: AHI, leak rate, and usage hours.')}
+      ${bulletList([
+        '<strong style="color:#fff;">AHI</strong> -- Apnea-Hypopnea Index. The number of breathing disruption events per hour of sleep. A lower AHI generally means fewer disruptions.',
+        '<strong style="color:#fff;">Leak rate</strong> -- your mask has intentional vents that release CO2. High <em>unintentional</em> leak means your device can\'t maintain the pressure it needs.',
+        '<strong style="color:#fff;">Usage hours</strong> -- how long you wore the mask. Consistency across the week matters as much as any single night.',
+      ])}
+      ${paragraph('In AirwayLab, you can see your leak rate alongside your AHI to spot whether a bad night was a therapy problem or a leak problem.')}
+      ${ctaButton('Open Your Session Dashboard', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=cpap_tips_2`)}
+      ${paragraph('<em>This content is informational only. It is not medical advice. Discuss any concerns with your prescribing clinician or sleep specialist.</em>')}
+    `, unsubscribeUrl),
+  };
+}
+
+export function cpapTipsStep3(unsubscribeUrl: string): { subject: string; html: string } {
+  return {
+    subject: 'Low AHI and still tired? Here\'s what your data might be showing',
+    html: layout(`
+      ${heading('Low AHI and still tired?')}
+      ${paragraph('Something a lot of CPAP users run into: AHI looks fine -- under 5, sometimes under 2 -- but they\'re still waking up exhausted.')}
+      ${paragraph('If that\'s you, your data might be showing something that standard AHI doesn\'t capture.')}
+      ${bulletList([
+        '<strong style="color:#fff;">Flow limitation</strong> -- partial airway resistance that doesn\'t trigger a scored event but disrupts the quality of airflow.',
+        '<strong style="color:#fff;">RERAs</strong> (Respiratory Effort-Related Arousals) -- brief arousals caused by increased respiratory effort. Standard AHI doesn\'t count them.',
+      ])}
+      ${paragraph('Alongside your AHI, AirwayLab surfaces a flow limitation score derived from your flow waveform data. You can see whether individual breaths look restricted, even on nights when your AHI looks clean.')}
+      ${paragraph('This isn\'t a diagnosis. It\'s a pattern in your data that may be worth discussing with your clinician.')}
+      ${ctaButton('Check Your Flow Limitation Score', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=cpap_tips_3`)}
+      ${paragraph('<em>This content is informational only. It is not medical advice. Discuss any concerns with your prescribing clinician or sleep specialist.</em>')}
+    `, unsubscribeUrl),
+  };
+}
+
+export function cpapTipsStep4(unsubscribeUrl: string): { subject: string; html: string } {
+  return {
+    subject: 'Five things you can do in AirwayLab right now',
+    html: layout(`
+      ${heading('Five things worth trying in AirwayLab')}
+      ${paragraph('You\'ve been using AirwayLab for a few weeks. Here are five things that are worth trying if you haven\'t already.')}
+      ${bulletList([
+        '<strong style="color:#fff;">Compare two sessions side by side</strong> -- pick any two nights and compare AHI, leak, flow limitation, and breath shape in a single screen.',
+        '<strong style="color:#fff;">Look at your trend charts</strong> -- the trend view shows your AHI, leak rate, and usage hours over 30 or 90 days. Trends are where the signal is.',
+        '<strong style="color:#fff;">Explore the breath shape visualisation</strong> -- see the actual shape of individual breaths from your flow waveform data.',
+        '<strong style="color:#fff;">Export a summary for your clinician</strong> -- generate a session summary with your key metrics and trends before your next appointment.',
+        '<strong style="color:#fff;">Everything above is free, and always will be</strong> -- all features run entirely in your browser. Your data stays on your device.',
+      ])}
+      ${ctaButton('Try Session Comparison', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=cpap_tips_4`)}
+      ${paragraph('<em>This content is informational only. It is not medical advice. Discuss any concerns with your prescribing clinician or sleep specialist.</em>')}
+    `, unsubscribeUrl),
+  };
+}
+
+export function cpapTipsStep5(unsubscribeUrl: string): { subject: string; html: string } {
+  return {
+    subject: 'Three weeks in -- how to make the most of your sleep clinic visit',
+    html: layout(`
+      ${heading('Three weeks of data for your clinician')}
+      ${paragraph('Three weeks of data is genuinely useful. If you have a sleep clinic visit coming up -- or if you\'re due to schedule one -- here\'s how to make the most of it.')}
+      ${paragraph('By now you can see trends rather than noise: whether your AHI has been stable, improving, or creeping up; whether your leak rate has been consistently low or intermittently high.')}
+      ${paragraph('Before your appointment, spend five minutes with the trend view in AirwayLab. Any patterns you notice are worth mentioning. You don\'t need to interpret them -- that\'s your clinician\'s job. You just need to be able to show the data.')}
+      ${paragraph('AirwayLab can export a session summary with your key metrics and trends. It\'s designed to be readable by a sleep specialist, not just a CPAP enthusiast.')}
+      ${paragraph('We\'re a tool for informed conversations -- not a substitute for clinical review. That\'s what we\'re here for.')}
+      ${ctaButton('Generate a Session Summary', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=cpap_tips_5`)}
+      ${paragraph('<em>This content is informational only. It is not medical advice. Discuss any concerns with your prescribing clinician or sleep specialist.</em>')}
+    `, unsubscribeUrl),
+  };
+}
+
 // ── Template registry ────────────────────────────────────────
 
-export type SequenceName = 'post_upload' | 'dormancy' | 'feature_education' | 'activation' | 'premium_onboarding';
+export type SequenceName = 'post_upload' | 'dormancy' | 'feature_education' | 'activation' | 'premium_onboarding' | 'cpap_tips';
 
 interface SequenceConfig {
   totalSteps: number;
@@ -321,6 +417,18 @@ export const SEQUENCES: Record<SequenceName, SequenceConfig> = {
       if (step === 1) return premiumOnboardingStep1(url);
       if (step === 2) return premiumOnboardingStep2(url);
       if (step === 3) return premiumOnboardingStep3(url);
+      return null;
+    },
+  },
+  cpap_tips: {
+    totalSteps: 5,
+    delays: [3, 7, 12, 18, 25], // days post-signup; scheduled from user's created_at
+    getTemplate: (step, url) => {
+      if (step === 1) return cpapTipsStep1(url);
+      if (step === 2) return cpapTipsStep2(url);
+      if (step === 3) return cpapTipsStep3(url);
+      if (step === 4) return cpapTipsStep4(url);
+      if (step === 5) return cpapTipsStep5(url);
       return null;
     },
   },

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -279,7 +279,7 @@ export function cpapTipsStep1(unsubscribeUrl: string): { subject: string; html: 
         '<strong style="color:#fff;">Mouth breathing</strong> -- if your mouth falls open at night, you\'ll lose pressure and your AHI may spike.',
         '<strong style="color:#fff;">Aerophagia</strong> -- that bloated, gassy feeling from swallowing air. More common at higher pressures.',
         '<strong style="color:#fff;">Pressure discomfort</strong> -- feeling like you\'re fighting the machine to exhale.',
-        '<strong style="color:#fff;">AHI fluctuating night to night</strong> -- completely normal early on. Look for trends over a week or more.',
+        '<strong style="color:#fff;">AHI fluctuating night to night</strong> -- common early on. Look for trends over a week or more.',
       ])}
       ${paragraph('Once you upload your SD card to AirwayLab, you\'ll see a session summary with AHI, leak rate, and usage hours. Even if your first few sessions look rough, that data is valuable.')}
       ${ctaButton('Upload Your First Session', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=cpap_tips_1`)}
@@ -300,7 +300,7 @@ export function cpapTipsStep2(unsubscribeUrl: string): { subject: string; html: 
         '<strong style="color:#fff;">Leak rate</strong> -- your mask has intentional vents that release CO2. High <em>unintentional</em> leak means your device can\'t maintain the pressure it needs.',
         '<strong style="color:#fff;">Usage hours</strong> -- how long you wore the mask. Consistency across the week matters as much as any single night.',
       ])}
-      ${paragraph('In AirwayLab, you can see your leak rate alongside your AHI to spot whether a bad night was a therapy problem or a leak problem.')}
+      ${paragraph('In AirwayLab, you can see your leak rate alongside your AHI for a fuller picture of each night.')}
       ${ctaButton('Open Your Session Dashboard', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=cpap_tips_2`)}
       ${paragraph('<em>This content is informational only. It is not medical advice. Discuss any concerns with your prescribing clinician or sleep specialist.</em>')}
     `, unsubscribeUrl),
@@ -315,11 +315,11 @@ export function cpapTipsStep3(unsubscribeUrl: string): { subject: string; html: 
       ${paragraph('Something a lot of CPAP users run into: AHI looks fine -- under 5, sometimes under 2 -- but they\'re still waking up exhausted.')}
       ${paragraph('If that\'s you, your data might be showing something that standard AHI doesn\'t capture.')}
       ${bulletList([
-        '<strong style="color:#fff;">Flow limitation</strong> -- partial airway resistance that doesn\'t trigger a scored event but disrupts the quality of airflow.',
-        '<strong style="color:#fff;">RERAs</strong> (Respiratory Effort-Related Arousals) -- brief arousals caused by increased respiratory effort. Standard AHI doesn\'t count them.',
+        '<strong style="color:#fff;">Flow limitation</strong> -- a pattern in the flow waveform that the standard AHI count does not include.',
+        '<strong style="color:#fff;">RERAs</strong> (Respiratory Effort-Related Arousals) -- a type of breathing event that standard AHI does not count.',
       ])}
-      ${paragraph('Alongside your AHI, AirwayLab surfaces a flow limitation score derived from your flow waveform data. You can see whether individual breaths look restricted, even on nights when your AHI looks clean.')}
-      ${paragraph('This isn\'t a diagnosis. It\'s a pattern in your data that may be worth discussing with your clinician.')}
+      ${paragraph('Alongside your AHI, AirwayLab surfaces a flow limitation score derived from your flow waveform data. You can see whether individual breaths show elevated flow limitation scores, even on nights when your AHI looks clean.')}
+      ${paragraph('This isn\'t a diagnosis. It\'s a pattern in your data. Your clinician can help interpret these findings in context.')}
       ${ctaButton('Check Your Flow Limitation Score', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=cpap_tips_3`)}
       ${paragraph('<em>This content is informational only. It is not medical advice. Discuss any concerns with your prescribing clinician or sleep specialist.</em>')}
     `, unsubscribeUrl),
@@ -351,7 +351,7 @@ export function cpapTipsStep5(unsubscribeUrl: string): { subject: string; html: 
     html: layout(`
       ${heading('Three weeks of data for your clinician')}
       ${paragraph('Three weeks of data is genuinely useful. If you have a sleep clinic visit coming up -- or if you\'re due to schedule one -- here\'s how to make the most of it.')}
-      ${paragraph('By now you can see trends rather than noise: whether your AHI has been stable, improving, or creeping up; whether your leak rate has been consistently low or intermittently high.')}
+      ${paragraph('By now you can see trends rather than noise: whether your AHI has been stable, decreasing, or increasing; whether your leak rate has been consistently low or intermittently high.')}
       ${paragraph('Before your appointment, spend five minutes with the trend view in AirwayLab. Any patterns you notice are worth mentioning. You don\'t need to interpret them -- that\'s your clinician\'s job. You just need to be able to show the data.')}
       ${paragraph('AirwayLab can export a session summary with your key metrics and trends. It\'s designed to be readable by a sleep specialist, not just a CPAP enthusiast.')}
       ${paragraph('We\'re a tool for informed conversations -- not a substitute for clinical review. That\'s what we\'re here for.')}


### PR DESCRIPTION
Adds cpap_tips 5-email drip (Days 3/7/12/18/25 post-signup). MDR-compliant templates, signup-relative scheduling, gated to 2026-04-14+ users. 1779/1779 tests pass.

Closes AIR-367