### PR TITLE
fix(sentry): lower partial-failure alert threshold and add fingerprinting (AIR-716)

### DIFF
--- a/__tests__/upload-orchestrator.test.ts
+++ b/__tests__/upload-orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isTransientServerError } from '@/lib/storage/upload-orchestrator';
+import { isTransientServerError, getPartialFailureLevel } from '@/lib/storage/upload-orchestrator';
 
 describe('isTransientServerError', () => {
   it('identifies 502 Bad Gateway as transient', () => {
@@ -62,5 +62,35 @@ describe('isTransientServerError', () => {
     expect(isTransientServerError('error code 5020')).toBe(false);
     // 1503 should not match 503
     expect(isTransientServerError('request id 1503')).toBe(false);
+  });
+});
+
+describe('getPartialFailureLevel', () => {
+  it('returns error when all files failed (uploaded === 0)', () => {
+    expect(getPartialFailureLevel(0, 3)).toBe('error');
+  });
+
+  it('returns error when failed > 5 even if some uploaded', () => {
+    expect(getPartialFailureLevel(10, 6)).toBe('error');
+    expect(getPartialFailureLevel(100, 20)).toBe('error');
+  });
+
+  it('returns warning when failed <= 5 and some uploaded', () => {
+    expect(getPartialFailureLevel(10, 5)).toBe('warning');
+    expect(getPartialFailureLevel(50, 1)).toBe('warning');
+    expect(getPartialFailureLevel(10, 3)).toBe('warning');
+  });
+
+  it('returns error at the boundary (failed === 6)', () => {
+    expect(getPartialFailureLevel(10, 6)).toBe('error');
+  });
+
+  it('returns warning at the boundary (failed === 5)', () => {
+    expect(getPartialFailureLevel(10, 5)).toBe('warning');
+  });
+
+  it('returns error when uploaded === 0 and failed === 0', () => {
+    // Edge case: no files processed at all
+    expect(getPartialFailureLevel(0, 0)).toBe('error');
   });
 });

--- a/lib/storage/upload-orchestrator.ts
+++ b/lib/storage/upload-orchestrator.ts
@@ -37,6 +37,16 @@ export function isTransientServerError(errorMessage: string): boolean {
   return /\b(502|503|504|520)\b/.test(errorMessage);
 }
 
+/**
+ * Determine Sentry severity level for partial upload failures.
+ * Escalates to 'error' when all files failed OR more than 5 files failed,
+ * so that Sentry alerts trigger before floods accumulate unnoticed.
+ */
+export function getPartialFailureLevel(uploaded: number, failed: number): 'error' | 'warning' {
+  if (uploaded === 0 || failed > 5) return 'error';
+  return 'warning';
+}
+
 function getFilePath(file: File): string {
   return (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || file.name;
 }
@@ -252,8 +262,11 @@ class UploadOrchestrator {
       (err) => /\b(500|502|503|504|520)\b/.test(err)
     );
 
+    const userId = String(Sentry.getCurrentScope().getUser()?.id ?? 'anonymous');
+
     Sentry.captureMessage('cloud_upload_partial_failure', {
-      level: result.uploaded === 0 ? 'error' : 'warning',
+      level: getPartialFailureLevel(result.uploaded, result.failed),
+      fingerprint: ['cloud_upload_partial_failure', userId],
       tags: {
         allFailed: String(result.uploaded === 0),
         failedCount: String(result.failed),


### PR DESCRIPTION
## Summary
- Escalate `cloud_upload_partial_failure` to `error` level when `failed > 5`, not only when `uploaded === 0`. Prevents floods like the 785-event incident (AIR-690) from accumulating unnoticed.
- Add `fingerprint: ['cloud_upload_partial_failure', userId]` so repeated failures from one user group into a single Sentry issue instead of N separate events.
- Extract `getPartialFailureLevel()` helper for testability with 6 unit tests.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (1771 tests, 111 files)
- [x] `npm run build` passes
- [ ] Vercel preview deploy verified by Demian

## Pre-merge checklist
- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [x] Self-review: no regressions, loading/error/empty states handled
- [x] PR contains one concern only