### PR TITLE
Remove 5 non-actionable Discord notification types

### DIFF
--- a/app/api/admin/broadcast/route.ts
+++ b/app/api/admin/broadcast/route.ts
@@ -26,7 +26,7 @@ import { getSupabaseServiceRole } from '@/lib/supabase/server'
 import { sendEmail } from '@/lib/email/send'
 import { getUnsubscribeUrl } from '@/lib/email/unsubscribe-token'
 import { BROADCAST_TEMPLATES, type BroadcastSubjectVariant } from '@/lib/email/broadcast'
-import { sendAlert, formatBroadcastEmbed } from '@/lib/discord-webhook'
+
 
 const BroadcastSchema = z.object({
   templateId: z.string().min(1, 'Template ID is required.'),
@@ -168,14 +168,13 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    // Discord #ops-alerts (fire-and-forget)
-    void sendAlert('ops', '', [formatBroadcastEmbed({
-      templateId: templateId,
+    console.error('[broadcast] Broadcast completed', {
+      templateId,
       sent,
       skipped,
       errors: errors.length,
       totalOptedIn: users.length,
-    })])
+    })
 
     return NextResponse.json({
       dryRun: false,

--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -10,39 +10,12 @@ import { exceedsPayloadLimit } from '@/lib/api/payload-guard';
 import { salvageTruncatedJSON } from './salvage';
 import { sanitizePromptInput } from '@/lib/prompt-sanitize';
 import { cancelSequence } from '@/lib/email/sequences';
-import { sendAlert, COLORS } from '@/lib/discord-webhook';
 
 // Vercel Pro default is 15s — far too short for Claude Sonnet (10-25s typical).
 // 60s allows for cold starts + slow responses + deep mode with large payloads.
 export const maxDuration = 60;
 
 const AI_MONTHLY_LIMIT = 3;
-
-// Dedup rate-limit alerts: one alert per user per hour max
-const rateLimitAlertCache = new Map<string, number>();
-
-async function sendOpsRateLimitAlert(userId: string, tier: string) {
-  const now = Date.now();
-  const lastAlert = rateLimitAlertCache.get(userId) ?? 0;
-  if (now - lastAlert < 3_600_000) return; // 1 hour dedup
-  rateLimitAlertCache.set(userId, now);
-  // Prune stale entries
-  if (rateLimitAlertCache.size > 100) {
-    for (const [key, ts] of rateLimitAlertCache) {
-      if (now - ts > 3_600_000) rateLimitAlertCache.delete(key);
-    }
-  }
-  await sendAlert('ops', '', [{
-    title: ':warning: AI Rate Limit Hit',
-    color: COLORS.amber,
-    fields: [
-      { name: 'User', value: userId.slice(0, 8) + '...', inline: true },
-      { name: 'Tier', value: tier, inline: true },
-    ],
-    footer: { text: 'AI Insights' },
-    timestamp: new Date().toISOString(),
-  }]);
-}
 
 const DEEP_SYSTEM_PROMPT_EXTENSION = `
 
@@ -295,7 +268,7 @@ export async function POST(request: NextRequest) {
   const isPaidTierForRateLimit = userTier === 'supporter' || userTier === 'champion';
   const rateLimiter = isPaidTierForRateLimit ? aiPremiumRateLimiter : aiRateLimiter;
   if (await rateLimiter.isLimited(getUserRateLimitKey(user.id))) {
-    void sendOpsRateLimitAlert(user.id, userTier);
+    console.error('[ai-insights] Rate limit hit', { userId: user.id.slice(0, 8), tier: userTier });
     return NextResponse.json({ error: 'Too many requests. Please try again later.' }, { status: 429 });
   }
 
@@ -318,7 +291,7 @@ export async function POST(request: NextRequest) {
 
     const currentCount = usage?.count ?? 0;
     if (currentCount >= AI_MONTHLY_LIMIT) {
-      void sendOpsRateLimitAlert(user.id, 'community (monthly limit)');
+      console.error('[ai-insights] Monthly limit reached', { userId: user.id.slice(0, 8), tier: 'community' });
       return NextResponse.json(
         { error: 'Monthly AI analysis limit reached. Support AirwayLab for unlimited access.' },
         { status: 403 }

--- a/app/api/contribute-data/route.ts
+++ b/app/api/contribute-data/route.ts
@@ -6,7 +6,6 @@ import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import { exceedsPayloadLimit } from '@/lib/api/payload-guard';
 import type { NightResult } from '@/lib/types';
-import { sendAlert, formatGrowthEmbed } from '@/lib/discord-webhook';
 import { isValidDeviceMode } from '@/lib/device-capabilities';
 
 const limiter = new RateLimiter({ windowMs: 3_600_000, max: 30 });
@@ -342,14 +341,12 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // Discord #growth alert (fire-and-forget)
-    const hasOximetry = anonymised.some((n) => n.oximetry !== null)
-    void sendAlert('growth', '', [formatGrowthEmbed({
-      event: 'data_contribution',
+    const hasOximetry = anonymised.some((n) => n.oximetry !== null);
+    console.error('[contribute-data] Data contribution received', {
       nightCount: anonymised.length,
       hasOximetry,
-      deviceModel: anonymised[0]?.settings.deviceModel || undefined,
-    })]);
+      deviceModel: anonymised[0]?.settings.deviceModel || 'Unknown',
+    });
 
     return NextResponse.json({
       ok: true,

--- a/app/api/cron/discord-sync/route.ts
+++ b/app/api/cron/discord-sync/route.ts
@@ -19,7 +19,6 @@ import {
   searchGuildMember,
   syncRole,
 } from '@/lib/discord';
-import { sendAlert, COLORS } from '@/lib/discord-webhook';
 
 export const dynamic = 'force-dynamic';
 
@@ -129,21 +128,13 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Alert ops if Discord API errors are blocking resolution
     if (errors > 0) {
-      await sendAlert('ops', '', [{
-        title: ':warning: Discord Sync — API Errors',
-        description: `${errors} of ${unlinked.length} users could not be resolved due to Discord API errors. Paying users may be stuck without roles.`,
-        color: COLORS.amber,
-        fields: [
-          { name: 'Checked', value: String(unlinked.length), inline: true },
-          { name: 'Resolved', value: String(resolved), inline: true },
-          { name: 'Errors', value: String(errors), inline: true },
-          { name: 'Not found', value: String(notFound), inline: true },
-        ],
-        footer: { text: 'discord-sync cron' },
-        timestamp: new Date().toISOString(),
-      }]);
+      console.error('[discord-sync] API errors blocking resolution', {
+        checked: unlinked.length,
+        resolved,
+        errors,
+        notFound,
+      });
     }
 
     return NextResponse.json({ resolved, checked: unlinked.length, errors, not_found: notFound });

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -7,7 +7,6 @@ import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { NextResponse, type NextRequest } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
-import { sendAlert, formatGrowthEmbed } from '@/lib/discord-webhook';
 
 /**
  * Validate the `next` redirect parameter to prevent open redirect attacks.
@@ -99,15 +98,12 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  // Detect new signups: if user was created within the last 60 seconds, it's a new signup
+  // Log new signups (detected if account created within the last 60 seconds)
   if (user?.created_at) {
     const createdAt = new Date(user.created_at).getTime();
     const now = Date.now();
     if (now - createdAt < 60_000) {
-      void sendAlert('growth', '', [formatGrowthEmbed({
-        event: 'new_signup',
-        email: user.email ?? undefined,
-      })]);
+      console.error('[auth/callback] New signup', { userId: user.id });
     }
   }
 


### PR DESCRIPTION
## Summary

Suppresses 5 Discord notification types identified in AIR-656 as failing the 15-second actionability test:

- **Discord Sync Errors** (#ops-alerts) — transient API issues, auto-resolves
- **AI Rate Limit Hit** (#ops-alerts) — expected behavior, not actionable
- **New Signup** (#growth) — volume metric, not actionable per-event
- **Data Contribution** (#growth) — awareness only, belongs in weekly digest
- **Broadcast Completion** (#ops-alerts) — post-action confirmation, no follow-up

The 6th type (Service Monitor — all green) was already gated and never fires when healthy — no change needed.

### What changed
- Removed `sendAlert()` calls from 5 routes
- Replaced each with structured `console.error` log preserving event data in Vercel logs
- Cleaned up unused imports
- Removed `sendOpsRateLimitAlert` function and dedup cache from `ai-insights/route.ts`

### What is preserved
- All underlying event logging (structured logs flow to Vercel + Sentry)
- Critical notification paths (revenue, user-signals, email bounce/complaint, monitor warnings/criticals)
- Embed builder functions in `discord-webhook.ts` (dead code cleanup is separate)

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 1765/1765 pass
- [x] `npm run build` — passes
- [ ] Verify no Discord messages fire for suppressed types on Vercel preview