### PR TITLE
fix(layout): suppress body hydration warnings from browser extensions (AIR-692)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -110,6 +110,7 @@ export default function RootLayout({
           plusJakarta.variable,
           jetbrainsMono.variable
         )}
+        suppressHydrationWarning
       >
         <script
           type="application/ld+json"

--- a/components/feedback/feedback-panel.tsx
+++ b/components/feedback/feedback-panel.tsx
@@ -34,6 +34,10 @@ export function FeedbackPanel({ open, onClose }: Props) {
   const [email, setEmail] = useState('')
   const [contactOk, setContactOk] = useState(false)
   const [status, setStatus] = useState<'idle' | 'sending' | 'success' | 'error' | 'rate_limited'>('idle')
+  const [isMac, setIsMac] = useState(false)
+  useEffect(() => {
+    setIsMac(navigator.platform?.includes('Mac') ?? false)
+  }, [])
 
   // Callbacks first (referenced by effects below)
   const handleClose = useCallback(() => {
@@ -216,7 +220,7 @@ export function FeedbackPanel({ open, onClose }: Props) {
                 />
                 <div className="mt-1 flex justify-between">
                   <span className="text-[10px] text-muted-foreground/40">
-                    {navigator.platform?.includes('Mac') ? '⌘' : 'Ctrl'}+Enter to send
+                    {isMac ? '⌘' : 'Ctrl'}+Enter to send
                   </span>
                   <span
                     className={cn(


### PR DESCRIPTION
## Summary

Adds `suppressHydrationWarning` to `<body>` in `app/layout.tsx` to prevent React hydration errors caused by browser extensions injecting attributes post-SSR.

## Root cause

Browser extensions (password managers, dark-mode tools, translation extensions) inject `class` and `data-*` attributes into `<body>` after SSR. The `<html>` element already had `suppressHydrationWarning`, but `<body>` didn't — so React threw on any extension-modified body attribute.

## Changes

- `app/layout.tsx` — add `suppressHydrationWarning` to `<body>`
- `components/feedback/feedback-panel.tsx` — move `navigator.platform` check from render into `useEffect`/`useState` to avoid fragile synchronous navigator access

## Context

- Closes AIR-692 (ticket was mistakenly marked done on 2026-04-20 before PR was opened)
- Branch + commit `3916a5a` already on remote, CTO review approved 2026-04-20T09:19
- Board opening this PR on 2026-04-21 to ship the fix to main

## Test plan

- [x] Tests: 1776/1776 pass (per CTO review)
- [x] tsc + lint clean
- [ ] Vercel preview verified