### PR TITLE
fix(insights): use directional language for proxy metric trends (AIR-537)

### DIFF
--- a/__tests__/insights.test.ts
+++ b/__tests__/insights.test.ts
@@ -214,9 +214,12 @@ describe('generateInsights', () => {
 
     it('IFL worsening insight uses type info, not actionable', () => {
       // newest-first: high flScore first (worsening IFL trend when reversed to chrono)
+      // Strip machineSummary + settingsMetrics so single-night info insights don't fill the 6-cap
       const makeNight = (flScore: number, dateStr: string): NightResult => ({
         ...SAMPLE_NIGHTS[0]!,
         dateStr,
+        machineSummary: null,
+        settingsMetrics: null,
         wat: { ...SAMPLE_NIGHTS[0]!.wat, flScore },
         ned: { ...SAMPLE_NIGHTS[0]!.ned, nedMean: 15 },
         oximetry: { ...SAMPLE_NIGHTS[0]!.oximetry!, odi3: 3 },
@@ -230,19 +233,22 @@ describe('generateInsights', () => {
       ];
       const result = generateInsights(nights, nights[0]!, nights[1]!, null);
       const iflWorsen = result.find((i) => i.id === 'trend-ifl-worsening');
-      if (iflWorsen) {
-        expect(iflWorsen.type).toBe('info');
-        expect(iflWorsen.body).toContain('proxy composite');
-        expect(iflWorsen.body).toContain('ODI');
-      }
+      expect(iflWorsen).toBeDefined();
+      expect(iflWorsen!.type).toBe('info');
+      expect(iflWorsen!.body).toContain('proxy composite');
+      expect(iflWorsen!.body).toContain('ODI');
     });
 
     it('Glasgow worsening insight uses type info, not actionable', () => {
+      // Strip machineSummary + settingsMetrics so single-night info insights don't fill the 6-cap
       const makeNight = (glasgow: number, dateStr: string): NightResult => ({
         ...SAMPLE_NIGHTS[0]!,
         dateStr,
+        machineSummary: null,
+        settingsMetrics: null,
         glasgow: { ...SAMPLE_NIGHTS[0]!.glasgow, overall: glasgow },
-        oximetry: { ...SAMPLE_NIGHTS[0]!.oximetry!, odi3: 3 },
+        oximetry: null,
+        oximetryTrace: null,
       });
       // newest-first: high glasgow first (worsening trend when reversed to chrono)
       const nights = [
@@ -254,11 +260,10 @@ describe('generateInsights', () => {
       ];
       const result = generateInsights(nights, nights[0]!, nights[1]!, null);
       const gWorsen = result.find((i) => i.id === 'trend-glasgow-worsening');
-      if (gWorsen) {
-        expect(gWorsen.type).toBe('info');
-        expect(gWorsen.body).toContain('context-tier metric');
-        expect(gWorsen.body).toContain('flow shape patterns');
-      }
+      expect(gWorsen).toBeDefined();
+      expect(gWorsen!.type).toBe('info');
+      expect(gWorsen!.body).toContain('context-tier metric');
+      expect(gWorsen!.body).toContain('flow shape patterns');
     });
 
     describe('proxy-outcome divergence', () => {
@@ -279,20 +284,20 @@ describe('generateInsights', () => {
 
       it('fires when IFL worsening and ODI-3 stable with ≥3 oximetry nights', () => {
         // newest-first: high IFL recently (worsening proxy), flat ODI-3 (stable outcome)
+        // Strip machineSummary + settingsMetrics so single-night info insights don't fill the 6-cap
         const nights = [
           makeOxNight(80, 15, 3.0, '2025-02-05'),
           makeOxNight(70, 14, 3.2, '2025-02-04'),
           makeOxNight(60, 14, 3.1, '2025-02-03'),
           makeOxNight(50, 13, 2.9, '2025-02-02'),
           makeOxNight(40, 13, 3.0, '2025-02-01'),
-        ];
+        ].map((n) => ({ ...n, machineSummary: null, settingsMetrics: null }));
         const result = generateInsights(nights, nights[0]!, nights[1]!, null);
         const divergence = result.find((i) => i.id === 'proxy-outcome-divergence');
-        if (divergence) {
-          expect(divergence.type).toBe('info');
-          expect(divergence.category).toBe('trend');
-          expect(divergence.body).toContain('clinician');
-        }
+        expect(divergence).toBeDefined();
+        expect(divergence!.type).toBe('info');
+        expect(divergence!.category).toBe('trend');
+        expect(divergence!.body).toContain('clinician');
       });
 
       it('does not fire when ODI-3 is also worsening', () => {

--- a/__tests__/insights.test.ts
+++ b/__tests__/insights.test.ts
@@ -211,6 +211,138 @@ describe('generateInsights', () => {
       expect(therapyInsight).toBeDefined();
       expect(therapyInsight!.type).toBe('positive');
     });
+
+    it('IFL worsening insight uses type info, not actionable', () => {
+      // newest-first: high flScore first (worsening IFL trend when reversed to chrono)
+      const makeNight = (flScore: number, dateStr: string): NightResult => ({
+        ...SAMPLE_NIGHTS[0]!,
+        dateStr,
+        wat: { ...SAMPLE_NIGHTS[0]!.wat, flScore },
+        ned: { ...SAMPLE_NIGHTS[0]!.ned, nedMean: 15 },
+        oximetry: { ...SAMPLE_NIGHTS[0]!.oximetry!, odi3: 3 },
+      });
+      const nights = [
+        makeNight(80, '2025-02-05'),
+        makeNight(70, '2025-02-04'),
+        makeNight(60, '2025-02-03'),
+        makeNight(50, '2025-02-02'),
+        makeNight(40, '2025-02-01'),
+      ];
+      const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+      const iflWorsen = result.find((i) => i.id === 'trend-ifl-worsening');
+      if (iflWorsen) {
+        expect(iflWorsen.type).toBe('info');
+        expect(iflWorsen.body).toContain('proxy composite');
+        expect(iflWorsen.body).toContain('ODI');
+      }
+    });
+
+    it('Glasgow worsening insight uses type info, not actionable', () => {
+      const makeNight = (glasgow: number, dateStr: string): NightResult => ({
+        ...SAMPLE_NIGHTS[0]!,
+        dateStr,
+        glasgow: { ...SAMPLE_NIGHTS[0]!.glasgow, overall: glasgow },
+        oximetry: { ...SAMPLE_NIGHTS[0]!.oximetry!, odi3: 3 },
+      });
+      // newest-first: high glasgow first (worsening trend when reversed to chrono)
+      const nights = [
+        makeNight(3.5, '2025-02-05'),
+        makeNight(3.0, '2025-02-04'),
+        makeNight(2.5, '2025-02-03'),
+        makeNight(2.0, '2025-02-02'),
+        makeNight(1.5, '2025-02-01'),
+      ];
+      const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+      const gWorsen = result.find((i) => i.id === 'trend-glasgow-worsening');
+      if (gWorsen) {
+        expect(gWorsen.type).toBe('info');
+        expect(gWorsen.body).toContain('context-tier metric');
+        expect(gWorsen.body).toContain('flow shape patterns');
+      }
+    });
+
+    describe('proxy-outcome divergence', () => {
+      function makeOxNight(
+        flScore: number,
+        nedMean: number,
+        odi3: number,
+        dateStr: string,
+      ): NightResult {
+        return {
+          ...SAMPLE_NIGHTS[0]!,
+          dateStr,
+          wat: { ...SAMPLE_NIGHTS[0]!.wat, flScore },
+          ned: { ...SAMPLE_NIGHTS[0]!.ned, nedMean },
+          oximetry: { ...SAMPLE_NIGHTS[0]!.oximetry!, odi3 },
+        };
+      }
+
+      it('fires when IFL worsening and ODI-3 stable with ≥3 oximetry nights', () => {
+        // newest-first: high IFL recently (worsening proxy), flat ODI-3 (stable outcome)
+        const nights = [
+          makeOxNight(80, 15, 3.0, '2025-02-05'),
+          makeOxNight(70, 14, 3.2, '2025-02-04'),
+          makeOxNight(60, 14, 3.1, '2025-02-03'),
+          makeOxNight(50, 13, 2.9, '2025-02-02'),
+          makeOxNight(40, 13, 3.0, '2025-02-01'),
+        ];
+        const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+        const divergence = result.find((i) => i.id === 'proxy-outcome-divergence');
+        if (divergence) {
+          expect(divergence.type).toBe('info');
+          expect(divergence.category).toBe('trend');
+          expect(divergence.body).toContain('clinician');
+        }
+      });
+
+      it('does not fire when ODI-3 is also worsening', () => {
+        const nights = [
+          makeOxNight(80, 15, 8.0, '2025-02-05'),
+          makeOxNight(70, 14, 7.0, '2025-02-04'),
+          makeOxNight(60, 14, 6.0, '2025-02-03'),
+          makeOxNight(50, 13, 5.0, '2025-02-02'),
+          makeOxNight(40, 13, 4.0, '2025-02-01'),
+        ];
+        const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+        const divergence = result.find((i) => i.id === 'proxy-outcome-divergence');
+        expect(divergence).toBeUndefined();
+      });
+
+      it('does not fire when fewer than 3 nights have oximetry', () => {
+        const makeNoOxNight = (flScore: number, dateStr: string): NightResult => ({
+          ...SAMPLE_NIGHTS[0]!,
+          dateStr,
+          wat: { ...SAMPLE_NIGHTS[0]!.wat, flScore },
+          ned: { ...SAMPLE_NIGHTS[0]!.ned, nedMean: 15 },
+          oximetry: null,
+          oximetryTrace: null,
+        });
+        const nights = [
+          makeOxNight(80, 15, 3.0, '2025-02-05'), // has oximetry
+          makeOxNight(70, 14, 3.1, '2025-02-04'), // has oximetry
+          makeNoOxNight(60, '2025-02-03'), // no oximetry
+          makeNoOxNight(50, '2025-02-02'), // no oximetry
+          makeNoOxNight(40, '2025-02-01'), // no oximetry
+        ];
+        const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+        const divergence = result.find((i) => i.id === 'proxy-outcome-divergence');
+        expect(divergence).toBeUndefined();
+      });
+
+      it('does not fire when proxy metrics are not worsening', () => {
+        // IFL improving, ODI-3 stable — no divergence
+        const nights = [
+          makeOxNight(40, 13, 3.0, '2025-02-05'),
+          makeOxNight(50, 14, 3.1, '2025-02-04'),
+          makeOxNight(60, 15, 3.2, '2025-02-03'),
+          makeOxNight(70, 16, 3.0, '2025-02-02'),
+          makeOxNight(80, 17, 3.1, '2025-02-01'),
+        ];
+        const result = generateInsights(nights, nights[0]!, nights[1]!, null);
+        const divergence = result.find((i) => i.id === 'proxy-outcome-divergence');
+        expect(divergence).toBeUndefined();
+      });
+    });
   });
 
   describe('symptom rating cross-reference', () => {

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -671,9 +671,9 @@ function trendInsights(
   } else if (iflTrend === 'worsening') {
     insights.push({
       id: 'trend-ifl-worsening',
-      type: 'actionable',
+      type: 'info',
       title: 'IFL Symptom Risk trending upward',
-      body: `Your flow limitation composite is increasing over ${nights.length} nights (${fmt(iflVals[0]!)}% \u2192 ${fmt(iflVals[iflVals.length - 1]!)}%). An upward trend in flow limitation metrics was observed across this period.`,
+      body: `Your flow limitation composite is increasing over ${nights.length} nights (${fmt(iflVals[0]!)}% \u2192 ${fmt(iflVals[iflVals.length - 1]!)}%). This proxy composite is trending higher. Check outcome metrics (ODI, SpO₂) for whether this pattern is reflected in direct measurements.`,
       category: 'trend',
     });
   }
@@ -690,11 +690,30 @@ function trendInsights(
   } else if (gTrend === 'worsening') {
     insights.push({
       id: 'trend-glasgow-worsening',
-      type: 'actionable',
+      type: 'info',
       title: 'Glasgow Index trending upward',
-      body: `Flow limitation is increasing over ${nights.length} nights (${fmt(glasgowVals[0]!)} → ${fmt(glasgowVals[glasgowVals.length - 1]!)}). Review flow waveforms alongside this trend for context.`,
+      body: `Flow limitation is increasing over ${nights.length} nights (${fmt(glasgowVals[0]!)} → ${fmt(glasgowVals[glasgowVals.length - 1]!)}). This context-tier metric is trending higher. It reflects flow shape patterns, not direct outcomes.`,
       category: 'trend',
     });
+  }
+
+  // Proxy-outcome divergence: Tier 2 proxy adverse but Tier 1 outcome stable
+  const nedVals = chrono.map((n) => n.ned.nedMean);
+  const nedTrend = trendLowerBetter(nedVals);
+  const proxyAdverse = iflTrend === 'worsening' || nedTrend === 'worsening';
+  const oximetryNights = chrono.filter((n) => n.oximetry != null);
+  if (proxyAdverse && oximetryNights.length >= 3) {
+    const odiVals = oximetryNights.map((n) => n.oximetry!.odi3);
+    const odiTrend = trendLowerBetter(odiVals);
+    if (odiTrend === 'stable' || odiTrend === 'improving') {
+      insights.push({
+        id: 'proxy-outcome-divergence',
+        type: 'info',
+        title: 'Pattern metrics trending differently from outcome metrics',
+        body: `Your flow limitation proxy metrics are trending higher, but your direct outcome measurements (ODI, SpO₂) remain stable. This divergence is common and does not necessarily indicate a problem — your clinician can help interpret these findings in context.`,
+        category: 'trend',
+      });
+    }
   }
 
   // Therapy change impact


### PR DESCRIPTION
## Summary

- Use info type and directional language for proxy metric trend insights
- Replace if-guards with explicit assertions in trend tests
- Builds on AIR-535 (merge that first)
- Board-approved batch merge (AIR-545)

🤖 Generated with [Claude Code](https://claude.com/claude-code)