### PR TITLE
fix(discord-sync): add persistent-failure backoff (AIR-757)

### DIFF
--- a/__tests__/discord-sync-cron.test.ts
+++ b/__tests__/discord-sync-cron.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for the Discord sync cron (app/api/cron/discord-sync/route.ts).
+ *
+ * Covers: auth guard, persistent-failure backoff (error count increment,
+ * threshold exclusion), success path (counter reset), not-found path,
+ * Sentry emission rules (first + threshold only), and ops alert.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+// ── Mocks ────────────────────────────────────────────────────────
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+const mockSearchGuildMember = vi.fn();
+const mockSyncRole = vi.fn();
+
+vi.mock('@/lib/discord', () => ({
+  isDiscordConfigured: vi.fn().mockReturnValue(true),
+  searchGuildMember: (...args: unknown[]) => mockSearchGuildMember(...args),
+  syncRole: (...args: unknown[]) => mockSyncRole(...args),
+}));
+
+const mockSendAlert = vi.fn();
+vi.mock('@/lib/discord-webhook', () => ({
+  sendAlert: (...args: unknown[]) => mockSendAlert(...args),
+  COLORS: { amber: 0xf59e0b },
+}));
+
+// Chainable Supabase mock ─────────────────────────────────────────
+type MockBuilder = {
+  select: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  not: ReturnType<typeof vi.fn>;
+  is: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  lt: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  neq: ReturnType<typeof vi.fn>;
+  maybeSingle: ReturnType<typeof vi.fn>;
+  _result: { data: unknown; error: unknown };
+};
+
+function makeBuilder(result: { data: unknown; error: unknown }): MockBuilder {
+  const b: MockBuilder = {
+    _result: result,
+    select: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockResolvedValue({ error: null }),
+    delete: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    lt: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    neq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+  };
+  // The last awaited call on the chain resolves to result
+  // The `lt` filter is the final link before await in the query path.
+  b.lt.mockResolvedValue(result);
+  b.eq.mockResolvedValue({ error: null });
+  return b;
+}
+
+const mockFrom = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseServiceRole: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  })),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function makeRequest(secret = 'test-secret'): NextRequest {
+  return {
+    headers: {
+      get: (h: string) => (h === 'authorization' ? `Bearer ${secret}` : null),
+    },
+  } as unknown as NextRequest;
+}
+
+// Fake profile row
+function profile(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'user-1',
+    discord_username: 'colorado_24106',
+    tier: 'supporter',
+    discord_sync_error_count: 0,
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe('discord-sync cron', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = 'test-secret';
+    mockSyncRole.mockResolvedValue(true);
+    mockSendAlert.mockResolvedValue(undefined);
+  });
+
+  it('returns 401 for wrong CRON_SECRET', async () => {
+    const { GET } = await import('@/app/api/cron/discord-sync/route');
+    const res = await GET(makeRequest('wrong'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with zeros when no unlinked users', async () => {
+    mockFrom.mockReturnValue(makeBuilder({ data: [], error: null }));
+    const { GET } = await import('@/app/api/cron/discord-sync/route');
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.checked).toBe(0);
+    expect(body.resolved).toBe(0);
+  });
+
+  it('increments discord_sync_error_count on API error', async () => {
+    const p = profile({ discord_sync_error_count: 0 });
+    const builder = makeBuilder({ data: [p], error: null });
+    const updateBuilder = { eq: vi.fn().mockResolvedValue({ error: null }) };
+    builder.update = vi.fn().mockReturnValue(updateBuilder);
+    mockFrom.mockReturnValue(builder);
+
+    mockSearchGuildMember.mockResolvedValue({ status: 'error', message: 'Discord API error (429)' });
+
+    const { GET } = await import('@/app/api/cron/discord-sync/route');
+    await GET(makeRequest());
+
+    expect(builder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ discord_sync_error_count: 1 })
+    );
+  });
+
+  it('excludes users at the error threshold from the query', async () => {
+    // The cron filters lt('discord_sync_error_count', 5) — this is verified
+    // by checking the lt() call receives the threshold value.
+    const builder = makeBuilder({ data: [], error: null });
+    mockFrom.mockReturnValue(builder);
+
+    const { GET } = await import('@/app/api/cron/discord-sync/route');
+    await GET(makeRequest());
+
+    expect(builder.lt).toHaveBeenCalledWith('discord_sync_error_count', 5);
+  });
+
+  it('fires Sentry only on first error, not intermediate retries', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    const p = profile({ discord_sync_error_count: 1 }); // second failure (count going to 2)
+    const builder = makeBuilder({ data: [p], error: null });
+    const updateBuilder = { eq: vi.fn().mockResolvedValue({ error: null }) };
+    builder.update = vi.fn().mockReturnValue(updateBuilder);
+    mockFrom.mockReturnValue(builder);
+
+    mockSearchGuildMember.mockResolvedValue({ status: 'error', message: 'API error' });
+
+    const { GET } = await import('@/app/api/cron/discord-sync/route');
+    await GET(makeRequest());
+
+    // count goes from 1 → 2, which is neither 1 (first) nor 5 (threshold) — no Sentry
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('fires Sentry when threshold is reached', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    const p = profile({ discord_sync_error_count: 4 }); // next failure hits threshold
+    const builder = makeBuilder({ data: [p], error: null });
+    const updateBuilder = { eq: vi.fn().mockResolvedValue({ error: null }) };
+    builder.update = vi.fn().mockReturnValue(updateBuilder);
+    mockFrom.mockReturnValue(builder);
+
+    mockSearchGuildMember.mockResolvedValue({ status: 'error', message: 'API error' });
+
+    const { GET } = await import('@/app/api/cron/discord-sync/route');
+    await GET(makeRequest());
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('threshold reached'),
+      expect.objectContaining({ level: 'error' })
+    );
+  });
+
+  it('resets error count to 0 on successful link', async () => {
+    const p = profile({ discord_sync_error_count: 2 });
+
+    // from('profiles') is called three times: initial query, dupe check, update.
+    // Each call must return a fresh mock so the chain methods don't conflict.
+    let profilesCallCount = 0;
+    const updateData: Array<Record<string, unknown>> = [];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        profilesCallCount++;
+        if (profilesCallCount === 1) {
+          // Initial query chain: select → not → is → in → lt (resolves to profile list)
+          return {
+            select: vi.fn().mockReturnThis(),
+            not: vi.fn().mockReturnThis(),
+            is: vi.fn().mockReturnThis(),
+            in: vi.fn().mockReturnThis(),
+            lt: vi.fn().mockResolvedValue({ data: [p], error: null }),
+          };
+        }
+        if (profilesCallCount === 2) {
+          // Dupe check chain: select → eq → neq → maybeSingle (no conflict)
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            neq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+          };
+        }
+        // Auto-link update chain: update → eq
+        return {
+          update: vi.fn().mockImplementation((data: Record<string, unknown>) => {
+            updateData.push(data);
+            return { eq: vi.fn().mockResolvedValue({ error: null }) };
+          }),
+        };
+      }
+      if (table === 'discord_role_events') {
+        return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      }
+      if (table === 'discord_pending_roles') {
+        return { delete: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) }) };
+      }
+      return makeBuilder({ data: [], error: null });
+    });
+
+    mockSearchGuildMember.mockResolvedValue({ status: 'found', discordId: 'disc-123' });
+
+    const { GET } = await import('@/app/api/cron/discord-sync/route');
+    await GET(makeRequest());
+
+    expect(updateData).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ discord_sync_error_count: 0, discord_sync_last_error: null }),
+      ])
+    );
+  });
+
+  it('sends ops alert when errors > 0', async () => {
+    const p = profile();
+    const builder = makeBuilder({ data: [p], error: null });
+    const updateBuilder = { eq: vi.fn().mockResolvedValue({ error: null }) };
+    builder.update = vi.fn().mockReturnValue(updateBuilder);
+    mockFrom.mockReturnValue(builder);
+
+    mockSearchGuildMember.mockResolvedValue({ status: 'error', message: 'Timeout' });
+
+    const { GET } = await import('@/app/api/cron/discord-sync/route');
+    await GET(makeRequest());
+
+    expect(mockSendAlert).toHaveBeenCalledWith('ops', '', expect.any(Array));
+  });
+
+  it('counts not_found separately without incrementing error count', async () => {
+    const p = profile();
+    const builder = makeBuilder({ data: [p], error: null });
+    builder.update = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    mockFrom.mockReturnValue(builder);
+
+    mockSearchGuildMember.mockResolvedValue({ status: 'not_found' });
+
+    const { GET } = await import('@/app/api/cron/discord-sync/route');
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(body.not_found).toBe(1);
+    expect(body.errors).toBe(0);
+    // update should NOT have been called for a not_found
+    expect(builder.update).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/cron/discord-sync/route.ts
+++ b/app/api/cron/discord-sync/route.ts
@@ -8,6 +8,11 @@
  * This closes the gap where users join Discord via invite link
  * but never manually click "Connect" on their account page.
  *
+ * Persistent-failure backoff: after DISCORD_SYNC_ERROR_THRESHOLD consecutive
+ * Discord API errors the row is excluded from the query. This prevents
+ * permanently-failing usernames from generating unbounded Sentry noise.
+ * An operator can reset a user by zeroing discord_sync_error_count in the DB.
+ *
  * Protected by CRON_SECRET.
  */
 
@@ -19,8 +24,12 @@ import {
   searchGuildMember,
   syncRole,
 } from '@/lib/discord';
+import { sendAlert, COLORS } from '@/lib/discord-webhook';
 
 export const dynamic = 'force-dynamic';
+
+/** Stop retrying after this many consecutive Discord API errors. */
+const DISCORD_SYNC_ERROR_THRESHOLD = 5;
 
 export async function GET(request: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
@@ -43,13 +52,15 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    // Find paid users with a saved username but no discord_id
+    // Find paid users with a saved username but no discord_id who haven't
+    // exceeded the consecutive-error threshold.
     const { data: unlinked, error: queryError } = await supabase
       .from('profiles')
-      .select('id, discord_username, tier')
+      .select('id, discord_username, tier, discord_sync_error_count')
       .not('discord_username', 'is', null)
       .is('discord_id', null)
-      .in('tier', ['supporter', 'champion']);
+      .in('tier', ['supporter', 'champion'])
+      .lt('discord_sync_error_count', DISCORD_SYNC_ERROR_THRESHOLD);
 
     if (queryError) {
       console.error('[discord-sync] Query failed:', queryError);
@@ -58,7 +69,7 @@ export async function GET(request: NextRequest) {
     }
 
     if (!unlinked || unlinked.length === 0) {
-      return NextResponse.json({ resolved: 0, checked: 0, errors: 0, not_found: 0 });
+      return NextResponse.json({ resolved: 0, checked: 0, errors: 0, not_found: 0, skipped: 0 });
     }
 
     let resolved = 0;
@@ -71,12 +82,39 @@ export async function GET(request: NextRequest) {
 
         if (result.status === 'error') {
           errors++;
-          console.error(`[discord-sync] Discord API error for ${profile.discord_username}: ${result.message}`);
-          Sentry.captureMessage(`Discord sync: API error for ${profile.discord_username}`, {
-            level: 'warning',
-            tags: { action: 'discord-sync-cron' },
-            extra: { username: profile.discord_username, error: result.message },
-          });
+          const newCount = (profile.discord_sync_error_count ?? 0) + 1;
+          const hitThreshold = newCount >= DISCORD_SYNC_ERROR_THRESHOLD;
+
+          console.error(
+            `[discord-sync] Discord API error for ${profile.discord_username}: ${result.message}` +
+            ` (error count now ${newCount}${hitThreshold ? ', threshold reached — will skip future runs' : ''})`
+          );
+
+          // Persist the incremented error count and timestamp
+          await supabase.from('profiles').update({
+            discord_sync_error_count: newCount,
+            discord_sync_last_error: new Date().toISOString(),
+          }).eq('id', profile.id);
+
+          // Only fire Sentry on the first failure and when the threshold is hit,
+          // not on every intermediate retry, to suppress repetitive noise.
+          if (newCount === 1 || hitThreshold) {
+            Sentry.captureMessage(
+              hitThreshold
+                ? `Discord sync: threshold reached for ${profile.discord_username} — no further retries`
+                : `Discord sync: first API error for ${profile.discord_username}`,
+              {
+                level: hitThreshold ? 'error' : 'warning',
+                tags: { action: 'discord-sync-cron' },
+                extra: {
+                  username: profile.discord_username,
+                  error: result.message,
+                  errorCount: newCount,
+                },
+              }
+            );
+          }
+
           continue;
         }
 
@@ -99,6 +137,10 @@ export async function GET(request: NextRequest) {
         await supabase.from('profiles').update({
           discord_id: result.discordId,
           discord_linked_at: new Date().toISOString(),
+          // Reset error counter on success so any previous transient failures
+          // don't permanently taint the row if it later resolves.
+          discord_sync_error_count: 0,
+          discord_sync_last_error: null,
         }).eq('id', profile.id);
 
         // Assign role
@@ -120,21 +162,35 @@ export async function GET(request: NextRequest) {
         console.info(`[discord-sync] Auto-linked ${profile.discord_username} (${profile.tier})`);
       } catch (err) {
         errors++;
+        const newCount = (profile.discord_sync_error_count ?? 0) + 1;
         console.error(`[discord-sync] Failed for ${profile.discord_username}:`, err);
+
+        await supabase.from('profiles').update({
+          discord_sync_error_count: newCount,
+          discord_sync_last_error: new Date().toISOString(),
+        }).eq('id', profile.id);
+
         Sentry.captureException(err, {
           tags: { action: 'discord-sync-cron' },
-          extra: { username: profile.discord_username },
+          extra: { username: profile.discord_username, errorCount: newCount },
         });
       }
     }
 
     if (errors > 0) {
-      console.error('[discord-sync] API errors blocking resolution', {
-        checked: unlinked.length,
-        resolved,
-        errors,
-        notFound,
-      });
+      await sendAlert('ops', '', [{
+        title: ':warning: Discord Sync — API Errors',
+        description: `${errors} of ${unlinked.length} users could not be resolved due to Discord API errors. Paying users may be stuck without roles.`,
+        color: COLORS.amber,
+        fields: [
+          { name: 'Checked', value: String(unlinked.length), inline: true },
+          { name: 'Resolved', value: String(resolved), inline: true },
+          { name: 'Errors', value: String(errors), inline: true },
+          { name: 'Not found', value: String(notFound), inline: true },
+        ],
+        footer: { text: `discord-sync cron (threshold: ${DISCORD_SYNC_ERROR_THRESHOLD} failures)` },
+        timestamp: new Date().toISOString(),
+      }]);
     }
 
     return NextResponse.json({ resolved, checked: unlinked.length, errors, not_found: notFound });

--- a/supabase/migrations/040_discord_sync_backoff.sql
+++ b/supabase/migrations/040_discord_sync_backoff.sql
@@ -1,0 +1,16 @@
+-- Discord sync persistent-failure backoff
+-- Adds error tracking columns to profiles so the cron job can stop
+-- retrying usernames that consistently fail Discord API lookups.
+-- After DISCORD_SYNC_ERROR_THRESHOLD consecutive failures the row is
+-- excluded from the cron query until an operator resets the counter.
+
+ALTER TABLE profiles
+  ADD COLUMN discord_sync_error_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN discord_sync_last_error  TIMESTAMPTZ;
+
+-- Partial index: fast lookup of candidates that haven't hit the threshold.
+-- The cron query filters discord_sync_error_count < 5 so this covers it.
+CREATE INDEX idx_profiles_discord_sync_candidates
+  ON profiles (discord_sync_error_count)
+  WHERE discord_id IS NULL
+    AND discord_username IS NOT NULL;


### PR DESCRIPTION
## Summary

- Adds persistent-failure backoff to Discord sync cron: after 5 consecutive API errors, a username is excluded from future cron queries
- Eliminates ~34 Sentry events/day from permanently-failing usernames (colorado_24106, swiss_andreas)
- Error count resets to 0 on successful link

## Changes

- `supabase/migrations/040_discord_sync_backoff.sql`: adds `discord_sync_error_count` and `discord_sync_last_error` columns to profiles
- `app/api/cron/discord-sync/route.ts`: filters `lt(error_count, 5)`, increments on API error, resets on success, sends ops Discord alert on errors
- `__tests__/discord-sync-cron.test.ts`: 9 tests covering threshold exclusion, counter increment, Sentry suppression, counter reset

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] PR contains one concern only
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)