### PR TITLE
feat(feedback): add daily feedback processor cron (AIR-759)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,11 @@ DISCORD_CHAMPION_ROLE_ID=
 DISCORD_REDIRECT_URI=https://airwaylab.app/api/auth/discord/callback
 DISCORD_INVITE_URL=
 NEXT_PUBLIC_DISCORD_INVITE_URL=
+
+# Gmail OAuth2 (Feedback Processor — AIR-759)
+# OAuth2 credentials for dev@airwaylab.app to create Gmail drafts from feedback.
+# Obtain via Google Cloud Console > APIs & Services > Credentials.
+# Use OAuth2 Playground (https://developers.google.com/oauthplayground) to get refresh token.
+GMAIL_CLIENT_ID=
+GMAIL_CLIENT_SECRET=
+GMAIL_REFRESH_TOKEN=

--- a/__tests__/feedback-processor.test.ts
+++ b/__tests__/feedback-processor.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  normaliseEmail,
+  groupByEmail,
+  buildDraftBody,
+  type FeedbackRow,
+} from '@/lib/services/feedback-processor'
+import { getGmailConfig, refreshAccessToken, createGmailDraft } from '@/lib/gmail/client'
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeRow(overrides: Partial<FeedbackRow> = {}): FeedbackRow {
+  return {
+    id: 'row-1',
+    message: 'This is a test message',
+    email: 'user@example.com',
+    type: 'feedback',
+    page: '/analyze',
+    created_at: '2026-04-22T07:00:00Z',
+    metadata: null,
+    ...overrides,
+  }
+}
+
+// ── Test 1: Email normalisation ───────────────────────────────
+
+describe('normaliseEmail', () => {
+  it('lowercases and trims the email', () => {
+    expect(normaliseEmail('  User@EXAMPLE.COM  ')).toBe('user@example.com')
+  })
+
+  it('does not alter an already-normalised email', () => {
+    expect(normaliseEmail('dev@airwaylab.app')).toBe('dev@airwaylab.app')
+  })
+})
+
+// ── Test 2: groupByEmail ──────────────────────────────────────
+
+describe('groupByEmail', () => {
+  it('groups rows by normalised email', () => {
+    const rows = [
+      makeRow({ id: '1', email: 'alice@example.com' }),
+      makeRow({ id: '2', email: 'Alice@Example.COM' }),
+      makeRow({ id: '3', email: 'bob@example.com' }),
+    ]
+
+    const groups = groupByEmail(rows)
+
+    expect(groups.size).toBe(2)
+    expect(groups.get('alice@example.com')).toHaveLength(2)
+    expect(groups.get('bob@example.com')).toHaveLength(1)
+  })
+
+  it('excludes rows with null email', () => {
+    const rows = [
+      makeRow({ id: '1', email: null }),
+      makeRow({ id: '2', email: 'user@example.com' }),
+    ]
+
+    const groups = groupByEmail(rows)
+
+    expect(groups.size).toBe(1)
+    expect(groups.get('user@example.com')).toHaveLength(1)
+  })
+
+  it('returns an empty map when all rows have null email', () => {
+    const rows = [makeRow({ email: null }), makeRow({ email: null })]
+    expect(groupByEmail(rows).size).toBe(0)
+  })
+
+  it('returns an empty map for empty input', () => {
+    expect(groupByEmail([]).size).toBe(0)
+  })
+})
+
+// ── Test 3: buildDraftBody ────────────────────────────────────
+
+describe('buildDraftBody', () => {
+  it('includes the email address in the header', () => {
+    const row = makeRow({ message: 'Hello world', type: 'bug' })
+    const body = buildDraftBody('alice@example.com', [row])
+    expect(body).toContain('Feedback from: alice@example.com')
+  })
+
+  it('includes the message text', () => {
+    const row = makeRow({ message: 'Please add dark mode' })
+    const body = buildDraftBody('user@example.com', [row])
+    expect(body).toContain('Please add dark mode')
+  })
+
+  it('includes the item count', () => {
+    const rows = [makeRow({ id: '1' }), makeRow({ id: '2' })]
+    const body = buildDraftBody('user@example.com', rows)
+    expect(body).toContain('Count: 2 items')
+  })
+
+  it('uses singular item label for one row', () => {
+    const body = buildDraftBody('user@example.com', [makeRow()])
+    expect(body).toContain('Count: 1 item')
+    expect(body).not.toContain('Count: 1 items')
+  })
+
+  it('includes page path when present', () => {
+    const row = makeRow({ page: '/pricing' })
+    const body = buildDraftBody('user@example.com', [row])
+    expect(body).toContain('Page: /pricing')
+  })
+})
+
+// ── Test 4: getGmailConfig ────────────────────────────────────
+
+describe('getGmailConfig', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns null when env vars are missing', () => {
+    vi.stubEnv('GMAIL_CLIENT_ID', '')
+    vi.stubEnv('GMAIL_CLIENT_SECRET', '')
+    vi.stubEnv('GMAIL_REFRESH_TOKEN', '')
+    expect(getGmailConfig()).toBeNull()
+  })
+
+  it('returns config when all three vars are set', () => {
+    vi.stubEnv('GMAIL_CLIENT_ID', 'test-client-id')
+    vi.stubEnv('GMAIL_CLIENT_SECRET', 'test-secret')
+    vi.stubEnv('GMAIL_REFRESH_TOKEN', 'test-refresh')
+
+    const config = getGmailConfig()
+    expect(config).not.toBeNull()
+    expect(config?.clientId).toBe('test-client-id')
+    expect(config?.clientSecret).toBe('test-secret')
+    expect(config?.refreshToken).toBe('test-refresh')
+  })
+
+  it('returns null when only some vars are set', () => {
+    vi.stubEnv('GMAIL_CLIENT_ID', 'test-client-id')
+    vi.stubEnv('GMAIL_CLIENT_SECRET', '')
+    vi.stubEnv('GMAIL_REFRESH_TOKEN', '')
+    expect(getGmailConfig()).toBeNull()
+  })
+})
+
+// ── Test 5: refreshAccessToken ────────────────────────────────
+
+describe('refreshAccessToken', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns access token on success', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: 'ya29.test-token', expires_in: 3600, token_type: 'Bearer' }),
+    } as Response)
+
+    const token = await refreshAccessToken({
+      clientId: 'cid',
+      clientSecret: 'csec',
+      refreshToken: 'rtoken',
+    })
+
+    expect(token).toBe('ya29.test-token')
+  })
+
+  it('throws on non-OK response', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => 'invalid_grant',
+    } as Response)
+
+    await expect(
+      refreshAccessToken({ clientId: 'cid', clientSecret: 'csec', refreshToken: 'expired' }),
+    ).rejects.toThrow('Gmail token refresh failed')
+  })
+})
+
+// ── Test 6: createGmailDraft ──────────────────────────────────
+
+describe('createGmailDraft', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns draftId on success', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'draft-abc123', message: { id: 'msg-xyz' } }),
+    } as Response)
+
+    const result = await createGmailDraft('test-token', {
+      to: 'dev@airwaylab.app',
+      subject: 'Test subject',
+      body: 'Test body',
+    })
+
+    expect(result.draftId).toBe('draft-abc123')
+  })
+
+  it('throws on non-OK response', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: { code: 403, message: 'Forbidden', status: 'PERMISSION_DENIED' } }),
+    } as Response)
+
+    await expect(
+      createGmailDraft('bad-token', {
+        to: 'dev@airwaylab.app',
+        subject: 'Test',
+        body: 'Test',
+      }),
+    ).rejects.toThrow('Gmail draft creation failed')
+  })
+})

