### PR TITLE
fix(persistence): add Sentry diagnostics to total-failure path

### DIFF
--- a/__tests__/persistence.test.ts
+++ b/__tests__/persistence.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { persistResults, loadPersistedResults, clearPersistedResults } from '@/lib/persistence';
 import { SAMPLE_NIGHTS } from '@/lib/sample-data';
 
+vi.mock('@sentry/nextjs', () => ({
+  addBreadcrumb: vi.fn(),
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+import * as Sentry from '@sentry/nextjs';
+
 // Mock localStorage
 const storage = new Map<string, string>();
 const localStorageMock: Storage = {
@@ -89,6 +97,54 @@ describe('persistence', () => {
       expect(result.reason).toBeDefined();
       // Restore original mock
       (localStorageMock as { setItem: typeof localStorageMock.setItem }).setItem = originalSetItem;
+    });
+
+    it('strips ned.reras from persisted data', () => {
+      const nightWithReras = {
+        ...SAMPLE_NIGHTS[0]!,
+        ned: {
+          ...SAMPLE_NIGHTS[0]!.ned,
+          reras: [
+            { startBreathIdx: 0, endBreathIdx: 10, breathCount: 10, nedSlope: 1.2, hasRecovery: true, hasSigh: false, maxNED: 45, startSec: 100, durationSec: 30 },
+            { startBreathIdx: 20, endBreathIdx: 28, breathCount: 8, nedSlope: 0.8, hasRecovery: false, hasSigh: true, maxNED: 38, startSec: 200, durationSec: 24 },
+          ],
+        },
+      };
+      persistResults([nightWithReras] as unknown as typeof SAMPLE_NIGHTS, null);
+      const saved = storage.get('airwaylab_results');
+      const parsed = JSON.parse(saved!);
+      expect(parsed.nights[0].ned.reras).toBeUndefined();
+    });
+
+    it('reports size diagnostics in Sentry on total failure', () => {
+      // Force total failure: override trySerialise by making the JSON size check fail.
+      // We do this by making the first night have a field that JSON.stringify produces > 4MB.
+      // Easiest: temporarily lower the cap by monkey-patching MAX_STORAGE_BYTES.
+      // Instead, build a night where JSON is genuinely large — use a huge extendedSettings map.
+      const hugeSettings = Object.fromEntries(
+        Array.from({ length: 200_000 }, (_, i) => [`key${i}`, i])
+      );
+      const largeNight = {
+        ...SAMPLE_NIGHTS[0]!,
+        settings: { ...SAMPLE_NIGHTS[0]!.settings, extendedSettings: hugeSettings },
+      };
+      vi.mocked(Sentry.captureMessage).mockClear();
+      persistResults([largeNight] as unknown as typeof SAMPLE_NIGHTS, null);
+
+      const calls = vi.mocked(Sentry.captureMessage).mock.calls;
+      const totalFailureCall = calls.find(
+        (c) => c[0] === 'Persistence: total failure — cannot save any nights'
+      );
+      if (totalFailureCall) {
+        const extra = (totalFailureCall[1] as { extra?: Record<string, unknown> })?.extra;
+        expect(extra).toBeDefined();
+        expect(typeof extra!.singleNightApproxBytes).toBe('number');
+        expect(extra!.singleNightApproxBytes).toBeGreaterThan(0);
+        expect(extra!.singleNightSections).toBeDefined();
+        expect(typeof extra!.totalNights).toBe('number');
+      }
+      // If saved successfully (the huge extendedSettings still fits — that's fine),
+      // just verify we didn't break anything.
     });
   });
 

--- a/__tests__/persistence.test.ts
+++ b/__tests__/persistence.test.ts
@@ -135,16 +135,13 @@ describe('persistence', () => {
       const totalFailureCall = calls.find(
         (c) => c[0] === 'Persistence: total failure — cannot save any nights'
       );
-      if (totalFailureCall) {
-        const extra = (totalFailureCall[1] as { extra?: Record<string, unknown> })?.extra;
-        expect(extra).toBeDefined();
-        expect(typeof extra!.singleNightApproxBytes).toBe('number');
-        expect(extra!.singleNightApproxBytes).toBeGreaterThan(0);
-        expect(extra!.singleNightSections).toBeDefined();
-        expect(typeof extra!.totalNights).toBe('number');
-      }
-      // If saved successfully (the huge extendedSettings still fits — that's fine),
-      // just verify we didn't break anything.
+      expect(totalFailureCall).toBeDefined();
+      const extra = (totalFailureCall![1] as { extra?: Record<string, unknown> })?.extra;
+      expect(extra).toBeDefined();
+      expect(typeof extra!.singleNightApproxBytes).toBe('number');
+      expect(extra!.singleNightApproxBytes).toBeGreaterThan(0);
+      expect(extra!.singleNightSections).toBeDefined();
+      expect(typeof extra!.totalNights).toBe('number');
     });
   });
 

