### PR TITLE
feat(seo): add seoTitle, faqItems, and CTA copy fix to blog posts

### DIFF
--- a/app/blog/posts/ahi-normal-still-tired.tsx
+++ b/app/blog/posts/ahi-normal-still-tired.tsx
@@ -319,7 +319,7 @@ export default function AHINormalStillTiredPost() {
       <section className="mt-10 rounded-xl border border-primary/20 bg-primary/5 p-6 text-center">
         <h3 className="text-lg font-bold">See What Your AHI Is Missing</h3>
         <p className="mt-2 text-sm text-muted-foreground">
-          Upload your ResMed SD card to AirwayLab. Four research-grade engines analyse your flow
+          Load your ResMed SD card into AirwayLab. Four research-grade engines analyse your flow
           data for the patterns AHI ignores. Free, open-source, and 100% private — your data
           never leaves your browser.
         </p>

--- a/lib/blog-posts.ts
+++ b/lib/blog-posts.ts
@@ -151,6 +151,7 @@ export const blogPosts: BlogPost[] = [
   {
     slug: 'how-to-read-cpap-data',
     title: 'How to Read Your CPAP Data (And Why AHI Isn\'t the Whole Story)',
+    seoTitle: 'How to Read Your CPAP Data — AirwayLab',
     description:
       'Your PAP machine records thousands of data points every night. AHI only shows part of the picture. Learn how to read your CPAP data properly -- flow limitation, breathing patterns, and the metrics that matter.',
     date: '2026-04-03',
@@ -191,6 +192,7 @@ export const blogPosts: BlogPost[] = [
   {
     slug: 'why-ahi-is-lying',
     title: 'Why Your AHI Is Lying to You',
+    seoTitle: 'Why Your CPAP AHI Score Can Be Misleading — AirwayLab',
     description:
       'AHI was never designed to measure sleep quality. It misses flow limitation, RERAs, breathing irregularity, and the autonomic stress response. Here is the evidence -- and what you can track instead.',
     date: '2026-03-20',
@@ -322,6 +324,16 @@ export const blogPosts: BlogPost[] = [
     tags: ['Flow Limitation', 'Research', 'UARS', 'Sleepiness'],
     ogDescription:
       'Research shows inspiratory flow limitation predicts sleepiness independent of arousals and AHI. Learn what this means for tracking your PAP therapy.',
+    faqItems: [
+      {
+        question: 'Does flow limitation on CPAP cause daytime sleepiness?',
+        answer: 'Research shows inspiratory flow limitation is associated with daytime sleepiness and fatigue independently of AHI and arousal index. Studies have found that patients with high flow limitation scores report worse subjective sleepiness even when arousals and AHI are controlled for, suggesting the respiratory effort response itself may contribute to symptoms.',
+      },
+      {
+        question: 'What is the relationship between flow limitation and UARS?',
+        answer: 'Upper Airway Resistance Syndrome (UARS) is characterised by high respiratory effort and symptoms despite normal AHI. Flow limitation is one of the primary physiological markers of UARS. Many UARS patients show high FL scores and elevated RERA counts in their PAP data even with AHI under 5.',
+      },
+    ],
   },
   {
     slug: 'arousals-vs-flow-limitation',
@@ -333,6 +345,16 @@ export const blogPosts: BlogPost[] = [
     tags: ['Arousals', 'Flow Limitation', 'UARS', 'Research'],
     ogDescription:
       'Arousals may not be the primary driver of sleep-disordered breathing symptoms. Dr. Gold\'s limbic stress response model offers a compelling alternative.',
+    faqItems: [
+      {
+        question: 'What is a RERA in CPAP data?',
+        answer: 'A RERA (Respiratory Effort-Related Arousal) is a sequence of flow-limited breaths that ends in a brief cortical arousal. Unlike apneas, RERAs do not meet AHI threshold criteria but can fragment sleep architecture. They are detected through flow waveform analysis of PAP SD card data.',
+      },
+      {
+        question: 'Do arousals cause sleep apnea symptoms or does flow limitation?',
+        answer: 'Research from Dr. Avram Gold and others suggests the autonomic stress response to flow limitation itself — not the cortical arousal — may be the primary driver of symptoms in upper airway resistance. This means patients with high flow limitation but few measurable arousals can still experience significant fatigue.',
+      },
+    ],
   },
   {
     slug: 'epworth-sleepiness-scale',


### PR DESCRIPTION
## Summary

SEO enhancements to existing blog posts. No new posts added.

- `lib/blog-posts.ts`: adds `seoTitle` to `how-to-read-cpap-data` (38-char keyword-optimised) and `why-ahi-is-lying`; adds 2 `faqItems` each to `flow-limitation-and-sleepiness` and `arousals-vs-flow-limitation` for FAQ rich-snippet eligibility
- `app/blog/posts/ahi-normal-still-tired.tsx`: "Upload your ResMed SD card" → "Load your ResMed SD card" (browser-local framing consistency)

All FAQ answers are informational; no therapeutic claims. Scope-split from PR #572.

## Test plan

- [ ] `how-to-read-cpap-data` and `why-ahi-is-lying` pages have correct `<title>` from `seoTitle`
- [ ] `flow-limitation-and-sleepiness` and `arousals-vs-flow-limitation` pages render FAQ section with new items
- [ ] `ahi-normal-still-tired` CTA shows "Load" not "Upload"

🤖 Generated with [Claude Code](https://claude.com/claude-code)