### PR TITLE
fix(blog): replace MDR violations in blog posts (AIR-597, AIR-631)

### DIFF
--- a/app/about/flow-limitation/page.tsx
+++ b/app/about/flow-limitation/page.tsx
@@ -265,9 +265,9 @@ export default function FlowLimitationPage() {
           <div className="flex flex-col gap-3 text-sm leading-relaxed text-muted-foreground">
             <p>
               AirwayLab identifies flow limitation patterns in your data.
-              Your clinician can review these findings and determine whether
-              any therapy adjustments are appropriate. AirwayLab provides the
-              data to support that conversation.
+              Your clinician can help interpret these patterns in the context
+              of your overall therapy. AirwayLab provides the data to support
+              that conversation.
             </p>
             <p>
               Bring your AirwayLab report to your next appointment -- the

--- a/app/blog/posts/hidden-respiratory-events.tsx
+++ b/app/blog/posts/hidden-respiratory-events.tsx
@@ -221,8 +221,7 @@ export default function HiddenRespiratoryEventsPost() {
                 <p className="text-sm font-semibold text-foreground">Look at NED-invisible percentage</p>
                 <p className="mt-0.5 text-xs text-muted-foreground">
                   A high percentage of NED-invisible events suggests the airway is collapsing rather
-                  than progressively narrowing. This is a different mechanism that may respond to
-                  different pressure strategies.
+                  than progressively narrowing. This represents a distinct pattern in the data.
                 </p>
               </div>
             </div>
@@ -243,11 +242,11 @@ export default function HiddenRespiratoryEventsPost() {
         </div>
       </section>
 
-      {/* How AirwayLab Detects This */}
+      {/* How Brief Obstructions Appear */}
       <section className="mt-10">
         <div className="flex items-center gap-2.5">
           <BookOpen className="h-5 w-5 text-blue-400" />
-          <h2 className="text-xl font-bold sm:text-2xl">How AirwayLab Detects Brief Obstructions</h2>
+          <h2 className="text-xl font-bold sm:text-2xl">How Brief Obstructions Appear in AirwayLab</h2>
         </div>
         <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
           <p>


### PR DESCRIPTION
## Summary

- Replace 2 borderline MDR violations in hidden-respiratory-events blog post (AIR-597)
- Replace MDR Rule 1 violation ("therapy adjustments") in flow-limitation FAQ (AIR-631)

Both are string-only changes to blog copy — no logic, no engine, no component changes.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` passes
- [ ] Verify corrected language on Vercel preview deploy