### PR TITLE
fix(insights): use directional language for proxy metric trends (AIR-537)

### DIFF
--- a/__tests__/insights.test.ts
+++ b/__tests__/insights.test.ts
@@ -214,9 +214,12 @@ describe('generateInsights', () => {
 
     it('IFL worsening insight uses type info, not actionable', () => {
       // newest-first: high flScore first (worsening IFL trend when reversed to chrono)
+      // Strip machineSummary + settingsMetrics so single-night info insights don't fill the 6-cap
       const makeNight = (flScore: number, dateStr: string): NightResult => ({
         ...SAMPLE_NIGHTS[0]!,
         dateStr,
+        machineSummary: null,
+        settingsMetrics: null,
         wat: { ...SAMPLE_NIGHTS[0]!.wat, flScore },
         ned: { ...SAMPLE_NIGHTS[0]!.ned, nedMean: 15 },
         oximetry: { ...SAMPLE_NIGHTS[0]!.oximetry!, odi3: 3 },
@@ -230,19 +233,22 @@ describe('generateInsights', () => {
       ];
       const result = generateInsights(nights, nights[0]!, nights[1]!, null);
       const iflWorsen = result.find((i) => i.id === 'trend-ifl-worsening');
-      if (iflWorsen) {
-        expect(iflWorsen.type).toBe('info');
-        expect(iflWorsen.body).toContain('proxy composite');
-        expect(iflWorsen.body).toContain('ODI');
-      }
+      expect(iflWorsen).toBeDefined();
+      expect(iflWorsen!.type).toBe('info');
+      expect(iflWorsen!.body).toContain('proxy composite');
+      expect(iflWorsen!.body).toContain('ODI');
     });
 
     it('Glasgow worsening insight uses type info, not actionable', () => {
+      // Strip machineSummary + settingsMetrics so single-night info insights don't fill the 6-cap
       const makeNight = (glasgow: number, dateStr: string): NightResult => ({
         ...SAMPLE_NIGHTS[0]!,
         dateStr,
+        machineSummary: null,
+        settingsMetrics: null,
         glasgow: { ...SAMPLE_NIGHTS[0]!.glasgow, overall: glasgow },
-        oximetry: { ...SAMPLE_NIGHTS[0]!.oximetry!, odi3: 3 },
+        oximetry: null,
+        oximetryTrace: null,
       });
       // newest-first: high glasgow first (worsening trend when reversed to chrono)
       const nights = [
@@ -254,11 +260,10 @@ describe('generateInsights', () => {
       ];
       const result = generateInsights(nights, nights[0]!, nights[1]!, null);
       const gWorsen = result.find((i) => i.id === 'trend-glasgow-worsening');
-      if (gWorsen) {
-        expect(gWorsen.type).toBe('info');
-        expect(gWorsen.body).toContain('context-tier metric');
-        expect(gWorsen.body).toContain('flow shape patterns');
-      }
+      expect(gWorsen).toBeDefined();
+      expect(gWorsen!.type).toBe('info');
+      expect(gWorsen!.body).toContain('context-tier metric');
+      expect(gWorsen!.body).toContain('flow shape patterns');
     });
 
     describe('proxy-outcome divergence', () => {
@@ -279,20 +284,20 @@ describe('generateInsights', () => {
 
       it('fires when IFL worsening and ODI-3 stable with ≥3 oximetry nights', () => {
         // newest-first: high IFL recently (worsening proxy), flat ODI-3 (stable outcome)
+        // Strip machineSummary + settingsMetrics so single-night info insights don't fill the 6-cap
         const nights = [
           makeOxNight(80, 15, 3.0, '2025-02-05'),
           makeOxNight(70, 14, 3.2, '2025-02-04'),
           makeOxNight(60, 14, 3.1, '2025-02-03'),
           makeOxNight(50, 13, 2.9, '2025-02-02'),
           makeOxNight(40, 13, 3.0, '2025-02-01'),
-        ];
+        ].map((n) => ({ ...n, machineSummary: null, settingsMetrics: null }));
         const result = generateInsights(nights, nights[0]!, nights[1]!, null);
         const divergence = result.find((i) => i.id === 'proxy-outcome-divergence');
-        if (divergence) {
-          expect(divergence.type).toBe('info');
-          expect(divergence.category).toBe('trend');
-          expect(divergence.body).toContain('clinician');
-        }
+        expect(divergence).toBeDefined();
+        expect(divergence!.type).toBe('info');
+        expect(divergence!.category).toBe('trend');
+        expect(divergence!.body).toContain('clinician');
       });
 
       it('does not fire when ODI-3 is also worsening', () => {

--- a/__tests__/insights.test.ts
+++ b/__tests__/insights.test.ts
@@ -211,6 +211,138 @@ describe('generateInsights', () => {
       expect(therapyInsight).toBeDefined();
       expect(therapyInsight!.type).toBe('positive');
     });
+
+    it('IFL worsening insight uses type info, not actionable', () => {
+      // newest-first: high flScore first (worsening IFL trend when reversed to chrono)
+      const makeNight = (flScore: number, dateStr: string): NightResult => ({
+        ...SAMPLE_NIGHTS[0]!,
+        dateStr,
+        wat: { ...SAMPLE_NIGHTS[0]!.wat, flScore },
+        ned: { ...SAMPLE_NIGHTS[0]!.ned, nedMean: 15 },
+        oximetry: { ...SAMPLE_NIGHTS[0]!.oximetry!, odi3: 3 },
+      });
+      const nights = [
+        makeNight(80, '2025-02-05'),
+        makeNight(70, '2025-02-04'),
+        makeNight(60, '2025-02-03'),
+        makeNight(50, '2025-02-02'),
+        makeNight(40, '2025-02-01'),
+      ];
+      const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+      const iflWorsen = result.find((i) => i.id === 'trend-ifl-worsening');
+      if (iflWorsen) {
+        expect(iflWorsen.type).toBe('info');
+        expect(iflWorsen.body).toContain('proxy composite');
+        expect(iflWorsen.body).toContain('ODI');
+      }
+    });
+
+    it('Glasgow worsening insight uses type info, not actionable', () => {
+      const makeNight = (glasgow: number, dateStr: string): NightResult => ({
+        ...SAMPLE_NIGHTS[0]!,
+        dateStr,
+        glasgow: { ...SAMPLE_NIGHTS[0]!.glasgow, overall: glasgow },
+        oximetry: { ...SAMPLE_NIGHTS[0]!.oximetry!, odi3: 3 },
+      });
+      // newest-first: high glasgow first (worsening trend when reversed to chrono)
+      const nights = [
+        makeNight(3.5, '2025-02-05'),
+        makeNight(3.0, '2025-02-04'),
+        makeNight(2.5, '2025-02-03'),
+        makeNight(2.0, '2025-02-02'),
+        makeNight(1.5, '2025-02-01'),
+      ];
+      const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+      const gWorsen = result.find((i) => i.id === 'trend-glasgow-worsening');
+      if (gWorsen) {
+        expect(gWorsen.type).toBe('info');
+        expect(gWorsen.body).toContain('context-tier metric');
+        expect(gWorsen.body).toContain('flow shape patterns');
+      }
+    });
+
+    describe('proxy-outcome divergence', () => {
+      function makeOxNight(
+        flScore: number,
+        nedMean: number,
+        odi3: number,
+        dateStr: string,
+      ): NightResult {
+        return {
+          ...SAMPLE_NIGHTS[0]!,
+          dateStr,
+          wat: { ...SAMPLE_NIGHTS[0]!.wat, flScore },
+          ned: { ...SAMPLE_NIGHTS[0]!.ned, nedMean },
+          oximetry: { ...SAMPLE_NIGHTS[0]!.oximetry!, odi3 },
+        };
+      }
+
+      it('fires when IFL worsening and ODI-3 stable with ≥3 oximetry nights', () => {
+        // newest-first: high IFL recently (worsening proxy), flat ODI-3 (stable outcome)
+        const nights = [
+          makeOxNight(80, 15, 3.0, '2025-02-05'),
+          makeOxNight(70, 14, 3.2, '2025-02-04'),
+          makeOxNight(60, 14, 3.1, '2025-02-03'),
+          makeOxNight(50, 13, 2.9, '2025-02-02'),
+          makeOxNight(40, 13, 3.0, '2025-02-01'),
+        ];
+        const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+        const divergence = result.find((i) => i.id === 'proxy-outcome-divergence');
+        if (divergence) {
+          expect(divergence.type).toBe('info');
+          expect(divergence.category).toBe('trend');
+          expect(divergence.body).toContain('clinician');
+        }
+      });
+
+      it('does not fire when ODI-3 is also worsening', () => {
+        const nights = [
+          makeOxNight(80, 15, 8.0, '2025-02-05'),
+          makeOxNight(70, 14, 7.0, '2025-02-04'),
+          makeOxNight(60, 14, 6.0, '2025-02-03'),
+          makeOxNight(50, 13, 5.0, '2025-02-02'),
+          makeOxNight(40, 13, 4.0, '2025-02-01'),
+        ];
+        const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+        const divergence = result.find((i) => i.id === 'proxy-outcome-divergence');
+        expect(divergence).toBeUndefined();
+      });
+
+      it('does not fire when fewer than 3 nights have oximetry', () => {
+        const makeNoOxNight = (flScore: number, dateStr: string): NightResult => ({
+          ...SAMPLE_NIGHTS[0]!,
+          dateStr,
+          wat: { ...SAMPLE_NIGHTS[0]!.wat, flScore },
+          ned: { ...SAMPLE_NIGHTS[0]!.ned, nedMean: 15 },
+          oximetry: null,
+          oximetryTrace: null,
+        });
+        const nights = [
+          makeOxNight(80, 15, 3.0, '2025-02-05'), // has oximetry
+          makeOxNight(70, 14, 3.1, '2025-02-04'), // has oximetry
+          makeNoOxNight(60, '2025-02-03'), // no oximetry
+          makeNoOxNight(50, '2025-02-02'), // no oximetry
+          makeNoOxNight(40, '2025-02-01'), // no oximetry
+        ];
+        const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+        const divergence = result.find((i) => i.id === 'proxy-outcome-divergence');
+        expect(divergence).toBeUndefined();
+      });
+
+      it('does not fire when proxy metrics are not worsening', () => {
+        // IFL improving, ODI-3 stable — no divergence
+        const nights = [
+          makeOxNight(40, 13, 3.0, '2025-02-05'),
+          makeOxNight(50, 14, 3.1, '2025-02-04'),
+          makeOxNight(60, 15, 3.2, '2025-02-03'),
+          makeOxNight(70, 16, 3.0, '2025-02-02'),
+          makeOxNight(80, 17, 3.1, '2025-02-01'),
+        ];
+        const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+        const divergence = result.find((i) => i.id === 'proxy-outcome-divergence');
+        expect(divergence).toBeUndefined();
+      });
+    });
   });
 
   describe('symptom rating cross-reference', () => {

--- a/__tests__/thresholds.test.ts
+++ b/__tests__/thresholds.test.ts
@@ -4,8 +4,14 @@ import {
   getTrafficColor,
   getTrafficBg,
   getTrafficDotColor,
+  getThresholdKeysByPanel,
+  getMetricPanel,
+  isProxyMetric,
   THRESHOLDS,
+  PANEL_LABELS,
+  PANEL_DESCRIPTIONS,
   type ThresholdDef,
+  type MetricPanel,
 } from '@/lib/thresholds';
 
 describe('getTrafficLight', () => {
@@ -182,5 +188,91 @@ describe('THRESHOLDS object', () => {
         expect(def.green).toBeGreaterThanOrEqual(def.amber);
       }
     }
+  });
+});
+
+describe('metric tier hierarchy', () => {
+  it('every threshold has a tier assignment', () => {
+    for (const [key, def] of Object.entries(THRESHOLDS)) {
+      expect(def.tier, `${key} missing tier`).toBeDefined();
+    }
+  });
+
+  it('every threshold has a panel assignment', () => {
+    for (const [key, def] of Object.entries(THRESHOLDS)) {
+      expect(def.panel, `${key} missing panel`).toBeDefined();
+    }
+  });
+
+  it('outcome panel contains Tier 1 oximetry metrics', () => {
+    const outcomeKeys = getThresholdKeysByPanel('outcome');
+    expect(outcomeKeys).toContain('odi3');
+    expect(outcomeKeys).toContain('spo2Mean');
+    expect(outcomeKeys).toContain('hrClin10');
+    expect(outcomeKeys).toContain('tBelow94');
+  });
+
+  it('pattern panel contains Tier 2 proxy metrics', () => {
+    const patternKeys = getThresholdKeysByPanel('pattern');
+    expect(patternKeys).toContain('iflRisk');
+    expect(patternKeys).toContain('nedMean');
+    expect(patternKeys).toContain('reraIndex');
+    expect(patternKeys).toContain('eai');
+  });
+
+  it('context panel contains Tier 3 metrics', () => {
+    const contextKeys = getThresholdKeysByPanel('context');
+    expect(contextKeys).toContain('glasgowOverall');
+    expect(contextKeys).toContain('watFL');
+    expect(contextKeys).toContain('watRegularity');
+  });
+
+  it('device panel contains machine and settings metrics', () => {
+    const deviceKeys = getThresholdKeysByPanel('device');
+    expect(deviceKeys).toContain('machineAhi');
+    expect(deviceKeys).toContain('leak95');
+    expect(deviceKeys).toContain('settingsTriggerDelay');
+  });
+
+  it('machineAhi is Tier 1-asym (alarm-only)', () => {
+    expect(THRESHOLDS.machineAhi!.tier).toBe('1-asym');
+  });
+
+  it('getMetricPanel returns correct panel', () => {
+    expect(getMetricPanel('odi3')).toBe('outcome');
+    expect(getMetricPanel('nedMean')).toBe('pattern');
+    expect(getMetricPanel('glasgowOverall')).toBe('context');
+    expect(getMetricPanel('machineAhi')).toBe('device');
+  });
+
+  it('getMetricPanel returns null for unknown key', () => {
+    expect(getMetricPanel('nonexistent')).toBeNull();
+  });
+
+  it('isProxyMetric identifies Tier 2/3 correctly', () => {
+    expect(isProxyMetric('iflRisk')).toBe(true);
+    expect(isProxyMetric('nedMean')).toBe(true);
+    expect(isProxyMetric('glasgowOverall')).toBe(true);
+    expect(isProxyMetric('odi3')).toBe(false);
+    expect(isProxyMetric('machineAhi')).toBe(false);
+  });
+
+  it('all four panels have labels and descriptions', () => {
+    const panels: MetricPanel[] = ['outcome', 'pattern', 'context', 'device'];
+    for (const panel of panels) {
+      expect(PANEL_LABELS[panel]).toBeTruthy();
+      expect(PANEL_DESCRIPTIONS[panel]).toBeTruthy();
+    }
+  });
+
+  it('no threshold key is unclassified (panel covers all)', () => {
+    const allPanelKeys = new Set([
+      ...getThresholdKeysByPanel('outcome'),
+      ...getThresholdKeysByPanel('pattern'),
+      ...getThresholdKeysByPanel('context'),
+      ...getThresholdKeysByPanel('device'),
+    ]);
+    const allKeys = Object.keys(THRESHOLDS);
+    expect(allPanelKeys.size).toBe(allKeys.length);
   });
 });

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -671,9 +671,9 @@ function trendInsights(
   } else if (iflTrend === 'worsening') {
     insights.push({
       id: 'trend-ifl-worsening',
-      type: 'actionable',
+      type: 'info',
       title: 'IFL Symptom Risk trending upward',
-      body: `Your flow limitation composite is increasing over ${nights.length} nights (${fmt(iflVals[0]!)}% \u2192 ${fmt(iflVals[iflVals.length - 1]!)}%). An upward trend in flow limitation metrics was observed across this period.`,
+      body: `Your flow limitation composite is increasing over ${nights.length} nights (${fmt(iflVals[0]!)}% \u2192 ${fmt(iflVals[iflVals.length - 1]!)}%). This proxy composite is trending higher. Check outcome metrics (ODI, SpO₂) for whether this pattern is reflected in direct measurements.`,
       category: 'trend',
     });
   }
@@ -690,11 +690,30 @@ function trendInsights(
   } else if (gTrend === 'worsening') {
     insights.push({
       id: 'trend-glasgow-worsening',
-      type: 'actionable',
+      type: 'info',
       title: 'Glasgow Index trending upward',
-      body: `Flow limitation is increasing over ${nights.length} nights (${fmt(glasgowVals[0]!)} → ${fmt(glasgowVals[glasgowVals.length - 1]!)}). Review flow waveforms alongside this trend for context.`,
+      body: `Flow limitation is increasing over ${nights.length} nights (${fmt(glasgowVals[0]!)} → ${fmt(glasgowVals[glasgowVals.length - 1]!)}). This context-tier metric is trending higher. It reflects flow shape patterns, not direct outcomes.`,
       category: 'trend',
     });
+  }
+
+  // Proxy-outcome divergence: Tier 2 proxy adverse but Tier 1 outcome stable
+  const nedVals = chrono.map((n) => n.ned.nedMean);
+  const nedTrend = trendLowerBetter(nedVals);
+  const proxyAdverse = iflTrend === 'worsening' || nedTrend === 'worsening';
+  const oximetryNights = chrono.filter((n) => n.oximetry != null);
+  if (proxyAdverse && oximetryNights.length >= 3) {
+    const odiVals = oximetryNights.map((n) => n.oximetry!.odi3);
+    const odiTrend = trendLowerBetter(odiVals);
+    if (odiTrend === 'stable' || odiTrend === 'improving') {
+      insights.push({
+        id: 'proxy-outcome-divergence',
+        type: 'info',
+        title: 'Pattern metrics trending differently from outcome metrics',
+        body: `Your flow limitation proxy metrics are trending higher, but your direct outcome measurements (ODI, SpO₂) remain stable. This divergence is common and does not necessarily indicate a problem — your clinician can help interpret these findings in context.`,
+        category: 'trend',
+      });
+    }
   }
 
   // Therapy change impact

--- a/lib/thresholds.ts
+++ b/lib/thresholds.ts
@@ -1,56 +1,72 @@
 // Traffic light thresholds: [greenMax, amberMax] — above amberMax is red
 // Lower-is-better metrics (default)
+
+import type { MetricTier } from './metric-registry';
+
+/**
+ * UI panel grouping derived from metric tiers.
+ * - outcome: Tier 1 direct measurements (ODI, SpO₂, machine AHI)
+ * - pattern: Tier 2 reliable proxies (NED, RERA, IFL composite)
+ * - context: Tier 3 contextual indicators (Glasgow, WAT)
+ * - device:  Machine-reported and settings metrics
+ */
+export type MetricPanel = 'outcome' | 'pattern' | 'context' | 'device';
+
 export type ThresholdDef = {
   green: number;
   amber: number;
   lowerIsBetter: boolean;
+  tier?: MetricTier;
+  panel?: MetricPanel;
 };
 
 export const THRESHOLDS: Record<string, ThresholdDef> = {
-  iflRisk: { green: 20, amber: 45, lowerIsBetter: true },
-  glasgowOverall: { green: 1.0, amber: 2.0, lowerIsBetter: true },
-  nedMean: { green: 15, amber: 25, lowerIsBetter: true },
-  nedP95: { green: 30, amber: 50, lowerIsBetter: true },
-  nedClearFL: { green: 2, amber: 5, lowerIsBetter: true },
-  combinedFL: { green: 20, amber: 40, lowerIsBetter: true },
-  reraIndex: { green: 5, amber: 10, lowerIsBetter: true },
-  watFL: { green: 30, amber: 50, lowerIsBetter: true },
-  watRegularity: { green: 30, amber: 50, lowerIsBetter: true },
-  watPeriodicity: { green: 20, amber: 40, lowerIsBetter: true },
-  eai: { green: 5, amber: 10, lowerIsBetter: true },
-  hrClin10: { green: 10, amber: 20, lowerIsBetter: true },
-  odi3: { green: 5, amber: 15, lowerIsBetter: true },
-  odi4: { green: 3, amber: 10, lowerIsBetter: true },
-  tBelow90: { green: 5, amber: 15, lowerIsBetter: true },
-  tBelow94: { green: 10, amber: 30, lowerIsBetter: true },
-  spo2Mean: { green: 95, amber: 92, lowerIsBetter: false },
-  briefObstructionIndex: { green: 3, amber: 6, lowerIsBetter: true },
-  hypopneaIndex: { green: 2, amber: 5, lowerIsBetter: true },
-  amplitudeCv: { green: 20, amber: 30, lowerIsBetter: true },
-  unstableEpochPct: { green: 15, amber: 25, lowerIsBetter: true },
+  // ---------- Pattern metrics (Tier 2 — reliable proxies) ----------
+  iflRisk: { green: 20, amber: 45, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  nedMean: { green: 15, amber: 25, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  nedP95: { green: 30, amber: 50, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  nedClearFL: { green: 2, amber: 5, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  combinedFL: { green: 20, amber: 40, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  reraIndex: { green: 5, amber: 10, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  eai: { green: 5, amber: 10, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  briefObstructionIndex: { green: 3, amber: 6, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  hypopneaIndex: { green: 2, amber: 5, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  amplitudeCv: { green: 20, amber: 30, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  unstableEpochPct: { green: 15, amber: 25, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  estimatedRdi: { green: 5, amber: 15, lowerIsBetter: true, tier: 2, panel: 'pattern' },
 
-  estimatedRdi: { green: 5, amber: 15, lowerIsBetter: true },
+  // ---------- Context metrics (Tier 3 — contextual indicators) ----------
+  glasgowOverall: { green: 1.0, amber: 2.0, lowerIsBetter: true, tier: 3, panel: 'context' },
+  watFL: { green: 30, amber: 50, lowerIsBetter: true, tier: 3, panel: 'context' },
+  watRegularity: { green: 30, amber: 50, lowerIsBetter: true, tier: 3, panel: 'context' },
+  watPeriodicity: { green: 20, amber: 40, lowerIsBetter: true, tier: 3, panel: 'context' },
 
-  // Settings validation thresholds (BiPAP)
-  settingsTriggerDelay: { green: 300, amber: 500, lowerIsBetter: true },
-  settingsAutoTrigger: { green: 2, amber: 5, lowerIsBetter: true },
-  settingsTi: { green: 1200, amber: 1000, lowerIsBetter: false },
-  settingsIeRatio: { green: 1.2, amber: 1.0, lowerIsBetter: false },
-  settingsTimeAtIpap: { green: 600, amber: 400, lowerIsBetter: false },
-  settingsIpapDwell: { green: 45, amber: 35, lowerIsBetter: false },
-  settingsPrematureCycle: { green: 2, amber: 10, lowerIsBetter: true },
-  settingsLateCycle: { green: 2, amber: 10, lowerIsBetter: true },
-  settingsVtCv: { green: 25, amber: 30, lowerIsBetter: true },
-  settingsEpapDelta: { green: 0.5, amber: 1.0, lowerIsBetter: true },
+  // ---------- Outcome metrics (Tier 1 — direct measurements) ----------
+  hrClin10: { green: 10, amber: 20, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  odi3: { green: 5, amber: 15, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  odi4: { green: 3, amber: 10, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  tBelow90: { green: 5, amber: 15, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  tBelow94: { green: 10, amber: 30, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  spo2Mean: { green: 95, amber: 92, lowerIsBetter: false, tier: 1, panel: 'outcome' },
+  couplingPct: { green: 30, amber: 50, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  h2CouplingGap: { green: 10, amber: 25, lowerIsBetter: true, tier: 1, panel: 'outcome' },
 
-  // Cross-device RERA-arousal matching
-  couplingPct: { green: 30, amber: 50, lowerIsBetter: true },
-  h2CouplingGap: { green: 10, amber: 25, lowerIsBetter: true },
+  // ---------- Device metrics (Tier 1-asym / Tier 3) ----------
+  machineAhi: { green: 5, amber: 10, lowerIsBetter: true, tier: '1-asym', panel: 'device' },
+  leak95: { green: 24, amber: 40, lowerIsBetter: true, tier: 3, panel: 'device' },
+  spontCycPct: { green: 80, amber: 60, lowerIsBetter: false, tier: 3, panel: 'device' },
 
-  // Machine-reported summary stats
-  machineAhi: { green: 5, amber: 10, lowerIsBetter: true },
-  leak95: { green: 24, amber: 40, lowerIsBetter: true },
-  spontCycPct: { green: 80, amber: 60, lowerIsBetter: false },
+  // ---------- Settings validation thresholds (BiPAP) ----------
+  settingsTriggerDelay: { green: 300, amber: 500, lowerIsBetter: true, tier: 3, panel: 'device' },
+  settingsAutoTrigger: { green: 2, amber: 5, lowerIsBetter: true, tier: 3, panel: 'device' },
+  settingsTi: { green: 1200, amber: 1000, lowerIsBetter: false, tier: 3, panel: 'device' },
+  settingsIeRatio: { green: 1.2, amber: 1.0, lowerIsBetter: false, tier: 3, panel: 'device' },
+  settingsTimeAtIpap: { green: 600, amber: 400, lowerIsBetter: false, tier: 3, panel: 'device' },
+  settingsIpapDwell: { green: 45, amber: 35, lowerIsBetter: false, tier: 3, panel: 'device' },
+  settingsPrematureCycle: { green: 2, amber: 10, lowerIsBetter: true, tier: 3, panel: 'device' },
+  settingsLateCycle: { green: 2, amber: 10, lowerIsBetter: true, tier: 3, panel: 'device' },
+  settingsVtCv: { green: 25, amber: 30, lowerIsBetter: true, tier: 3, panel: 'device' },
+  settingsEpapDelta: { green: 0.5, amber: 1.0, lowerIsBetter: true, tier: 3, panel: 'device' },
 };
 
 export type TrafficLight = 'good' | 'warn' | 'bad';
@@ -90,3 +106,37 @@ export function getTrafficDotColor(light: TrafficLight): string {
     case 'bad': return 'bg-red-500';
   }
 }
+
+/** Get all threshold keys belonging to a specific panel group */
+export function getThresholdKeysByPanel(panel: MetricPanel): string[] {
+  return Object.entries(THRESHOLDS)
+    .filter(([, def]) => def.panel === panel)
+    .map(([key]) => key);
+}
+
+/** Get the panel group for a threshold key */
+export function getMetricPanel(key: string): MetricPanel | null {
+  return THRESHOLDS[key]?.panel ?? null;
+}
+
+/** Check if a metric is a proxy (Tier 2/3) rather than a direct outcome (Tier 1) */
+export function isProxyMetric(key: string): boolean {
+  const tier = THRESHOLDS[key]?.tier;
+  return tier === 2 || tier === 3;
+}
+
+/** Panel display labels for UI headings */
+export const PANEL_LABELS: Record<MetricPanel, string> = {
+  outcome: 'Outcome Metrics',
+  pattern: 'Pattern Metrics',
+  context: 'Context Metrics',
+  device: 'Device Metrics',
+};
+
+/** Panel descriptions for UI subheadings */
+export const PANEL_DESCRIPTIONS: Record<MetricPanel, string> = {
+  outcome: 'Direct measurements from oximetry and machine data',
+  pattern: 'Reliable proxy indicators from breath-by-breath analysis',
+  context: 'Contextual flow shape indicators — interpret alongside outcome metrics',
+  device: 'Machine-reported statistics and settings validation',
+};


### PR DESCRIPTION
## Summary

- Replace if-guard patterns with explicit assertions in trend insight tests
- Use info type and directional language for proxy metric trend insights
- Ensures MDR compliance: no therapeutic recommendations, no diagnostic claims
- 137 lines of new insight tests + improvements to existing trend test patterns

## Files changed

- `lib/insights.ts` — directional language for proxy metric trends
- `__tests__/insights.test.ts` — new trend divergence tests
- `lib/thresholds.ts` — metric tier hierarchy (shared with AIR-535)
- `__tests__/thresholds.test.ts` — tier tests (shared with AIR-535)

## Note

This branch builds on feat/air-535-metric-tier-hierarchy. Merge AIR-535 first.

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] PR contains one concern only
- [x] Self-review: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)