--- a/app/api/cron/feedback-processor/route.ts
+++ b/app/api/cron/feedback-processor/route.ts
@@ -1,0 +1,64 @@
+import crypto from 'crypto'
+import { NextRequest, NextResponse } from 'next/server'
+import * as Sentry from '@sentry/nextjs'
+import { getGmailConfig } from '@/lib/gmail/client'
+import { processFeedback } from '@/lib/services/feedback-processor'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * GET /api/cron/feedback-processor
+ *
+ * Runs daily at 07:00 UTC via Vercel Cron. Queries unprocessed feedback
+ * from Supabase, groups by user email, creates consolidated Gmail drafts
+ * on dev@airwaylab.app, and marks entries as processed.
+ *
+ * Protected by CRON_SECRET.
+ * Silently skips (200 OK) when Gmail credentials are not configured.
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization')
+  const cronSecret = process.env.CRON_SECRET
+
+  if (!cronSecret || !authHeader) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const expected = `Bearer ${cronSecret}`
+  const a = Buffer.from(authHeader)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const gmailConfig = getGmailConfig()
+  if (!gmailConfig) {
+    console.error('[cron/feedback-processor] Gmail credentials not configured — skipping')
+    return NextResponse.json({ skipped: true, reason: 'Gmail not configured' }, { status: 200 })
+  }
+
+  try {
+    const result = await processFeedback(gmailConfig)
+
+    console.error('[cron/feedback-processor] completed', {
+      totalUnprocessed: result.totalUnprocessed,
+      draftsCreated: result.draftsCreated,
+      draftsSkipped: result.draftsSkipped,
+      errors: result.errors.length,
+    })
+
+    return NextResponse.json({
+      ok: true,
+      totalUnprocessed: result.totalUnprocessed,
+      emailsWithFeedback: result.emailsWithFeedback,
+      draftsCreated: result.draftsCreated,
+      draftsSkipped: result.draftsSkipped,
+      errors: result.errors,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error('[cron/feedback-processor] fatal error:', msg)
+    Sentry.captureException(err, { tags: { cron: 'feedback-processor' } })
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -91,6 +91,15 @@ export const serverEnv = {
 
   /** Sentry webhook secret for authenticating alert forwards to Discord */
   SENTRY_WEBHOOK_SECRET: process.env.SENTRY_WEBHOOK_SECRET ?? undefined,
+
+  /** Gmail OAuth2 client ID for feedback processor drafts */
+  GMAIL_CLIENT_ID: process.env.GMAIL_CLIENT_ID ?? undefined,
+
+  /** Gmail OAuth2 client secret for feedback processor drafts */
+  GMAIL_CLIENT_SECRET: process.env.GMAIL_CLIENT_SECRET ?? undefined,
+
+  /** Gmail OAuth2 refresh token for feedback processor drafts */
+  GMAIL_REFRESH_TOKEN: process.env.GMAIL_REFRESH_TOKEN ?? undefined,
 } as const;
 
 /**

--- a/lib/gmail/client.ts
+++ b/lib/gmail/client.ts
@@ -1,0 +1,131 @@
+/**
+ * Gmail REST API client.
+ *
+ * Uses OAuth2 refresh token flow to obtain access tokens on demand.
+ * Creates Gmail drafts on behalf of the configured service account.
+ * Zero external dependencies — all network calls use fetch().
+ */
+
+const GMAIL_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me'
+
+export interface GmailConfig {
+  clientId: string
+  clientSecret: string
+  refreshToken: string
+}
+
+export interface GmailDraftInput {
+  to: string
+  subject: string
+  body: string
+}
+
+export interface GmailDraftResult {
+  draftId: string
+}
+
+interface TokenResponse {
+  access_token: string
+  expires_in: number
+  token_type: string
+}
+
+interface GmailApiError {
+  error: {
+    code: number
+    message: string
+    status: string
+  }
+}
+
+/**
+ * Refreshes the OAuth2 access token using the stored refresh token.
+ */
+export async function refreshAccessToken(config: GmailConfig): Promise<string> {
+  const body = new URLSearchParams({
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+    refresh_token: config.refreshToken,
+    grant_type: 'refresh_token',
+  })
+
+  const response = await fetch(GMAIL_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Gmail token refresh failed (${response.status}): ${text}`)
+  }
+
+  const data = (await response.json()) as TokenResponse
+  return data.access_token
+}
+
+/**
+ * Encodes a Gmail RFC 2822 message to base64url format.
+ */
+function encodeMessage(to: string, subject: string, body: string): string {
+  const message = [
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    'Content-Type: text/plain; charset=UTF-8',
+    'MIME-Version: 1.0',
+    '',
+    body,
+  ].join('\r\n')
+
+  return Buffer.from(message)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+
+/**
+ * Creates a Gmail draft in the configured mailbox.
+ */
+export async function createGmailDraft(
+  accessToken: string,
+  input: GmailDraftInput,
+): Promise<GmailDraftResult> {
+  const raw = encodeMessage(input.to, input.subject, input.body)
+
+  const response = await fetch(`${GMAIL_API_BASE}/drafts`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ message: { raw } }),
+  })
+
+  if (!response.ok) {
+    const data = (await response.json()) as GmailApiError
+    throw new Error(
+      `Gmail draft creation failed (${response.status}): ${data.error?.message ?? 'unknown error'}`,
+    )
+  }
+
+  const result = (await response.json()) as { id: string }
+  return { draftId: result.id }
+}
+
+/**
+ * Reads Gmail config from environment variables.
+ * Returns null when any required variable is missing (feature disabled).
+ */
+export function getGmailConfig(): GmailConfig | null {
+  const clientId = process.env.GMAIL_CLIENT_ID
+  const clientSecret = process.env.GMAIL_CLIENT_SECRET
+  const refreshToken = process.env.GMAIL_REFRESH_TOKEN
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    return null
+  }
+
+  return { clientId, clientSecret, refreshToken }
+}

--- a/lib/services/feedback-processor.ts
+++ b/lib/services/feedback-processor.ts
@@ -1,0 +1,192 @@
+/**
+ * Feedback processor service.
+ *
+ * Queries unprocessed feedback from Supabase, groups entries by user email,
+ * creates consolidated Gmail drafts on dev@airwaylab.app, and marks rows
+ * as processed. Designed for daily cron execution.
+ *
+ * Per-user error resilience: a draft failure for one email address does not
+ * prevent processing of other addresses.
+ */
+
+import * as Sentry from '@sentry/nextjs'
+import { getSupabaseAdmin } from '@/lib/supabase/server'
+import { createGmailDraft, refreshAccessToken } from '@/lib/gmail/client'
+import type { GmailConfig } from '@/lib/gmail/client'
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface FeedbackRow {
+  id: string
+  message: string
+  email: string | null
+  type: string | null
+  page: string | null
+  created_at: string
+  metadata: Record<string, unknown> | null
+}
+
+export interface ProcessingResult {
+  totalUnprocessed: number
+  emailsWithFeedback: number
+  draftsCreated: number
+  draftsSkipped: number
+  errors: string[]
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+/** Normalise email to lowercase for consistent grouping. */
+export function normaliseEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+/** Groups feedback rows by normalised email address. Rows without an email are excluded. */
+export function groupByEmail(rows: FeedbackRow[]): Map<string, FeedbackRow[]> {
+  const groups = new Map<string, FeedbackRow[]>()
+  for (const row of rows) {
+    if (!row.email) continue
+    const key = normaliseEmail(row.email)
+    const group = groups.get(key) ?? []
+    group.push(row)
+    groups.set(key, group)
+  }
+  return groups
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  feature: 'Feature request',
+  bug: 'Bug report',
+  support: 'Support request',
+  feedback: 'Feedback',
+}
+
+/** Builds the Gmail draft body for a group of feedback rows from the same email. */
+export function buildDraftBody(email: string, rows: FeedbackRow[]): string {
+  const lines: string[] = [
+    `Feedback from: ${email}`,
+    `Count: ${rows.length} item${rows.length === 1 ? '' : 's'}`,
+    '',
+    '─'.repeat(60),
+  ]
+
+  for (const row of rows) {
+    const label = TYPE_LABELS[row.type ?? ''] ?? 'Feedback'
+    const date = new Date(row.created_at).toUTCString()
+    lines.push(`\n[${label}] ${date}`)
+    if (row.page) lines.push(`Page: ${row.page}`)
+    lines.push(`\n${row.message}`)
+    lines.push('─'.repeat(60))
+  }
+
+  lines.push('\nThis draft was generated automatically by the AirwayLab feedback processor.')
+  return lines.join('\n')
+}
+
+// ── Main processor ───────────────────────────────────────────
+
+/**
+ * Processes all unprocessed feedback rows.
+ *
+ * Steps:
+ * 1. Query feedback rows where processed = false
+ * 2. Group by email (rows without email are marked processed without a draft)
+ * 3. Refresh Gmail access token once
+ * 4. For each email group: create a consolidated Gmail draft
+ * 5. Mark all successfully processed rows as done
+ */
+export async function processFeedback(gmailConfig: GmailConfig): Promise<ProcessingResult> {
+  const result: ProcessingResult = {
+    totalUnprocessed: 0,
+    emailsWithFeedback: 0,
+    draftsCreated: 0,
+    draftsSkipped: 0,
+    errors: [],
+  }
+
+  const supabase = getSupabaseAdmin()
+  if (!supabase) {
+    throw new Error('Supabase not configured')
+  }
+
+  // Step 1: Fetch all unprocessed feedback
+  const { data: rows, error: fetchError } = await supabase
+    .from('feedback')
+    .select('id, message, email, type, page, created_at, metadata')
+    .eq('processed', false)
+    .order('created_at', { ascending: true })
+
+  if (fetchError) {
+    throw new Error(`Failed to query feedback: ${fetchError.message}`)
+  }
+
+  const feedbackRows = (rows ?? []) as FeedbackRow[]
+  result.totalUnprocessed = feedbackRows.length
+
+  if (feedbackRows.length === 0) {
+    return result
+  }
+
+  // Rows with no email: mark processed immediately (no draft needed)
+  const noEmailIds = feedbackRows.filter((r) => !r.email).map((r) => r.id)
+  const emailRows = feedbackRows.filter((r) => !!r.email)
+
+  // Step 2: Group by email
+  const groups = groupByEmail(emailRows)
+  result.emailsWithFeedback = groups.size
+
+  // Step 3: Refresh Gmail access token once for the batch
+  let accessToken: string
+  try {
+    accessToken = await refreshAccessToken(gmailConfig)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    Sentry.captureException(err, { tags: { cron: 'feedback-processor' } })
+    throw new Error(`Gmail token refresh failed: ${msg}`)
+  }
+
+  // Step 4: Create drafts per email group (per-user error resilience)
+  const successfulIds: string[] = [...noEmailIds]
+
+  for (const [email, groupRows] of groups) {
+    try {
+      const body = buildDraftBody(email, groupRows)
+      const subject = `Feedback from ${email} (${groupRows.length} item${groupRows.length === 1 ? '' : 's'})`
+
+      await createGmailDraft(accessToken, {
+        to: 'dev@airwaylab.app',
+        subject,
+        body,
+      })
+
+      successfulIds.push(...groupRows.map((r) => r.id))
+      result.draftsCreated++
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      result.errors.push(`${email}: ${msg}`)
+      result.draftsSkipped++
+      Sentry.captureException(err, {
+        tags: { cron: 'feedback-processor' },
+        extra: { email, rowCount: groupRows.length },
+      })
+    }
+  }
+
+  // Step 5: Mark successfully processed rows
+  if (successfulIds.length > 0) {
+    const { error: updateError } = await supabase
+      .from('feedback')
+      .update({ processed: true, processed_at: new Date().toISOString() })
+      .in('id', successfulIds)
+
+    if (updateError) {
+      // Non-fatal: drafts were created, rows just aren't marked yet
+      const msg = `Failed to mark rows as processed: ${updateError.message}`
+      result.errors.push(msg)
+      console.error('[feedback-processor]', msg)
+      Sentry.captureException(new Error(msg), { tags: { cron: 'feedback-processor' } })
+    }
+  }
+
+  return result
+}

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,10 @@
     {
       "path": "/api/cron/subscription-drift",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/feedback-processor",
+      "schedule": "0 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Daily feedback processor cron re-implementation after lost worktree (AIR-759).

- **`lib/gmail/client.ts`** — Gmail REST API client: OAuth2 refresh token flow, base64url message encoding, draft creation. Zero external dependencies.
- **`lib/services/feedback-processor.ts`** — Query unprocessed feedback from Supabase, group by email, create consolidated Gmail drafts, mark rows processed. Per-user error resilience.
- **`app/api/cron/feedback-processor/route.ts`** — CRON_SECRET protected endpoint, silently skips if Gmail not configured.
- **`vercel.json`** — Daily cron at 07:00 UTC.
- **`lib/env.ts` / `.env.example`** — Document `GMAIL_CLIENT_ID`, `GMAIL_CLIENT_SECRET`, `GMAIL_REFRESH_TOKEN`.
- **`__tests__/feedback-processor.test.ts`** — 18 tests: email normalisation, grouping, draft body, config validation, token refresh, draft creation.

## Pre-merge checklist

- [x] Full pipeline passes (tsc, lint, test — 1932/1932 passed, build clean)
- [x] Bundle size impact: minimal (new server-only code, no client bundle impact)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked
- [ ] PR contains one concern only

## Gmail credentials required

Before the cron can create drafts, Demian must provision OAuth2 credentials for `dev@airwaylab.app` and set the three env vars in Vercel:
- `GMAIL_CLIENT_ID`
- `GMAIL_CLIENT_SECRET`
- `GMAIL_REFRESH_TOKEN`

Without them, the cron silently returns `{ skipped: true }` — safe to deploy before credentials are provisioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
