### PR TITLE
docs(privacy): add Google Gmail API as feedback processor (AIR-773)

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -21,8 +21,7 @@ export default function PrivacyPolicyPage() {
       <div className="mb-10">
         <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Privacy Policy</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Last updated: 12 April 2026
-          Last updated: 16 April 2026
+          Last updated: 22 April 2026
         </p>
         <div className="mt-4 flex items-center gap-1.5 text-xs text-emerald-500">
           <Shield className="h-3.5 w-3.5 shrink-0" />
@@ -87,6 +86,12 @@ export default function PrivacyPolicyPage() {
             <li>Email address (for authentication and account communications)</li>
             <li>Display name (optional, for supporter acknowledgement)</li>
             <li>Subscription tier and billing status (via Stripe)</li>
+            <li>
+              <strong>Feedback submissions:</strong> When you submit feedback through the app, your
+              email address and feedback text are stored in our database (Supabase, EU-West). A
+              daily automated process consolidates feedback into internal Gmail drafts for team
+              review (via Google Gmail API). No health data is included in feedback submissions.
+            </li>
           </ul>
 
           <h3 className="mt-4">3.2 Email Communications (Opt-In)</h3>
@@ -246,6 +251,11 @@ export default function PrivacyPolicyPage() {
             <li>
               <strong>Error logs (Sentry):</strong> Retained for 90 days.
             </li>
+            <li>
+              <strong>Feedback submissions:</strong> Retained in our database until you request
+              account deletion. Gmail drafts created by the daily feedback processor are internal
+              team records and are deleted as part of normal team operations.
+            </li>
           </ul>
         </section>
 
@@ -317,9 +327,9 @@ export default function PrivacyPolicyPage() {
                 </tr>
                 <tr>
                   <td className="py-2 pr-4 font-medium text-foreground">Upstash</td>
-                  <td className="py-2 pr-4">Rate limiting</td>
+                  <td className="py-2 pr-4">Rate limiting (Redis)</td>
                   <td className="py-2 pr-4">US</td>
-                  <td className="py-2">User IDs and hashed IP addresses (transient, rate-limit windows only)</td>
+                  <td className="py-2">IP-derived request counters only. No personal data or health data.</td>
                 </tr>
                 <tr>
                   <td className="py-2 pr-4 font-medium text-foreground">Resend</td>
@@ -334,16 +344,12 @@ export default function PrivacyPolicyPage() {
                   <td className="py-2">Discord user ID and username only. No health data is sent to Discord.</td>
                 </tr>
                 <tr>
-                  <td className="py-2 pr-4 font-medium text-foreground">Upstash</td>
-                  <td className="py-2 pr-4">Rate limiting (Redis)</td>
+                  <td className="py-2 pr-4 font-medium text-foreground">Google Gmail API</td>
+                  <td className="py-2 pr-4">Internal feedback review</td>
                   <td className="py-2 pr-4">US</td>
-                  <td className="py-2">IP-derived request counters only. No personal data or health data.</td>
+                  <td className="py-2">User email address and feedback text. Used by an automated daily process to consolidate submitted feedback into internal draft emails for team review. No health data is included.</td>
                 </tr>
                 <tr>
-                  <td className="py-2 pr-4 font-medium text-foreground">GitHub API</td>
-                  <td className="py-2 pr-4">Repository metadata (star count)</td>
-                  <td className="py-2 pr-4">US</td>
-                  <td className="py-2">Server-side only. No user data is sent to GitHub.</td>
                   <td className="py-2 pr-4 font-medium text-foreground">GitHub API</td>
                   <td className="py-2 pr-4">Repository star count display</td>
                   <td className="py-2 pr-4">US</td>
@@ -451,11 +457,8 @@ export default function PrivacyPolicyPage() {
           <h2>11. International Data Transfers</h2>
           <p>
             Our primary database is hosted in the EU (Supabase EU-West region). Some services
-            (Anthropic, Sentry, Resend, Upstash) process data in the US. For EU users, these transfers are
-            governed by Standard Contractual Clauses (SCCs) or the EU-US Data Privacy Framework
-            where applicable.
-            (Anthropic, Sentry, Resend, Upstash) process data in the US. For EU users, these
-            transfers are governed by Standard Contractual Clauses (SCCs) or the EU-US Data
+            (Anthropic, Sentry, Resend, Upstash, Google) process data in the US. For EU users,
+            these transfers are governed by Standard Contractual Clauses (SCCs) or the EU-US Data
             Privacy Framework where applicable.
           </p>
           <p>


### PR DESCRIPTION
## Summary

Adds Google Gmail API to the processors table in the privacy policy, disclosing that user email addresses and feedback text are processed via the daily feedback processor cron introduced in AIR-759. Also adds a feedback-submission data inventory entry to section 3.1, retention note to section 5, and updates section 11 (International Transfers) to include Google in the US-processor list. Incidental cleanup fixes duplicate "Last updated" dates, duplicate Upstash row, and a malformed GitHub API table row inherited from prior edits.

## Context

Re-cut from origin/main (61971f5) with isolated cherry-pick of `app/privacy/page.tsx` from commit 198f19b after the original PR #615 was closed for carrying unrelated reverts of AIR-757 (Discord sync backoff) and AIR-680 (insights MDR fixes).

CEO sign-off recorded on AIR-782. Gate was: diff must be `app/privacy/page.tsx` ONLY. Verified with `git diff --name-only origin/main` returning exactly that one file.

Refs: AIR-773, AIR-782 (CEO sign-off), AIR-759

## Test plan

- [x] Full pipeline: tsc clean, lint clean, build succeeds
- [x] Diff scope verified: `app/privacy/page.tsx` only (35 lines, +19 -16)
- [ ] Vercel preview deploy verified by Demian
- [ ] Privacy policy page loads on preview
- [ ] Processors table shows Google Gmail API row
- [ ] Section 3.1 shows feedback submissions inventory entry
- [ ] Section 5 shows feedback retention note
- [ ] Section 11 includes Google in US processor list
- [ ] No duplicate "Last updated" dates
- [ ] Mobile viewport renders correctly

## Notes

- Pre-existing test failure in `__tests__/first-run-onboarding.test.tsx` (8 tests, localStorage setup) is unrelated to this change. Confirmed reproduces on origin/main without this diff. Tracked under AIR-784 (CTO E2E investigation).
- Repo-wide E2E flake also tracked under AIR-784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)