### PR TITLE
feat(thresholds): add metric tier hierarchy to ThresholdDef (AIR-535)

### DIFF
--- a/__tests__/thresholds.test.ts
+++ b/__tests__/thresholds.test.ts
@@ -4,8 +4,14 @@ import {
   getTrafficColor,
   getTrafficBg,
   getTrafficDotColor,
+  getThresholdKeysByPanel,
+  getMetricPanel,
+  isProxyMetric,
   THRESHOLDS,
+  PANEL_LABELS,
+  PANEL_DESCRIPTIONS,
   type ThresholdDef,
+  type MetricPanel,
 } from '@/lib/thresholds';
 
 describe('getTrafficLight', () => {
@@ -182,5 +188,91 @@ describe('THRESHOLDS object', () => {
         expect(def.green).toBeGreaterThanOrEqual(def.amber);
       }
     }
+  });
+});
+
+describe('metric tier hierarchy', () => {
+  it('every threshold has a tier assignment', () => {
+    for (const [key, def] of Object.entries(THRESHOLDS)) {
+      expect(def.tier, `${key} missing tier`).toBeDefined();
+    }
+  });
+
+  it('every threshold has a panel assignment', () => {
+    for (const [key, def] of Object.entries(THRESHOLDS)) {
+      expect(def.panel, `${key} missing panel`).toBeDefined();
+    }
+  });
+
+  it('outcome panel contains Tier 1 oximetry metrics', () => {
+    const outcomeKeys = getThresholdKeysByPanel('outcome');
+    expect(outcomeKeys).toContain('odi3');
+    expect(outcomeKeys).toContain('spo2Mean');
+    expect(outcomeKeys).toContain('hrClin10');
+    expect(outcomeKeys).toContain('tBelow94');
+  });
+
+  it('pattern panel contains Tier 2 proxy metrics', () => {
+    const patternKeys = getThresholdKeysByPanel('pattern');
+    expect(patternKeys).toContain('iflRisk');
+    expect(patternKeys).toContain('nedMean');
+    expect(patternKeys).toContain('reraIndex');
+    expect(patternKeys).toContain('eai');
+  });
+
+  it('context panel contains Tier 3 metrics', () => {
+    const contextKeys = getThresholdKeysByPanel('context');
+    expect(contextKeys).toContain('glasgowOverall');
+    expect(contextKeys).toContain('watFL');
+    expect(contextKeys).toContain('watRegularity');
+  });
+
+  it('device panel contains machine and settings metrics', () => {
+    const deviceKeys = getThresholdKeysByPanel('device');
+    expect(deviceKeys).toContain('machineAhi');
+    expect(deviceKeys).toContain('leak95');
+    expect(deviceKeys).toContain('settingsTriggerDelay');
+  });
+
+  it('machineAhi is Tier 1-asym (alarm-only)', () => {
+    expect(THRESHOLDS.machineAhi!.tier).toBe('1-asym');
+  });
+
+  it('getMetricPanel returns correct panel', () => {
+    expect(getMetricPanel('odi3')).toBe('outcome');
+    expect(getMetricPanel('nedMean')).toBe('pattern');
+    expect(getMetricPanel('glasgowOverall')).toBe('context');
+    expect(getMetricPanel('machineAhi')).toBe('device');
+  });
+
+  it('getMetricPanel returns null for unknown key', () => {
+    expect(getMetricPanel('nonexistent')).toBeNull();
+  });
+
+  it('isProxyMetric identifies Tier 2/3 correctly', () => {
+    expect(isProxyMetric('iflRisk')).toBe(true);
+    expect(isProxyMetric('nedMean')).toBe(true);
+    expect(isProxyMetric('glasgowOverall')).toBe(true);
+    expect(isProxyMetric('odi3')).toBe(false);
+    expect(isProxyMetric('machineAhi')).toBe(false);
+  });
+
+  it('all four panels have labels and descriptions', () => {
+    const panels: MetricPanel[] = ['outcome', 'pattern', 'context', 'device'];
+    for (const panel of panels) {
+      expect(PANEL_LABELS[panel]).toBeTruthy();
+      expect(PANEL_DESCRIPTIONS[panel]).toBeTruthy();
+    }
+  });
+
+  it('no threshold key is unclassified (panel covers all)', () => {
+    const allPanelKeys = new Set([
+      ...getThresholdKeysByPanel('outcome'),
+      ...getThresholdKeysByPanel('pattern'),
+      ...getThresholdKeysByPanel('context'),
+      ...getThresholdKeysByPanel('device'),
+    ]);
+    const allKeys = Object.keys(THRESHOLDS);
+    expect(allPanelKeys.size).toBe(allKeys.length);
   });
 });

--- a/lib/thresholds.ts
+++ b/lib/thresholds.ts
@@ -1,56 +1,72 @@
 // Traffic light thresholds: [greenMax, amberMax] — above amberMax is red
 // Lower-is-better metrics (default)