--- a/lib/persistence.ts
+++ b/lib/persistence.ts
@@ -37,6 +37,7 @@ function stripBulkData(nights: NightResult[]): NightResult[] {
     ned: {
       ...n.ned,
       breaths: [], // Per-breath data stored in IndexedDB (breath-data-idb.ts), not localStorage
+      reras: undefined, // RERA candidate list not needed for display; can be large for heavy RERA users
     },
     oximetryTrace: null, // trace data too large for localStorage — re-extract on demand
     // settingsMetrics is a small summary object — keep it for persistence
@@ -122,17 +123,40 @@ export function persistResults(
     }
 
     // Even a single night doesn't fit — total failure
-    console.error('[persistence] Cannot save even 1 night — data too large.');
+    // Compute size breakdown to diagnose root cause in Sentry
+    const singleNightDiag = (() => {
+      if (nights.length === 0) return null;
+      const strippedArr = stripBulkData([nights[0]!]);
+      const stripped = strippedArr[0];
+      if (!stripped) return null;
+      const sections: Record<string, number> = {};
+      for (const key of Object.keys(stripped) as (keyof NightResult)[]) {
+        try {
+          sections[key] = JSON.stringify(stripped[key]).length * 2;
+        } catch {
+          sections[key] = -1;
+        }
+      }
+      const totalBytes = JSON.stringify(stripped).length * 2;
+      return { totalBytes, sections };
+    })();
+
+    console.error('[persistence] Cannot save even 1 night — data too large.', singleNightDiag);
     Sentry.captureMessage('Persistence: total failure — cannot save any nights', {
       level: 'error',
-      extra: { totalNights: nights.length },
+      extra: {
+        totalNights: nights.length,
+        maxStorageBytes: MAX_STORAGE_BYTES,
+        singleNightApproxBytes: singleNightDiag?.totalBytes ?? null,
+        singleNightSections: singleNightDiag?.sections ?? null,
+      },
     });
 
     return {
       saved: false,
       nightsSaved: 0,
       nightsDropped: nights.length,
-      reason: 'Your results are too large to save in this browser. They will be available until you close the tab, but you\'ll need to re-upload next time.',
+      reason: 'Your results are too large to save in this browser. They will be available until you close the tab, but you\'ll need to re-upload next time. Try clearing your browser\'s site data for airwaylab.app if this persists.',
     };
   } catch (err) {
     // QuotaExceededError or SecurityError


### PR DESCRIPTION
## Summary

- Strip `ned.reras` from localStorage persistence — not needed for display, but can be sizeable for heavy RERA users, contributing to the 4MB cap being hit
- Add per-section size breakdown to Sentry capture on total-failure path so future occurrences reveal which field caused the size limit breach
- Improve user-facing error message to suggest clearing site data if the issue persists

## Test plan

- [ ] `npm test` passes (reras stripping verified, Sentry diagnostic context on failure verified)
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Upload SD card data — results persist normally, no regression in displayed NED metrics
- [ ] Verify reras are not present in localStorage after analysis

## Pre-Merge Checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Bundle size impact checked (flag if >10KB increase)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [ ] Self-review: no regressions, loading/error/empty states handled
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)