### PR TITLE
docs(privacy): add Google Gmail API as feedback processor (AIR-773)

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -21,8 +21,7 @@ export default function PrivacyPolicyPage() {
       <div className="mb-10">
         <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Privacy Policy</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Last updated: 12 April 2026
-          Last updated: 16 April 2026
+          Last updated: 22 April 2026
         </p>
         <div className="mt-4 flex items-center gap-1.5 text-xs text-emerald-500">
           <Shield className="h-3.5 w-3.5 shrink-0" />
@@ -87,6 +86,12 @@ export default function PrivacyPolicyPage() {
             <li>Email address (for authentication and account communications)</li>
             <li>Display name (optional, for supporter acknowledgement)</li>
             <li>Subscription tier and billing status (via Stripe)</li>
+            <li>
+              <strong>Feedback submissions:</strong> When you submit feedback through the app, your
+              email address and feedback text are stored in our database (Supabase, EU-West). A
+              daily automated process consolidates feedback into internal Gmail drafts for team
+              review (via Google Gmail API). No health data is included in feedback submissions.
+            </li>
           </ul>
 
           <h3 className="mt-4">3.2 Email Communications (Opt-In)</h3>
@@ -246,6 +251,11 @@ export default function PrivacyPolicyPage() {
             <li>
               <strong>Error logs (Sentry):</strong> Retained for 90 days.
             </li>
+            <li>
+              <strong>Feedback submissions:</strong> Retained in our database until you request
+              account deletion. Gmail drafts created by the daily feedback processor are internal
+              team records and are deleted as part of normal team operations.
+            </li>
           </ul>
         </section>
 
@@ -317,9 +327,9 @@ export default function PrivacyPolicyPage() {
                 </tr>
                 <tr>
                   <td className="py-2 pr-4 font-medium text-foreground">Upstash</td>
-                  <td className="py-2 pr-4">Rate limiting</td>
+                  <td className="py-2 pr-4">Rate limiting (Redis)</td>
                   <td className="py-2 pr-4">US</td>
-                  <td className="py-2">User IDs and hashed IP addresses (transient, rate-limit windows only)</td>
+                  <td className="py-2">IP-derived request counters only. No personal data or health data.</td>
                 </tr>
                 <tr>
                   <td className="py-2 pr-4 font-medium text-foreground">Resend</td>
@@ -334,16 +344,12 @@ export default function PrivacyPolicyPage() {
                   <td className="py-2">Discord user ID and username only. No health data is sent to Discord.</td>
                 </tr>
                 <tr>
-                  <td className="py-2 pr-4 font-medium text-foreground">Upstash</td>
-                  <td className="py-2 pr-4">Rate limiting (Redis)</td>
+                  <td className="py-2 pr-4 font-medium text-foreground">Google Gmail API</td>
+                  <td className="py-2 pr-4">Internal feedback review</td>
                   <td className="py-2 pr-4">US</td>
-                  <td className="py-2">IP-derived request counters only. No personal data or health data.</td>
+                  <td className="py-2">User email address and feedback text. Used by an automated daily process to consolidate submitted feedback into internal draft emails for team review. No health data is included.</td>
                 </tr>
                 <tr>
-                  <td className="py-2 pr-4 font-medium text-foreground">GitHub API</td>
-                  <td className="py-2 pr-4">Repository metadata (star count)</td>
-                  <td className="py-2 pr-4">US</td>
-                  <td className="py-2">Server-side only. No user data is sent to GitHub.</td>
                   <td className="py-2 pr-4 font-medium text-foreground">GitHub API</td>
                   <td className="py-2 pr-4">Repository star count display</td>
                   <td className="py-2 pr-4">US</td>
@@ -451,11 +457,8 @@ export default function PrivacyPolicyPage() {
           <h2>11. International Data Transfers</h2>
           <p>
             Our primary database is hosted in the EU (Supabase EU-West region). Some services
-            (Anthropic, Sentry, Resend, Upstash) process data in the US. For EU users, these transfers are
-            governed by Standard Contractual Clauses (SCCs) or the EU-US Data Privacy Framework
-            where applicable.
-            (Anthropic, Sentry, Resend, Upstash) process data in the US. For EU users, these
-            transfers are governed by Standard Contractual Clauses (SCCs) or the EU-US Data
+            (Anthropic, Sentry, Resend, Upstash, Google) process data in the US. For EU users,
+            these transfers are governed by Standard Contractual Clauses (SCCs) or the EU-US Data
             Privacy Framework where applicable.
           </p>
           <p>


### PR DESCRIPTION
## Summary

Cherry-pick of commit `198f19b` (originally on `feat/air-759-feedback-processor`, not included in PR #611 merge).

Discloses Google Gmail API as a data processor — the daily feedback processor cron introduced in [AIR-759](#611) creates internal Gmail drafts from user feedback. This was compliance-reviewed and approved before PR #611 merged but was not included in that PR.

**Changes (single commit, docs-only):**
- Section 3.1: Feedback submissions data inventory item
- Section 5: Feedback submissions retention note
- Section 6 processor table: Google Gmail API row (purpose, US region, data types, no health data)
- Section 11: Google added to international transfers list
- Housekeeping: fixed duplicate "Last updated" dates, duplicate Upstash row, malformed GitHub API table row

## Compliance

Previously reviewed and approved by Head of Compliance on 2026-04-23.

## Test plan

- [x]  ✓
- [x] 
> airwaylab@1.2.2 lint
> eslint . ✓  
- [x] 
> airwaylab@1.2.2 build
> node scripts/check-version.mjs && next build --webpack

✓ Version 1.2.2 matches CHANGELOG.md
▲ Next.js 16.2.1 (webpack)
- Experiments (use with caution):
  · clientTraceMetadata

  Creating an optimized production build ...
✓ Compiled successfully in 27.8s
  Running TypeScript ...
  Finished TypeScript in 18.0s ...
  Collecting page data using 7 workers ...
  Generating static pages using 7 workers (0/167) ...
  Generating static pages using 7 workers (41/167) 
  Generating static pages using 7 workers (83/167) 
  Generating static pages using 7 workers (125/167) 
✓ Generating static pages using 7 workers (167/167) in 1113ms
  Finalizing page optimization ...
  Collecting build traces ...

Route (app)                                            Revalidate  Expire
┌ ○ /
├ ○ /_not-found
├ ○ /about
├ ○ /about/flow-limitation
├ ○ /about/glasgow-index
├ ○ /about/oximetry-analysis
├ ○ /accessibility
├ ○ /account
├ ○ /analyze
├ ƒ /api/admin/broadcast
├ ƒ /api/admin/ml-export
├ ƒ /api/admin/send-discord-announcement
├ ƒ /api/ai-insights
├ ƒ /api/auth/discord
├ ƒ /api/auth/discord/callback
├ ƒ /api/auth/discord/link-username
├ ƒ /api/auth/discord/unlink
├ ƒ /api/community-benchmarks
├ ƒ /api/community-insights
├ ƒ /api/consent-audit
├ ƒ /api/contact
├ ƒ /api/contribute-data
├ ƒ /api/contribute-oximetry-trace
├ ƒ /api/contribute-symptoms
├ ƒ /api/contribute-waveforms
├ ƒ /api/create-checkout-session
├ ƒ /api/cron/ai-monitor
├ ƒ /api/cron/cleanup
├ ƒ /api/cron/discord-sync
├ ƒ /api/cron/feedback-processor
├ ƒ /api/cron/monitor
├ ƒ /api/cron/subscription-drift
├ ƒ /api/cron/weekly-digest
├ ƒ /api/customer-portal
├ ƒ /api/delete-user-data
├ ƒ /api/device-diagnostic
├ ƒ /api/email/announce
├ ƒ /api/email/opt-in
├ ƒ /api/email/trigger
├ ƒ /api/email/unsubscribe
├ ƒ /api/feedback
├ ƒ /api/files/check-hashes
├ ƒ /api/files/confirm
├ ƒ /api/files/consent
├ ƒ /api/files/delete
├ ƒ /api/files/download
├ ƒ /api/files/list
├ ƒ /api/files/presign
├ ƒ /api/files/usage
├ ƒ /api/github-stars
├ ƒ /api/health
├ ƒ /api/provider-interest
├ ƒ /api/remind-desktop
├ ƒ /api/remind-desktop/unsubscribe
├ ƒ /api/request-account-deletion
├ ƒ /api/share
├ ƒ /api/share/files
├ ƒ /api/stats
├ ƒ /api/store-analysis-data
├ ƒ /api/submit-device-data
├ ƒ /api/submit-error-data
├ ƒ /api/subscribe
├ ƒ /api/track-analysis
├ ƒ /api/user-data-stats
├ ƒ /api/version
├ ƒ /api/webhooks/resend
├ ƒ /api/webhooks/sentry
├ ƒ /api/webhooks/stripe
├ ○ /apple-icon
├ ƒ /auth/callback
├ ○ /blog
├ ● /blog/[slug]
│ ├ /blog/how-to-analyze-cpap-data-at-home
│ ├ /blog/how-to-read-oscar-cpap-charts
│ ├ /blog/cpap-leak-rate-explained
│ └ [+38 more paths]
├ ○ /blog/how-to-export-and-understand-your-cpap-data
├ ○ /changelog
├ ○ /community
├ ○ /compare
├ ○ /compare/myair
├ ○ /compare/oscar
├ ○ /compare/sleephq
├ ○ /contact
├ ○ /getting-started
├ ○ /glossary
├ ● /glossary/[term]
│ ├ /glossary/ahi
│ ├ /glossary/glasgow-index
│ ├ /glossary/fl-score
│ └ [+32 more paths]
├ ○ /guides
├ ● /guides/[device]
│ ├ /guides/airsense-10
│ ├ /guides/airsense-11
│ ├ /guides/aircurve-10
│ └ /guides/bmc-luna
├ ○ /icon.svg
├ ○ /manifest.webmanifest
├ ○ /opengraph-image
├ ○ /pricing
├ ○ /privacy
├ ○ /providers
├ ○ /research
├ ○ /robots.txt
├ ○ /settings
├ ƒ /shared/[id]
├ ○ /sitemap.xml
├ ○ /supporters                                                1h      1y
├ ○ /terms
└ ○ /twitter-image


ƒ Proxy (Middleware)

○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses generateStaticParams)
ƒ  (Dynamic)  server-rendered on demand ✓
- [x] 1941 tests pass ✓
- [x] Docs-only change — no bundle impact
- [ ] Vercel preview deploy verified by Demian

🤖 Generated with [Claude Code](https://claude.com/claude-code)