### PR TITLE
fix: align blog, about, and glossary copy with content guidelines (AIR-479)

### DIFF
--- a/app/about/glasgow-index/page.tsx
+++ b/app/about/glasgow-index/page.tsx
@@ -77,7 +77,7 @@ const components = [
   {
     name: 'Spike',
     description:
-      'Detects sharp transient peaks at the beginning of inspiration. A brief spike followed by reduced flow suggests the airway briefly opens then narrows, a hallmark of partial obstruction.',
+      'Detects sharp transient peaks at the beginning of inspiration. A brief spike followed by reduced flow shows a pattern where the waveform briefly opens then narrows.',
   },
   {
     name: 'Flat Top',
@@ -92,22 +92,22 @@ const components = [
   {
     name: 'Multi-Peak',
     description:
-      'Detects oscillatory flow patterns with multiple peaks during a single inspiration. Multi-peak patterns suggest upper airway instability and flutter, often seen with moderate flow limitation.',
+      'Detects oscillatory flow patterns with multiple peaks during a single inspiration. Multi-peak patterns show oscillation in the flow waveform, often seen with moderate flow limitation.',
   },
   {
     name: 'No Pause',
     description:
-      'Assesses whether there is an adequate pause between expiration and the next inspiration. Absent pauses can indicate increased respiratory drive, often a compensatory response to flow limitation.',
+      'Assesses whether there is an adequate pause between expiration and the next inspiration. Absent pauses are associated with higher respiratory rate, often a compensatory response to flow limitation.',
   },
   {
     name: 'Inspiratory Rate',
     description:
-      'Evaluates the peak inspiratory flow rate relative to the breath population. Abnormally high rates suggest increased respiratory effort to overcome airway resistance.',
+      'Evaluates the peak inspiratory flow rate relative to the breath population. Abnormally high rates may reflect higher respiratory rate.',
   },
   {
     name: 'Multi-Breath',
     description:
-      'Detects sequences of breaths with progressively worsening flow limitation characteristics, suggesting a crescendo pattern that may precede an arousal or obstructive event.',
+      'Detects sequences of breaths with progressively worsening flow limitation characteristics, showing a crescendo pattern in the waveform.',
   },
   {
     name: 'Variable Amplitude',

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -160,7 +160,7 @@ const engines = [
     methodology: [
       'NED = (Qpeak \u2212 Qmid) / Qpeak, where Qpeak is peak inspiratory flow and Qmid is flow at 50% of inspiratory time. Higher NED indicates more flow limitation.',
       'Flatness Index (FI) measures how flat the inspiratory flow plateau is. FI \u2265 0.85 indicates significant flow limitation.',
-      'M-shape detection identifies breaths with a characteristic mid-inspiratory dip suggesting upper airway oscillation.',
+      'M-shape detection identifies breaths with a characteristic mid-inspiratory dip showing oscillation in the flow waveform.',
       'RERA detection: sequences of \u22653 breaths with progressively rising NED slope, terminated by a recovery breath with sudden NED drop. Reported as events per hour.',
     ],
     reference: 'NED concept from Tamisier et al. RERA detection adapted from clinical scoring criteria.',

--- a/app/blog/posts/arousals-vs-flow-limitation.tsx
+++ b/app/blog/posts/arousals-vs-flow-limitation.tsx
@@ -35,7 +35,7 @@ export default function ArousalsVsFlowLimitationPost() {
           </p>
           <p>
             In this model, the arousal is the pivot point. It&apos;s the thing that breaks
-            your sleep. Treatment success means fewer arousals.
+            your sleep. Fewer arousals is one metric clinicians track.
           </p>
           <p>
             This model works well for severe obstructive sleep apnea. But at the milder end
@@ -71,7 +71,7 @@ export default function ArousalsVsFlowLimitationPost() {
               </p>
             </div>
             <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
-              <p className="text-sm font-semibold text-amber-400">3. Flow Limitation Predicts Symptoms After Controlling for Arousals</p>
+              <p className="text-sm font-semibold text-amber-400">3. Flow Limitation Associated With Symptoms After Controlling for Arousals</p>
               <p className="mt-1 text-xs text-muted-foreground">
                 The 2024 Mann et al. study found that inspiratory flow limitation predicted
                 excessive daytime sleepiness in people with AHI below 15, and this

--- a/app/blog/posts/flow-limitation-and-sleepiness.tsx
+++ b/app/blog/posts/flow-limitation-and-sleepiness.tsx
@@ -80,7 +80,7 @@ export default function FlowLimitationAndSleepinessPost() {
       <section className="mt-10">
         <div className="flex items-center gap-2.5">
           <Wind className="h-5 w-5 text-emerald-400" />
-          <h2 className="text-xl font-bold sm:text-2xl">Flow Limitation Predicts Sleepiness After Controlling for Arousals</h2>
+          <h2 className="text-xl font-bold sm:text-2xl">Flow Limitation Associated With Sleepiness After Controlling for Arousals</h2>
         </div>
         <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
           <p>

--- a/app/blog/posts/hidden-respiratory-events.tsx
+++ b/app/blog/posts/hidden-respiratory-events.tsx
@@ -14,7 +14,7 @@ export default function HiddenRespiratoryEventsPost() {
     <article>
       <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
         Your AHI is 2. Your RERA index is under 5. Your NED analysis shows normal breath shapes.
-        By every standard metric, your PAP therapy is working. But your oximetry tells a different
+        By every standard metric, your numbers look typical. But your oximetry tells a different
         story: ODI of 10, heart rate surges all night, coupled desaturation events every few minutes.{' '}
         <strong className="text-foreground">
           Something is disrupting your sleep that none of the standard metrics can see.

--- a/app/blog/posts/understanding-flow-limitation.tsx
+++ b/app/blog/posts/understanding-flow-limitation.tsx
@@ -409,8 +409,7 @@ export default function UnderstandingFlowLimitationPost() {
             <div className="rounded-xl border border-border/50 p-4">
               <p className="text-sm font-semibold text-foreground">Glasgow Index trend</p>
               <p className="mt-1 text-xs text-muted-foreground">
-                Stable, improving, or elevated over time? Consistently elevated values suggest
-                your airway may be partially narrowing during sleep.
+                Stable, improving, or elevated over time? Consistently elevated values are above the typical range for this metric.
               </p>
             </div>
             <div className="rounded-xl border border-border/50 p-4">
@@ -422,8 +421,7 @@ export default function UnderstandingFlowLimitationPost() {
             <div className="rounded-xl border border-border/50 p-4">
               <p className="text-sm font-semibold text-foreground">Estimated RERA count</p>
               <p className="mt-1 text-xs text-muted-foreground">
-                A high count suggests frequent brief arousals that may be fragmenting sleep
-                architecture without affecting AHI.
+                A high count is above the typical range. This metric is independent of AHI.
               </p>
             </div>
             <div className="rounded-xl border border-border/50 p-4">

--- a/app/glossary/page.tsx
+++ b/app/glossary/page.tsx
@@ -201,7 +201,7 @@ export default function GlossaryPage() {
             className="group rounded-lg border border-border/50 bg-card/30 p-4 transition-all hover:border-primary/30"
           >
             <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">Flow Limitation</h3>
-            <p className="mt-1 text-xs text-muted-foreground">How AirwayLab detects and scores airway restriction.</p>
+            <p className="mt-1 text-xs text-muted-foreground">How AirwayLab quantifies and scores airway restriction patterns.</p>
           </Link>
           <Link
             href="/about/glasgow-index"


### PR DESCRIPTION
## Summary

- Remove 13 MUST MDR violations across blog posts, about page, and glossary
- Board-approved batch merge (AIR-545)

🤖 Generated with [Claude Code](https://claude.com/claude-code)