### PR TITLE
content: replace RERA detection with estimation in sleephq compare page

### DIFF
--- a/app/compare/sleephq/page.tsx
+++ b/app/compare/sleephq/page.tsx
@@ -224,7 +224,7 @@ export default function CompareSleepHQPage() {
             <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
               <p className="text-sm font-semibold text-emerald-400">Four Analysis Engines</p>
               <p className="mt-1 text-xs text-muted-foreground">
-                Glasgow Index, WAT (FL Score, Regularity, Periodicity), NED (RERA detection,
+                Glasgow Index, WAT (FL Score, Regularity, Periodicity), NED (RERA estimation,
                 Flatness Index, M-shape), and a 17-metric Oximetry pipeline. SleepHQ provides
                 standard metrics that PAP machines already report.
               </p>
@@ -277,7 +277,7 @@ export default function CompareSleepHQPage() {
                 <td className="px-4 py-2.5 text-center text-emerald-400">4 engines</td>
               </tr>
               <tr className="border-b border-border/30">
-                <td className="py-2.5 pr-4">RERA detection</td>
+                <td className="py-2.5 pr-4">RERA estimation</td>
                 <td className="px-4 py-2.5 text-center text-muted-foreground/60">No</td>
                 <td className="px-4 py-2.5 text-center text-emerald-400">Yes (NED)</td>
               </tr>
@@ -462,7 +462,7 @@ export default function CompareSleepHQPage() {
         <h3 className="text-lg font-bold">Try AirwayLab Free</h3>
         <p className="mt-2 text-sm text-muted-foreground">
           Upload your ResMed SD card and get flow limitation analysis in minutes. Four research-grade
-          engines, composite metrics, RERA detection, and trend tracking. No installation, no account
+          engines, composite metrics, RERA estimation, and trend tracking. No installation, no account
           required, 100% private.
         </p>
         <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">


### PR DESCRIPTION
## Summary

Bonus cleanup found during [AIR-877](/AIR/issues/AIR-877) audit: 3 identical MDR Rule 2 violations in `app/compare/sleephq/page.tsx`.

- Comparison table row: `RERA detection` → `RERA estimation`
- Four Analysis Engines card: `NED (RERA detection, ...)` → `NED (RERA estimation, ...)`
- CTA paragraph: `RERA detection, and trend tracking` → `RERA estimation, and trend tracking`

**MDR Rule 2:** "detection" implies clinical classification; "estimation" frames the output as a derived metric.

Verified by Head of Compliance. **SPA class 1 — CTO auto-merge authorised.**

## Test plan

- [x] No instances of "RERA detection" remain in `compare/sleephq/page.tsx`
- [x] tsc ✓  lint ✓  1941 tests ✓  build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)