+
+import type { MetricTier } from './metric-registry';
+
+/**
+ * UI panel grouping derived from metric tiers.
+ * - outcome: Tier 1 direct measurements (ODI, SpO₂, machine AHI)
+ * - pattern: Tier 2 reliable proxies (NED, RERA, IFL composite)
+ * - context: Tier 3 contextual indicators (Glasgow, WAT)
+ * - device:  Machine-reported and settings metrics
+ */
+export type MetricPanel = 'outcome' | 'pattern' | 'context' | 'device';
+
 export type ThresholdDef = {
   green: number;
   amber: number;
   lowerIsBetter: boolean;
+  tier?: MetricTier;
+  panel?: MetricPanel;
 };
 
 export const THRESHOLDS: Record<string, ThresholdDef> = {
-  iflRisk: { green: 20, amber: 45, lowerIsBetter: true },
-  glasgowOverall: { green: 1.0, amber: 2.0, lowerIsBetter: true },
-  nedMean: { green: 15, amber: 25, lowerIsBetter: true },
-  nedP95: { green: 30, amber: 50, lowerIsBetter: true },
-  nedClearFL: { green: 2, amber: 5, lowerIsBetter: true },
-  combinedFL: { green: 20, amber: 40, lowerIsBetter: true },
-  reraIndex: { green: 5, amber: 10, lowerIsBetter: true },
-  watFL: { green: 30, amber: 50, lowerIsBetter: true },
-  watRegularity: { green: 30, amber: 50, lowerIsBetter: true },
-  watPeriodicity: { green: 20, amber: 40, lowerIsBetter: true },
-  eai: { green: 5, amber: 10, lowerIsBetter: true },
-  hrClin10: { green: 10, amber: 20, lowerIsBetter: true },
-  odi3: { green: 5, amber: 15, lowerIsBetter: true },
-  odi4: { green: 3, amber: 10, lowerIsBetter: true },
-  tBelow90: { green: 5, amber: 15, lowerIsBetter: true },
-  tBelow94: { green: 10, amber: 30, lowerIsBetter: true },
-  spo2Mean: { green: 95, amber: 92, lowerIsBetter: false },
-  briefObstructionIndex: { green: 3, amber: 6, lowerIsBetter: true },
-  hypopneaIndex: { green: 2, amber: 5, lowerIsBetter: true },
-  amplitudeCv: { green: 20, amber: 30, lowerIsBetter: true },
-  unstableEpochPct: { green: 15, amber: 25, lowerIsBetter: true },
+  // ---------- Pattern metrics (Tier 2 — reliable proxies) ----------
+  iflRisk: { green: 20, amber: 45, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  nedMean: { green: 15, amber: 25, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  nedP95: { green: 30, amber: 50, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  nedClearFL: { green: 2, amber: 5, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  combinedFL: { green: 20, amber: 40, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  reraIndex: { green: 5, amber: 10, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  eai: { green: 5, amber: 10, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  briefObstructionIndex: { green: 3, amber: 6, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  hypopneaIndex: { green: 2, amber: 5, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  amplitudeCv: { green: 20, amber: 30, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  unstableEpochPct: { green: 15, amber: 25, lowerIsBetter: true, tier: 2, panel: 'pattern' },
+  estimatedRdi: { green: 5, amber: 15, lowerIsBetter: true, tier: 2, panel: 'pattern' },
 
-  estimatedRdi: { green: 5, amber: 15, lowerIsBetter: true },
+  // ---------- Context metrics (Tier 3 — contextual indicators) ----------
+  glasgowOverall: { green: 1.0, amber: 2.0, lowerIsBetter: true, tier: 3, panel: 'context' },
+  watFL: { green: 30, amber: 50, lowerIsBetter: true, tier: 3, panel: 'context' },
+  watRegularity: { green: 30, amber: 50, lowerIsBetter: true, tier: 3, panel: 'context' },
+  watPeriodicity: { green: 20, amber: 40, lowerIsBetter: true, tier: 3, panel: 'context' },
 
-  // Settings validation thresholds (BiPAP)
-  settingsTriggerDelay: { green: 300, amber: 500, lowerIsBetter: true },
-  settingsAutoTrigger: { green: 2, amber: 5, lowerIsBetter: true },
-  settingsTi: { green: 1200, amber: 1000, lowerIsBetter: false },
-  settingsIeRatio: { green: 1.2, amber: 1.0, lowerIsBetter: false },
-  settingsTimeAtIpap: { green: 600, amber: 400, lowerIsBetter: false },
-  settingsIpapDwell: { green: 45, amber: 35, lowerIsBetter: false },
-  settingsPrematureCycle: { green: 2, amber: 10, lowerIsBetter: true },
-  settingsLateCycle: { green: 2, amber: 10, lowerIsBetter: true },
-  settingsVtCv: { green: 25, amber: 30, lowerIsBetter: true },
-  settingsEpapDelta: { green: 0.5, amber: 1.0, lowerIsBetter: true },
+  // ---------- Outcome metrics (Tier 1 — direct measurements) ----------
+  hrClin10: { green: 10, amber: 20, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  odi3: { green: 5, amber: 15, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  odi4: { green: 3, amber: 10, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  tBelow90: { green: 5, amber: 15, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  tBelow94: { green: 10, amber: 30, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  spo2Mean: { green: 95, amber: 92, lowerIsBetter: false, tier: 1, panel: 'outcome' },
+  couplingPct: { green: 30, amber: 50, lowerIsBetter: true, tier: 1, panel: 'outcome' },
+  h2CouplingGap: { green: 10, amber: 25, lowerIsBetter: true, tier: 1, panel: 'outcome' },
 
-  // Cross-device RERA-arousal matching
-  couplingPct: { green: 30, amber: 50, lowerIsBetter: true },
-  h2CouplingGap: { green: 10, amber: 25, lowerIsBetter: true },
+  // ---------- Device metrics (Tier 1-asym / Tier 3) ----------
+  machineAhi: { green: 5, amber: 10, lowerIsBetter: true, tier: '1-asym', panel: 'device' },
+  leak95: { green: 24, amber: 40, lowerIsBetter: true, tier: 3, panel: 'device' },
+  spontCycPct: { green: 80, amber: 60, lowerIsBetter: false, tier: 3, panel: 'device' },
 
-  // Machine-reported summary stats
-  machineAhi: { green: 5, amber: 10, lowerIsBetter: true },
-  leak95: { green: 24, amber: 40, lowerIsBetter: true },
-  spontCycPct: { green: 80, amber: 60, lowerIsBetter: false },
+  // ---------- Settings validation thresholds (BiPAP) ----------
+  settingsTriggerDelay: { green: 300, amber: 500, lowerIsBetter: true, tier: 3, panel: 'device' },
+  settingsAutoTrigger: { green: 2, amber: 5, lowerIsBetter: true, tier: 3, panel: 'device' },
+  settingsTi: { green: 1200, amber: 1000, lowerIsBetter: false, tier: 3, panel: 'device' },
+  settingsIeRatio: { green: 1.2, amber: 1.0, lowerIsBetter: false, tier: 3, panel: 'device' },
+  settingsTimeAtIpap: { green: 600, amber: 400, lowerIsBetter: false, tier: 3, panel: 'device' },
+  settingsIpapDwell: { green: 45, amber: 35, lowerIsBetter: false, tier: 3, panel: 'device' },
+  settingsPrematureCycle: { green: 2, amber: 10, lowerIsBetter: true, tier: 3, panel: 'device' },
+  settingsLateCycle: { green: 2, amber: 10, lowerIsBetter: true, tier: 3, panel: 'device' },
+  settingsVtCv: { green: 25, amber: 30, lowerIsBetter: true, tier: 3, panel: 'device' },
+  settingsEpapDelta: { green: 0.5, amber: 1.0, lowerIsBetter: true, tier: 3, panel: 'device' },
 };
 
 export type TrafficLight = 'good' | 'warn' | 'bad';
@@ -90,3 +106,37 @@ export function getTrafficDotColor(light: TrafficLight): string {
     case 'bad': return 'bg-red-500';
   }
 }
+
+/** Get all threshold keys belonging to a specific panel group */
+export function getThresholdKeysByPanel(panel: MetricPanel): string[] {
+  return Object.entries(THRESHOLDS)
+    .filter(([, def]) => def.panel === panel)
+    .map(([key]) => key);
+}
+
+/** Get the panel group for a threshold key */
+export function getMetricPanel(key: string): MetricPanel | null {
+  return THRESHOLDS[key]?.panel ?? null;
+}
+
+/** Check if a metric is a proxy (Tier 2/3) rather than a direct outcome (Tier 1) */
+export function isProxyMetric(key: string): boolean {
+  const tier = THRESHOLDS[key]?.tier;
+  return tier === 2 || tier === 3;
+}
+
+/** Panel display labels for UI headings */
+export const PANEL_LABELS: Record<MetricPanel, string> = {
+  outcome: 'Outcome Metrics',
+  pattern: 'Pattern Metrics',
+  context: 'Context Metrics',
+  device: 'Device Metrics',
+};
+
+/** Panel descriptions for UI subheadings */
+export const PANEL_DESCRIPTIONS: Record<MetricPanel, string> = {
+  outcome: 'Direct measurements from oximetry and machine data',
+  pattern: 'Reliable proxy indicators from breath-by-breath analysis',
+  context: 'Contextual flow shape indicators — interpret alongside outcome metrics',
+  device: 'Machine-reported statistics and settings validation',
+};


### PR DESCRIPTION
## Summary

- Add tier field to ThresholdDef for primary/secondary/tertiary metric classification
- Phase 1 of scoring UI rearchitecture: data model only, no UI changes
- Board-approved unconditionally (AIR-545), no screenshot gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)