### PR TITLE
fix: add consent filter to feedback processing query (AIR-861)

### DIFF
--- a/lib/services/feedback-processor.ts
+++ b/lib/services/feedback-processor.ts
@@ -109,11 +109,13 @@ export async function processFeedback(gmailConfig: GmailConfig): Promise<Process
     throw new Error('Supabase not configured')
   }
 
-  // Step 1: Fetch all unprocessed feedback
+  // Step 1: Fetch unprocessed feedback where user has consented to contact
   const { data: rows, error: fetchError } = await supabase
     .from('feedback')
     .select('id, message, email, type, page, created_at, metadata')
     .eq('processed', false)
+    .eq('contact_ok', true)
+    .not('email', 'is', null)
     .order('created_at', { ascending: true })
 
   if (fetchError) {
@@ -127,12 +129,8 @@ export async function processFeedback(gmailConfig: GmailConfig): Promise<Process
     return result
   }
 
-  // Rows with no email: mark processed immediately (no draft needed)
-  const noEmailIds = feedbackRows.filter((r) => !r.email).map((r) => r.id)
-  const emailRows = feedbackRows.filter((r) => !!r.email)
-
   // Step 2: Group by email
-  const groups = groupByEmail(emailRows)
+  const groups = groupByEmail(feedbackRows)
   result.emailsWithFeedback = groups.size
 
   // Step 3: Refresh Gmail access token once for the batch
@@ -146,7 +144,7 @@ export async function processFeedback(gmailConfig: GmailConfig): Promise<Process
   }
 
   // Step 4: Create drafts per email group (per-user error resilience)
-  const successfulIds: string[] = [...noEmailIds]
+  const successfulIds: string[] = []
 
   for (const [email, groupRows] of groups) {
     try {

--- a/supabase/migrations/041_feedback_consent_processing_index.sql
+++ b/supabase/migrations/041_feedback_consent_processing_index.sql
@@ -1,0 +1,10 @@
+-- 041: Partial index for consent-filtered feedback processing query
+-- Supports the consent-aware processor query:
+--   WHERE processed = false AND contact_ok = true AND email IS NOT NULL
+-- Replaces idx_feedback_processed (which ignored consent) for this path.
+
+CREATE INDEX IF NOT EXISTS idx_feedback_unprocessed_consented
+  ON public.feedback(created_at ASC)
+  WHERE processed = false
+    AND contact_ok = true
+    AND email IS NOT NULL;


### PR DESCRIPTION
## Summary

- Adds `.eq('contact_ok', true)` and `.not('email', 'is', null)` to the Supabase query in `processFeedback()` (`lib/services/feedback-processor.ts`)
- Only users who explicitly opted in to contact are included in Gmail draft batches
- Removes now-redundant client-side null-email filter (query handles it at DB level)
- Adds migration `041_feedback_consent_processing_index.sql` with a partial index on the consent-aware query path

## Context

Part of AIR-861 — recreating the AIR-786 fix that was lost to worktree cleanup. The feedback-processor has been running without a consent filter since AIR-759 merged (2026-04-22), creating Gmail drafts for non-consented users (GDPR Article 6 violation).

## ⚠️ Compliance review required

This PR touches consent / privacy-default code and is **not eligible for auto-ship**. Head of Compliance must PASS before merge.

**Review checklist:**
- [ ] `.eq('contact_ok', true)` correctly filters non-consented users
- [ ] `.not('email', 'is', null)` correctly excludes null-email rows from Gmail-draft surface
- [ ] Removal of client-side null-email filter is safe given new query-level filter
- [ ] Migration 041 partial index matches the new query predicate exactly
- [ ] No data already routed to Gmail needs scrubbing follow-up (in-scope or separate ticket)

## Pre-merge checklist

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 121 test files, 1941 tests passed
- [ ] Vercel preview verified by Demian (server-only route, no UI surface — preview should be smoke-tested via the cron endpoint directly)
- [ ] Head of Compliance PASS
- [x] PR contains one concern only
