### PR TITLE
feat(email): update dormancy re-engagement to 14/28/45-day cadence (AIR-471)

### DIFF
--- a/__tests__/email-templates.test.ts
+++ b/__tests__/email-templates.test.ts
@@ -5,6 +5,7 @@ import {
   postUploadStep3,
   dormancyStep1,
   dormancyStep2,
+  dormancyStep3,
   featureEducationStep1,
   featureEducationStep2,
   SEQUENCES,
@@ -59,6 +60,15 @@ describe('Dormancy sequence templates', () => {
     expect(html).toContain('Upload When You');
     expect(html).toContain('tracking');
   });
+
+  it('step 3 is warm final touchpoint with no-pressure messaging', () => {
+    const { subject, html } = dormancyStep3(UNSUB_URL);
+    expect(subject).toBe('Still here if you need us');
+    expect(html).toContain('No pressure, no guilt');
+    expect(html).toContain('dormancy_3');
+    expect(html).toContain(UNSUB_URL);
+    expect(html).toContain('not a medical device');
+  });
 });
 
 describe('Feature education sequence templates', () => {
@@ -88,6 +98,7 @@ describe('All templates — structural invariants', () => {
     { name: 'postUpload3', fn: postUploadStep3 },
     { name: 'dormancy1', fn: dormancyStep1 },
     { name: 'dormancy2', fn: dormancyStep2 },
+    { name: 'dormancy3', fn: dormancyStep3 },
     { name: 'featureEd1', fn: featureEducationStep1 },
     { name: 'featureEd2', fn: featureEducationStep2 },
   ];
@@ -160,9 +171,9 @@ describe('SEQUENCES registry', () => {
     expect(SEQUENCES.post_upload.delays).toEqual([0, 3, 7]);
   });
 
-  it('dormancy has 2 steps with delays [0, 7]', () => {
-    expect(SEQUENCES.dormancy.totalSteps).toBe(2);
-    expect(SEQUENCES.dormancy.delays).toEqual([0, 7]);
+  it('dormancy has 3 steps with delays [0, 14, 31]', () => {
+    expect(SEQUENCES.dormancy.totalSteps).toBe(3);
+    expect(SEQUENCES.dormancy.delays).toEqual([0, 14, 31]);
   });
 
   it('feature_education has 2 steps with delays [10, 17]', () => {

--- a/lib/email/sequences.ts
+++ b/lib/email/sequences.ts
@@ -164,7 +164,7 @@ export async function markSent(
 export async function scheduleDormancySequences(
   supabase: SupabaseClient
 ): Promise<number> {
-  const DORMANCY_DAYS = 7;
+  const DORMANCY_DAYS = 14;
   const cutoff = new Date(Date.now() - DORMANCY_DAYS * 24 * 60 * 60 * 1000).toISOString();
 
   // Find users who already have a dormancy sequence (to exclude them)
@@ -175,7 +175,7 @@ export async function scheduleDormancySequences(
 
   const excludeIds = existingDormancy?.map((r) => r.user_id) ?? [];
 
-  // Find users who are dormant (no upload in 7 days), opted in, no existing dormancy sequence
+  // Find users who are dormant (no upload in 14 days), opted in, no existing dormancy sequence
   let query = supabase
     .from('profiles')
     .select('id')

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -153,6 +153,20 @@ export function dormancyStep2(unsubscribeUrl: string): { subject: string; html: 
   };
 }
 
+export function dormancyStep3(unsubscribeUrl: string): { subject: string; html: string } {
+  return {
+    subject: 'Still here if you need us',
+    html: layout(`
+      ${heading('No pressure, no guilt')}
+      ${paragraph('It\'s been a while. You might have settled into therapy, started working with a specialist, or simply moved on -- and that\'s completely fine.')}
+      ${paragraph('AirwayLab is still free and private. Your data stays in your browser. Whenever you want a snapshot of how a recent night compared to the last time you tracked, it\'s here.')}
+      ${paragraph('This is the last email in this sequence. We won\'t send more re-engagement emails unless you upload new data.')}
+      ${ctaButton('Your data is ready when you are', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=dormancy_3`)}
+      ${paragraph('<em>AirwayLab is not a medical device. This email contains no health data. Your clinician can help interpret your results in the context of your care.</em>')}
+    `, unsubscribeUrl),
+  };
+}
+
 // ── Sequence 3: Feature Education ────────────────────────────
 
 export function featureEducationStep1(unsubscribeUrl: string): { subject: string; html: string } {
@@ -288,11 +302,12 @@ export const SEQUENCES: Record<SequenceName, SequenceConfig> = {
     },
   },
   dormancy: {
-    totalSteps: 2,
-    delays: [0, 7],
+    totalSteps: 3,
+    delays: [0, 14, 31],
     getTemplate: (step, url) => {
       if (step === 1) return dormancyStep1(url);
       if (step === 2) return dormancyStep2(url);
+      if (step === 3) return dormancyStep3(url);
       return null;
     },
   },


### PR DESCRIPTION
## Summary

- Update dormancy re-engagement email cadence to 14/28/45-day schedule
- Board-approved (AIR-545)

🤖 Generated with [Claude Code](https://claude.com/claude-code)