### PR TITLE
fix(uploads): session-level dedup guard and confirm response check (AIR-690)

### DIFF
--- a/__tests__/waveform-contribution-integration.test.ts
+++ b/__tests__/waveform-contribution-integration.test.ts
@@ -81,6 +81,7 @@ import {
   trackContributedWaveformDate,
   setContributedWaveformEngine,
 } from '@/components/upload/contribution-consent-utils';
+import { _sessionFailedDates } from '@/lib/contribute-waveforms';
 import type { NightResult } from '@/lib/types';
 
 // ── Test helpers ─────────────────────────────────────────────
@@ -145,6 +146,7 @@ describe('contributeWaveformsBackground — integration', () => {
   beforeEach(() => {
     storage.clear();
     vi.clearAllMocks();
+    _sessionFailedDates.clear();
     fetchSpy = vi.fn().mockResolvedValue({ ok: true });
     globalThis.fetch = fetchSpy as unknown as typeof fetch;
   });
@@ -367,6 +369,30 @@ describe('contributeWaveformsBackground — integration', () => {
     const files = [makeBRPFile('2025-01-15')];
 
     await contributeWaveformsBackground([], files, 'test-id');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips failed dates within the same session even when localStorage is unavailable', async () => {
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    // Make localStorage writes throw (simulates quota exceeded or private browsing)
+    const setItemSpy = vi.spyOn(localStorageMock, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+
+    // First call: upload fails, localStorage write fails silently
+    fetchSpy.mockResolvedValue({ ok: false, status: 500 });
+    await contributeWaveformsBackground([makeNight('2025-12-01')], [makeBRPFile('2025-12-01')], 'test-id');
+
+    // Restore localStorage writes
+    setItemSpy.mockRestore();
+
+    // Second call in the same session: should NOT retry '2025-12-01' (session guard)
+    fetchSpy.mockReset();
+    fetchSpy.mockResolvedValue({ ok: true });
+    await contributeWaveformsBackground([makeNight('2025-12-01')], [makeBRPFile('2025-12-01')], 'test-id');
+
+    // Fetch should NOT have been called because session guard blocked the retry
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 

--- a/lib/contribute-waveforms.ts
+++ b/lib/contribute-waveforms.ts
@@ -24,6 +24,15 @@ import type { NightResult, EDFFile } from './types';
 const MAX_COMPRESSED_BYTES = 5 * 1024 * 1024; // 5 MB per night
 
 /**
+ * In-memory dedup guard for failed waveform dates within the current page session.
+ * Survives localStorage failures (quota exceeded, private browsing) so the same date
+ * is never retried more than once per session even when the persistent failed-dates
+ * list cannot be written. Exported with underscore prefix to signal test-only usage.
+ */
+const sessionFailedDates = new Set<string>();
+export { sessionFailedDates as _sessionFailedDates };
+
+/**
  * Anonymise a NightResult for inclusion alongside waveform data.
  * Same shape as the existing contribute-data anonymisation.
  */
@@ -316,11 +325,16 @@ export async function contributeWaveformsBackground(
     clearContributedWaveformDates();
   }
 
-  // Filter to only new nights (skip already contributed and recently failed)
+  // Filter to only new nights (skip already contributed and recently failed).
+  // sessionFailedDates acts as an in-memory guard that survives localStorage
+  // failures within the current page session (see module-level declaration).
   const contributedDates = getContributedWaveformDates();
   const failedDates = getFailedWaveformDates();
   const newNights = nights.filter(
-    (n) => !contributedDates.has(n.dateStr) && !failedDates.has(n.dateStr)
+    (n) =>
+      !contributedDates.has(n.dateStr) &&
+      !failedDates.has(n.dateStr) &&
+      !sessionFailedDates.has(n.dateStr)
   );
   if (newNights.length === 0) return;
 
@@ -393,6 +407,8 @@ export async function contributeWaveformsBackground(
       if (result.ok) {
         trackContributedWaveformDate(night.dateStr);
       } else {
+        // Update in-memory guard first — survives even if localStorage write fails below
+        sessionFailedDates.add(night.dateStr);
         trackFailedWaveformDate(night.dateStr);
         // Rate-limited (429) is expected behavior -- log locally only, never to Sentry.
         // Actual failures (4xx/5xx) are reported to Sentry as warnings.
@@ -412,6 +428,8 @@ export async function contributeWaveformsBackground(
         }
       }
     } catch (err) {
+      // Update in-memory guard first — survives even if localStorage write fails below
+      sessionFailedDates.add(night.dateStr);
       trackFailedWaveformDate(night.dateStr);
       Sentry.captureException(err, {
         tags: { feature: 'waveform-contribution', nightDate: night.dateStr },

--- a/lib/storage/upload-orchestrator.ts
+++ b/lib/storage/upload-orchestrator.ts
@@ -622,14 +622,25 @@ class UploadOrchestrator {
       throw new Error(`Upload failed: ${uploadRes.status}`);
     }
 
-    // Step 3: Confirm upload
-    await fetch('/api/files/confirm', {
+    // Step 3: Confirm upload — marks the file as upload_confirmed in the DB
+    const confirmRes = await fetch('/api/files/confirm', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'same-origin',
       body: JSON.stringify({ fileId: presignData.fileId }),
       signal,
     });
+
+    if (!confirmRes.ok) {
+      if (confirmRes.status === 404) {
+        // File is not in storage despite the PUT appearing to succeed.
+        // Treat as a failed upload — the metadata row was already cleaned up by the confirm route.
+        throw new Error(`Upload not confirmed: file missing from storage (${confirmRes.status})`);
+      }
+      // Other errors (5xx, network): file may be in storage but unconfirmed.
+      // The stale orphan detection in presign will clean it up on the next attempt.
+      console.error('[upload-orchestrator] confirm failed:', confirmRes.status);
+    }
 
     return true;
   }


### PR DESCRIPTION
## Summary

- Add a module-level sessionFailedDates Set in lib/contribute-waveforms.ts that prevents retrying failed waveform dates within the same browser session, even when localStorage is unavailable (quota exceeded or private browsing)
- Check the /api/files/confirm response in lib/storage/upload-orchestrator.ts: a 404 now throws rather than silently returning true, correctly surfacing cases where the file is missing from Supabase Storage despite the PUT appearing to succeed
- Add a test case verifying session-level dedup survives localStorage write failures

## Root causes fixed

**Bug 1 (785 Sentry events):** trackFailedWaveformDate() silently swallows errors. When localStorage quota is exceeded or unavailable, the failure is never persisted, so every subsequent contributeWaveformsBackground() call retries the same date. The new module-level Set survives localStorage failures within the page session.

**Bug 2 (22 Sentry events):** The confirm step in uploadSingleFile was fire-and-forget. A 404 response (file not in storage despite PUT success) was silently treated as a successful upload. Now a 404 throws, counting the file as failed.

## Test plan

- [ ] Full pipeline passes (lint, typecheck, test, build) — verified locally
- [ ] 1741 tests pass including new session-dedup test
- [ ] Vercel preview deploy verified by Demian
- [ ] Manual QA: upload SD card data, verify cloud upload succeeds end-to-end
- [ ] Console check: no new errors or warnings

## Pre-merge checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [x] Self-review: no regressions, loading/error/empty states handled
- [x] PR contains one concern only

Generated with [Claude Code](https://claude.com/claude-code)