### PR TITLE
feat(analyze): Treatment B upload-again CTA (AIR-834)

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -50,6 +50,7 @@ import { safeGetItem } from '@/lib/safe-local-storage';
 import { isIOSDevice } from '@/lib/directory-traversal';
 import { GuidedWalkthrough } from '@/components/dashboard/guided-walkthrough';
 import { PostAnalysisUpgrade } from '@/components/dashboard/post-analysis-upgrade';
+import { UploadAgainCta } from '@/components/dashboard/upload-again-cta';
 import { HistoryExpiryWarning } from '@/components/dashboard/history-expiry-warning';
 import { Disclaimer } from '@/components/common/disclaimer';
 import * as Sentry from '@sentry/nextjs';
@@ -1093,6 +1094,13 @@ function AnalyzePageInner() {
             }} />
             <GuidedWalkthrough isComplete={isComplete} />
             {!isDemo && <PostAnalysisUpgrade isComplete={isComplete} />}
+            {!isDemo && (
+              <UploadAgainCta
+                isComplete={isComplete}
+                sessionCount={sessionCount}
+                onUploadAnother={handleReset}
+              />
+            )}
             {!isDemo && <HistoryExpiryWarning nights={nights} hiddenNightCount={hiddenNightCount} />}
             {!isDemo && <EmailOptInNudge />}
             <DataContribution

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -49,6 +49,7 @@ import { safeGetItem } from '@/lib/safe-local-storage';
 import { isIOSDevice } from '@/lib/directory-traversal';
 import { GuidedWalkthrough } from '@/components/dashboard/guided-walkthrough';
 import { PostAnalysisUpgrade } from '@/components/dashboard/post-analysis-upgrade';
+import { UploadAgainCta } from '@/components/dashboard/upload-again-cta';
 import { HistoryExpiryWarning } from '@/components/dashboard/history-expiry-warning';
 import { Disclaimer } from '@/components/common/disclaimer';
 import * as Sentry from '@sentry/nextjs';
@@ -1077,6 +1078,13 @@ function AnalyzePageInner() {
             }} />
             <GuidedWalkthrough isComplete={isComplete} />
             {!isDemo && <PostAnalysisUpgrade isComplete={isComplete} />}
+            {!isDemo && (
+              <UploadAgainCta
+                isComplete={isComplete}
+                sessionCount={sessionCount}
+                onUploadAnother={handleReset}
+              />
+            )}
             {!isDemo && <HistoryExpiryWarning nights={nights} />}
             {!isDemo && <EmailOptInNudge />}
             <DataContribution

--- a/components/dashboard/upload-again-cta.tsx
+++ b/components/dashboard/upload-again-cta.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Upload, X, TrendingUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { events } from '@/lib/analytics';
+
+const STORAGE_KEY = 'airwaylab_upload_again_cta_dismissed';
+
+interface Props {
+  isComplete: boolean;
+  sessionCount: number;
+  onUploadAnother: () => void;
+}
+
+export function UploadAgainCta({ isComplete, sessionCount, onUploadAnother }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isComplete || sessionCount !== 1) return;
+
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === '1') return;
+    } catch {
+      return;
+    }
+
+    setVisible(true);
+  }, [isComplete, sessionCount]);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    setVisible(false);
+    try {
+      localStorage.setItem(STORAGE_KEY, '1');
+    } catch { /* noop */ }
+    events.upgradeNudgeDismissed('upload_again_cta');
+  };
+
+  const handleUploadClick = () => {
+    dismiss();
+    events.upgradeNudgeClicked('upload_again_cta');
+    onUploadAnother();
+  };
+
+  return (
+    <div className="animate-fade-in-up rounded-xl border border-blue-500/20 bg-blue-500/5 px-4 py-4">
+      <div className="flex items-start gap-3">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
+          <TrendingUp className="h-4 w-4 text-blue-400" />
+        </div>
+        <div className="flex-1">
+          <div className="flex items-start justify-between">
+            <h3 className="text-sm font-semibold text-foreground">
+              Your first upload is a snapshot. Upload again to see what changed.
+            </h3>
+            <button
+              onClick={dismiss}
+              className="rounded p-2.5 text-muted-foreground/50 transition-colors hover:text-muted-foreground"
+              aria-label="Dismiss"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Users who track two or more uploads have more to discuss with their clinician.
+          </p>
+          <div className="mt-3">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleUploadClick}
+              className="gap-1.5"
+            >
+              <Upload className="h-3.5 w-3.5" />
+              Upload another file
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `UploadAgainCta` component (Treatment B) to the analyze page nudge banners section
- Shown once to users on their first completed analysis (`sessionCount === 1`), not in demo mode
- Dismissible via localStorage (`airwaylab_upload_again_cta_dismissed`)
- Button triggers `handleReset` → returns user to upload screen

## Approved copy (AIR-832 — PASS)

> **Headline:** "Your first upload is a snapshot. Upload again to see what changed."
> **Sub-copy (Option A):** "Users who track two or more uploads have more to discuss with their clinician."
> **Button:** "Upload another file"

Rejected sub-copy ("spot trends that change how they talk to their clinician") is not present anywhere in the codebase.

## Disclaimer

`<Disclaimer persistent />` already present on the analyze page — always visible above the results dashboard. No addition needed.

## Pre-merge checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] Bundle size impact checked — 2 files, 92 lines added, negligible
- [ ] Vercel preview deploy verified by Demian
- [x] ALL manual QA items checked (partial pass = no merge)
- [x] Self-review: no regressions, dismissed state handled via localStorage
- [x] PR contains one concern only

## Related

- Compliance sign-off: AIR-832 (PASS)
- CEO approval: Option A confirmed (AIR-570 auto-ship class, AIR-569)

🤖 Generated with [Claude Code](https://claude.com/claude-code)