### PR TITLE
docs: correct Glasgow Index scale from 0-8 to 0-9 (AIR-718)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ airwaylab/
 │   └── upload/             → File upload, validation, consent dialogs
 ├── lib/
 │   ├── analyzers/          → ⚠️ PROTECTED — Analysis engines (do not modify logic)
-│   │   ├── glasgow-index.ts → 9-component breath shape scoring (0–8 scale)
+│   │   ├── glasgow-index.ts → 9-component breath shape scoring (0–9 scale)
 │   │   ├── wat-engine.ts    → FL Score, Regularity (SampEn), Periodicity (FFT)
 │   │   ├── ned-engine.ts    → NED, FI, M-shape, RERA detection, EAI
 │   │   └── oximetry-engine.ts → 17-metric SpO2/HR framework
@@ -254,7 +254,7 @@ After merge, "verified" means ALL of these:
 - **Never send health data without consent.** No analytics on waveform data, no silent uploads, no background syncing. If data leaves the browser, the user must have opted in.
 - **Never exceed the 4MB localStorage cap.** Strip bulk data (per-breath arrays, raw waveforms) before persisting. Pre-flight size check in `persistence.ts`.
 - **Never modify engine logic without clinical understanding.** The engines implement published respiratory analysis methodologies. A "refactoring" that changes threshold values or algorithm steps can produce clinically incorrect results.
-- **Never modify, rescale, or transform Glasgow scores.** The Glasgow component scores (0–1 per component, 0–8 overall) are clinically validated metrics from the Glasgow Index methodology. Visualisation code must adapt the chart scale to fit the data — never change the data to fit the chart. This applies to all presentation layers (charts, tooltips, exports, reports).
+- **Never modify, rescale, or transform Glasgow scores.** The Glasgow component scores (0–1 per component, 0–9 overall) are clinically validated metrics from the Glasgow Index methodology. Visualisation code must adapt the chart scale to fit the data — never change the data to fit the chart. This applies to all presentation layers (charts, tooltips, exports, reports).
 - **Never create API routes without auth middleware.** Every `app/api/` route must validate authentication.
 - **Never use `console.log` in production.** Use `console.error` with structured context for debugging; these flow to Vercel logs + Sentry.
 - **Never hardcode secrets.** Use `process.env` with Zod validation. Add new vars to `.env.example`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ AirwayLab reads the raw flow waveform from your ResMed SD card and runs four ind
 
 | Engine | What it measures |
 |--------|-----------------|
-| **Glasgow Index** | 9-component breath shape scoring (skew, flat top, spike, etc.) on a 0–8 scale |
+| **Glasgow Index** | 9-component breath shape scoring (skew, flat top, spike, etc.) on a 0–9 scale |
 | **WAT (Wobble Analysis Tool)** | FL Score, Regularity (Sample Entropy), Periodicity (FFT spectral analysis) |
 | **NED Analysis** | Peak-to-mid inspiratory flow ratio with automated RERA detection |
 | **Oximetry Pipeline** | 17-metric SpO2 and heart rate framework from Viatom/Checkme O2 Max CSV |

--- a/docs/BRAND_VOICE.md
+++ b/docs/BRAND_VOICE.md
@@ -31,7 +31,7 @@ Not a health tech startup. Not a medical device company. Not a generic open-sour
 
 1. Lead with the benefit, follow with the mechanism.
    YES: "See your flow limitation trends (using Glasgow Index breath scoring)"
-   NO: "The Glasgow Index scores each breath on a 0-8 scale which we use to..."
+   NO: "The Glasgow Index scores each breath on a 0-9 scale which we use to..."
 2. Use "your" generously. "Your data", "your therapy", "your breathing patterns."
 3. Say "PAP" not "CPAP" (inclusive of BiPAP, ASV users).
 4. Avoid: "revolutionary", "cutting-edge", "AI-powered", "game-changing".


### PR DESCRIPTION
## Summary

- Corrected Glasgow Index overall scale references from 0-8 to 0-9 across documentation
- Glasgow Index has 9 components scored 0-1 each, so the correct overall range is 0-9
- Updated `CLAUDE.md` (directory tree + anti-patterns), `README.md` (engine table), `docs/BRAND_VOICE.md` (writing rules)
- Skipped historical records (`CHANGELOG.md`, `docs/audit-2026-03.md`) — those document past state accurately

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (1777 tests)
- [x] Docs-only change — no runtime impact

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [x] Self-review: no regressions, docs-only change
- [x] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)