### PR TITLE
fix: update BiPAP pressure description in how-pap-therapy-works blog

### DIFF
--- a/app/blog/posts/how-pap-therapy-works.tsx
+++ b/app/blog/posts/how-pap-therapy-works.tsx
@@ -723,7 +723,7 @@ export default function HowPAPTherapyWorksPost() {
               EPAP holds the door open. Pressure Support pushes you through it. EPAP prevents
               collapse, PS ensures adequate ventilation. On CPAP, one pressure tries to do both
               jobs. On BiPAP, each job gets its own optimised pressure. That&apos;s why BiPAP
-              can be more effective for complex cases.
+              may be better suited for cases where independent pressure control is needed.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Replace `"can be more effective for complex cases"` with `"may be better suited for cases where independent pressure control is needed."` in `app/blog/posts/how-pap-therapy-works.tsx` line 726
- Single file, single line change — zero logic impact
- Resolves MDR Rule 4 compliance finding from AIR-681 (audit parent: AIR-679)

## Pre-merge checklist

- [x] Full pipeline passes: `npx tsc --noEmit` ✅ · `npm run lint` ✅ · `npm test` ✅ (1740 tests)
- [x] Bundle size impact: none (text content only)
- [x] One concern only (single file, single line)
- [x] Standing Pre-Approval class #1 applies (text-only MDR swap, Compliance PASS on file)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)

## Test plan

- [ ] Open the blog post at `/blog/how-pap-therapy-works` on the preview deploy
- [ ] Confirm the BiPAP section reads "may be better suited for cases where independent pressure control is needed" — no "effective" language
- [ ] No console errors
- [ ] Mobile viewport renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
