### PR TITLE
fix: remove 12 MUST MDR violations (AIR-478)

### DIFF
--- a/app/about/glasgow-index/page.tsx
+++ b/app/about/glasgow-index/page.tsx
@@ -248,8 +248,8 @@ export default function GlasgowIndexPage() {
               <span className="text-sm font-semibold text-emerald-400">Below 1.0</span>
             </div>
             <p className="text-xs leading-relaxed text-muted-foreground">
-              Low flow limitation scores observed. Your current pressure settings
-              appear to be managing your airway well.
+              Low flow limitation scores observed. Your Glasgow Index is in the
+              typical range for this metric.
             </p>
           </div>
           <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
@@ -268,8 +268,8 @@ export default function GlasgowIndexPage() {
               <span className="text-sm font-semibold text-red-400">Above 2.0</span>
             </div>
             <p className="text-xs leading-relaxed text-muted-foreground">
-              Significant flow limitation. Your airway may be partially obstructed
-              despite therapy. The original Glasgow Index author describes a score
+              Significant flow limitation. Your Glasgow Index is elevated. Your
+              clinician can help interpret this in context. The original Glasgow Index author describes a score
               of 3 as &ldquo;significant problems.&rdquo; Your sleep physician can help interpret these findings in context.
             </p>
           </div>

--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -61,7 +61,7 @@ const PREMIUM_INSIGHT_EXTENSION = `
 Generate 6 to 10 data pattern observations for this analysis. As a premium analysis, be thorough — cover all engines with specific findings.
 
 In addition to the standard categories, you may use these categories for premium-depth analysis:
-- "correlation": Cross-engine correlations (e.g. Glasgow flat-top + high NED suggests steady-state FL; WAT periodicity + oximetry ODI coupling suggests central component)
+- "correlation": Cross-engine correlations (e.g. Glasgow flat-top scoring is elevated while NED M-shape percentage is low; WAT periodicity and oximetry ODI values are both elevated)
 - "temporal": Time-based patterns (e.g. progressive FL worsening across H1→H2, periodic clustering at specific intervals, REM-associated breath shape changes, positional transitions visible in H1/H2 splits)
 
 Prioritise correlation and temporal insights — these are the analysis patterns that go beyond what rule-based systems detect.
@@ -89,7 +89,7 @@ Your task is to generate 3–6 data pattern observations in JSON format. Each in
 }
 
 Focus on:
-- Cross-engine correlations the rule-based system misses (e.g. Glasgow flat-top high while NED shows low M-shape suggests steady-state flow limitation rather than oscillatory obstruction)
+- Cross-engine correlations the rule-based system misses (e.g. Glasgow flat-top scoring is elevated while NED M-shape percentage is low)
 - Patterns between WAT regularity/periodicity and Glasgow component breakdown
 - H1 vs H2 shifts across engines (positional or REM-related patterns)
 - Therapy settings context: analyse ALL machine settings provided (pressure, EPR, ramp, humidity, mask type, trigger/cycle sensitivity, comfort features). Describe how these settings relate to the data patterns observed. Do NOT suggest specific adjustments or changes.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,7 +70,7 @@ const engines = [
   {
     icon: Waves,
     title: 'WAT Analysis',
-    desc: 'Detects the breathing restriction your AHI completely misses. Measures tidal volume ratios and breathing regularity.',
+    desc: 'Quantifies the breathing patterns your AHI completely misses. Measures tidal volume ratios and breathing regularity.',
     metrics: ['FL Score', 'Sample Entropy', 'FFT Periodicity'],
     example: '28%',
     unit: 'FL score',
@@ -731,12 +731,12 @@ export default function Home() {
                 <p className="mt-0.5 text-[10px] text-muted-foreground">Changed from 1.2 to 1.8 (+0.6).</p>
               </div>
               <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-2">
-                <p className="text-xs font-medium text-emerald-300">Settings change improved flow limitation</p>
+                <p className="text-xs font-medium text-emerald-300">Settings change: flow limitation decreased</p>
                 <p className="mt-0.5 text-[10px] text-muted-foreground">Glasgow Index went from 2.1 to 1.5.</p>
               </div>
               <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-2">
                 <p className="text-xs font-medium text-emerald-300">Trending down over 7 nights</p>
-                <p className="mt-0.5 text-[10px] text-muted-foreground">Flow limitation is improving (2.1 → 1.8).</p>
+                <p className="mt-0.5 text-[10px] text-muted-foreground">Flow limitation is lower (2.1 → 1.8).</p>
               </div>
             </div>
           </div>

--- a/app/providers/page.tsx
+++ b/app/providers/page.tsx
@@ -42,7 +42,7 @@ const engines = [
   {
     icon: Waves,
     title: 'Flow Limitation Detection',
-    desc: 'WAT tidal volume ratios and breathing regularity analysis. Detects the restriction patterns that AHI completely misses.',
+    desc: 'WAT tidal volume ratios and breathing regularity analysis. Quantifies the restriction patterns that AHI completely misses.',
     color: 'text-emerald-400',
     bg: 'bg-emerald-500/10',
     border: 'border-emerald-500/20',

--- a/e2e/conversion-funnel.spec.ts
+++ b/e2e/conversion-funnel.spec.ts
@@ -373,8 +373,9 @@ test.describe('Conversion Funnel — Pricing Page', () => {
     // Click first "Sign in to get started" button (Supporter)
     await page.getByText('Sign in to get started').first().click();
 
-    const modal = page.getByRole('dialog').filter({ hasText: /sign in to airwaylab/i });
-    await expect(modal).toBeVisible({ timeout: 3_000 });
+    // Pricing context shows "Sign in to complete your upgrade" (auth-modal.tsx:128)
+    const modal = page.getByRole('dialog').filter({ hasText: /sign in to complete your upgrade/i });
+    await expect(modal).toBeVisible({ timeout: 5_000 });
   });
 });
 

--- a/e2e/landing-page.spec.ts
+++ b/e2e/landing-page.spec.ts
@@ -56,8 +56,9 @@ test.describe('Landing Page', () => {
   });
 
   test('header navigation links work', async ({ page }) => {
-    await page.locator('nav a[href="/analyze"]').first().click({ force: true });
-    await expect(page).toHaveURL('/analyze');
+    await page.waitForLoadState('networkidle');
+    await page.locator('nav a[href="/analyze"]').first().click();
+    await expect(page).toHaveURL('/analyze', { timeout: 10_000 });
   });
 
   test('privacy shield message is visible', async ({ page }) => {

--- a/lib/clinician-questions.ts
+++ b/lib/clinician-questions.ts
@@ -64,7 +64,7 @@ const SINGLE_NIGHT_RULES: QuestionRule[] = [
       return {
         id: 'fl-score',
         stem: 'My AirwayLab report shows elevated FL metrics. Can you help me understand what this means?',
-        rationale: `Your FL Score of ${Math.round(n.wat.flScore)}% suggests significant flow limitation during sleep.`,
+        rationale: `Your FL Score of ${Math.round(n.wat.flScore)}% is above the typical range for this metric.`,
         category: 'flow-limitation',
         urgency: light,
       };
@@ -115,11 +115,10 @@ const SINGLE_NIGHT_RULES: QuestionRule[] = [
     evaluate: (n, th) => {
       const light = getTrafficLight(n.ned.reraIndex, th.reraIndex!);
       if (light === 'good') return null;
-      const severity = n.ned.reraIndex > 10 ? 'frequent' : 'moderate';
       return {
         id: 'rera-index',
         stem: 'My data shows frequent respiratory effort-related arousals. Can you help me understand what might be causing this?',
-        rationale: `Your estimated RERA Index of ${fmt(n.ned.reraIndex)}/hr indicates ${severity} sleep disruptions beyond what AHI captures.`,
+        rationale: `Your estimated RERA Index of ${fmt(n.ned.reraIndex)}/hr is above the typical range.`,
         category: 'arousals',
         urgency: light,
       };
@@ -135,7 +134,7 @@ const SINGLE_NIGHT_RULES: QuestionRule[] = [
       return {
         id: 'eai',
         stem: 'My estimated arousal index is elevated. What might be contributing to this?',
-        rationale: `Your Estimated Arousal Index of ${fmt(eai)}/hr suggests sleep fragmentation that may affect how rested you feel.`,
+        rationale: `Your Estimated Arousal Index of ${fmt(eai)}/hr is elevated compared to the typical range.`,
         category: 'arousals',
         urgency: light,
       };
@@ -151,8 +150,8 @@ const SINGLE_NIGHT_RULES: QuestionRule[] = [
       if (light === 'good') return null;
       return {
         id: 'periodicity',
-        stem: 'My breathing shows cyclical patterns. Could this indicate periodic breathing or a central component?',
-        rationale: `Your Periodicity Index of ${fmt(n.wat.periodicityIndex)}% suggests recurring breathing cycles at 30–100 second intervals.`,
+        stem: 'My breathing shows cyclical patterns. Could you help me understand what this periodicity pattern means?',
+        rationale: `Your Periodicity Index of ${fmt(n.wat.periodicityIndex)}% shows a recurring pattern at 30–100 second intervals.`,
         category: 'breathing-stability',
         urgency: light,
       };


### PR DESCRIPTION
## Summary

- Fixes 12 P0 MUST MDR violations across landing page, Glasgow Index, providers page, AI system prompts, and clinician questions
- Replaces diagnostic language (Rule 2), predictive claims (Rule 3), and effectiveness judgments (Rule 4) with compliant alternatives
- All 1740 tests pass

Source audit: AIR-477

Co-Authored-By: Paperclip <noreply@paperclip.ing>