### PR TITLE
content: What Your CPAP Data Actually Shows You (Article 8)

### DIFF
--- a/app/blog/posts/how-to-read-cpap-data.tsx
+++ b/app/blog/posts/how-to-read-cpap-data.tsx
@@ -1,206 +1,78 @@
 import Link from 'next/link';
 import {
+  AlertTriangle,
   ArrowRight,
   BarChart3,
-  BookOpen,
   HardDrive,
-  Lightbulb,
-  Monitor,
-  Stethoscope,
-  TrendingUp,
   Wind,
+  XCircle,
 } from 'lucide-react';
 
 export default function HowToReadCPAPDataPost() {
   return (
     <article>
       <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
-        You&apos;ve started CPAP therapy. Your machine has been collecting data every night
-        &mdash; pressure, events, leak rate, flow &mdash; and at some point someone told you to
-        check it. So you downloaded an app, opened a file, and stared at a wall of numbers and
-        coloured graphs that made very little sense.
+        Most CPAP machines record detailed information every night. AHI, leak rate, usage hours,
+        pressure data — these numbers sit on an SD card, quietly accumulating. Your clinician
+        reviews them at appointments. But you can look at them too, right now, for free, without
+        sending your data anywhere.
       </p>
       <p className="mt-4 text-base leading-relaxed text-muted-foreground sm:text-lg">
-        This happens to almost everyone. The data your machine records is genuinely useful, but
-        the tools that display it were often designed by engineers, for engineers. Nobody hands
-        you a glossary when you pick up your mask.
-      </p>
-      <p className="mt-4 text-base leading-relaxed text-muted-foreground sm:text-lg">
-        This article is that glossary. We&apos;ll walk through what your CPAP machine actually
-        records, what the key metrics mean, and how to start reading your data in a way that&apos;s
-        useful &mdash; whether you&apos;re reviewing it yourself or preparing for a conversation
-        with your equipment provider or sleep clinician.
+        This guide explains what each metric represents and how to visualise it in AirwayLab.
       </p>
 
-      {/* Medical disclaimer at top */}
-      <blockquote className="mt-6 rounded-xl border border-amber-500/20 bg-amber-500/5 px-5 py-4">
-        <p className="text-sm leading-relaxed text-muted-foreground">
-          <strong className="text-foreground">Medical disclaimer:</strong> The information in this
-          article is educational only. Nothing here constitutes medical advice, a diagnosis, or a
-          treatment recommendation. CPAP data is informational &mdash; please discuss any
-          observations or concerns with your clinician or equipment provider.
-        </p>
-      </blockquote>
+      {/* Top disclaimer */}
+      <div className="mt-6 rounded-xl border border-amber-500/20 bg-amber-500/5 p-5">
+        <div className="flex items-start gap-2.5">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            <strong className="text-foreground">Medical disclaimer:</strong> AirwayLab is a data
+            visualisation tool, not a medical device. Nothing in this article constitutes medical
+            advice. Always discuss your therapy data and any concerns with your sleep physician or
+            qualified clinician.
+          </p>
+        </div>
+      </div>
 
-      {/* What Your CPAP Machine Actually Records */}
+      {/* Section 1: Four Key Metrics */}
       <section className="mt-10">
         <div className="flex items-center gap-2.5">
-          <HardDrive className="h-5 w-5 text-blue-400" />
+          <BarChart3 className="h-5 w-5 text-blue-400" />
           <h2 className="text-xl font-bold sm:text-2xl">
-            What Your CPAP Machine Actually Records
+            How to Read Your CPAP Data: The Four Metrics Your Clinician Will Reference
           </h2>
         </div>
-        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
-          <p>Your machine is running a quiet sensor session every night. Here&apos;s what it&apos;s capturing:</p>
-          <div className="space-y-3">
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Usage hours</p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                How long the machine was running. This is the most basic metric and the one your
-                provider usually checks first.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">
-                AHI (Apnoea-Hypopnoea Index)
-              </p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                The number of apnoeas (complete pauses in breathing) and hypopnoeas (partial
-                reductions in airflow) per hour of therapy. Your machine counts events it detects
-                while running; this is not the same as a diagnostic AHI from a sleep study, which
-                measures untreated events. A therapy AHI is what your machine reports during
-                treated sleep.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Leak rate</p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                The total air escaping from the system, measured in litres per minute (L/min). This
-                includes the intentional vent flow built into every mask (which flushes exhaled CO&#x2082;)
-                as well as any unintentional mask leak around the seal. The unintentional component
-                is the one to watch.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Pressure</p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                The pressure your machine is delivering, measured in cmH&#x2082;O. Fixed-pressure (CPAP)
-                machines hold one level all night. Auto-adjusting (APAP/CPAP) machines titrate
-                within a set range based on detected events.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Flow limitation</p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                How much your breathing is being squeezed or flattened, even without a full apnoea
-                or hypopnoea being scored. Flow limitation is often how upper airway resistance and
-                RERAs (Respiratory Effort Related Arousals) show up in the data. It&apos;s a
-                subtler signal that some providers find clinically meaningful alongside AHI.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Events breakdown</p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                Most machines split the AHI total into component event types: obstructive apnoeas,
-                central apnoeas, hypopnoeas, and sometimes RERAs (if your machine scores them
-                separately). The breakdown matters because different event types can point to
-                different causes.
-              </p>
-            </div>
-          </div>
-          <p>
-            Not every machine records all of these &mdash; older devices or basic models may only
-            report AHI and usage. And not all data is equally accessible depending on your machine
-            and what SD card or app access you have.
-          </p>
-        </div>
-      </section>
-
-      {/* Where to Find Your Data */}
-      <section className="mt-10">
-        <div className="flex items-center gap-2.5">
-          <Monitor className="h-5 w-5 text-emerald-400" />
-          <h2 className="text-xl font-bold sm:text-2xl">Where to Find Your Data</h2>
-        </div>
-        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
-          <p>Your machine stores data in one of a few ways:</p>
-          <div className="space-y-3">
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">SD card</p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                Most ResMed and Philips/Respironics machines use a standard SD card. You can remove
-                it, insert it into your computer, and view the raw data files. Dedicated software
-                reads these files and presents the data visually.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">
-                Machine app or cloud dashboard
-              </p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                ResMed&apos;s myAir and Philips&apos; DreamMapper/SleepMapper sync summary data to
-                a phone app or web portal. These are convenient but often only show you a simplified
-                view &mdash; AHI, usage hours, leak summary &mdash; without the full waveform detail
-                available from the SD card.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">OSCAR</p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                OSCAR (Open Source CPAP Analysis Reporter) is the community standard for reading SD
-                card data in detail. It&apos;s free, open source, and runs on Windows, macOS, and
-                Linux. OSCAR shows you full waveform data: every breath, every pressure change,
-                every event flagged across the night. It&apos;s the tool most CPAP community members
-                use for serious data review and is widely recommended in the PAP community.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">AirwayLab</p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                AirwayLab is a browser-based analysis tool that imports your CPAP data from OSCAR
-                exports or direct upload. It&apos;s designed to make patterns easier to spot,
-                particularly across multiple nights. Your data never leaves your browser &mdash; all
-                processing is local. The source code is GPL-3.0 licensed, so what it does is
-                verifiable, not just claimed. AirwayLab complements OSCAR rather than replacing it.
-              </p>
-            </div>
-          </div>
-          <p>
-            For most users, the path looks like this: SD card &rarr; OSCAR (full detail view) &rarr;
-            AirwayLab (multi-night pattern view, easy visual summaries).
-          </p>
-        </div>
-      </section>
-
-      {/* What the Key Metrics Mean */}
-      <section className="mt-10">
-        <div className="flex items-center gap-2.5">
-          <BarChart3 className="h-5 w-5 text-purple-400" />
-          <h2 className="text-xl font-bold sm:text-2xl">What the Key Metrics Mean</h2>
-        </div>
-        <div className="mt-4 space-y-6 text-sm leading-relaxed text-muted-foreground sm:text-base">
-
+        <div className="mt-4 space-y-8 text-sm leading-relaxed text-muted-foreground sm:text-base">
           {/* AHI */}
           <div>
-            <h3 className="text-lg font-bold text-foreground">AHI</h3>
+            <h3 className="text-lg font-bold text-foreground">AHI (Apnoea-Hypopnoea Index)</h3>
             <div className="mt-3 space-y-3">
               <p>
-                Your therapy AHI is the central number most people focus on first. A lower number
-                means fewer breathing events are being scored by the machine during the night &mdash;
-                but AHI alone doesn&apos;t tell the whole story. An AHI of 2 on a night where your
-                leak was 60 L/min means the AHI figure may be unreliable, because high leak can
-                prevent the machine from accurately detecting events.
+                AHI counts the number of breathing events — apnoeas and hypopnoeas — recorded per
+                hour of therapy. It is calculated from the machine&apos;s internal sensor data.
               </p>
               <p>
-                AHI is a count, not a complete picture of sleep quality. Some people have residual
-                flow limitation and RERAs that don&apos;t show up in AHI but may still affect how
-                they feel. This is one reason why looking at more than just AHI is worthwhile.
+                A lower AHI on therapy generally reflects fewer recorded breathing interruptions
+                during that session. Most clinicians use AHI as one data point among several when
+                reviewing how a therapy night went.{' '}
+                <Link href="/blog/why-ahi-is-lying" className="text-primary hover:text-primary/80">
+                  For a deeper look at what AHI measures and what it misses
+                </Link>
+                , the full picture goes beyond a single nightly number.
               </p>
-              <p>
-                What counts as a &ldquo;good&rdquo; therapy AHI is something to discuss with your
-                clinician, not something to benchmark from an article. Context matters &mdash; your
-                pre-treatment AHI, your symptoms, and how you feel are all part of the picture.
-              </p>
+              <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
+                <p className="text-xs font-semibold text-emerald-400">What AirwayLab shows</p>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  Nightly AHI alongside trend charts across multiple nights, so you can see how
+                  the number varies over time rather than reviewing a single session in isolation.
+                </p>
+              </div>
+              <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  Your clinician interprets AHI in the context of your symptoms, sleep quality,
+                  and clinical history. The number alone doesn&apos;t tell the whole story.
+                </p>
+              </div>
             </div>
           </div>
 
@@ -209,140 +81,239 @@ export default function HowToReadCPAPDataPost() {
             <h3 className="text-lg font-bold text-foreground">Leak Rate</h3>
             <div className="mt-3 space-y-3">
               <p>
-                Your leak rate combines two things: the intentional vent flow your mask needs to
-                flush CO&#x2082; (typically 20&ndash;40 L/min depending on mask type and pressure),
-                and any unintentional leak escaping around the seal. The second number is what you
-                want to minimise.
+                CPAP machines record air flow leaving the mask seal — termed unintentional or mask
+                leak. Higher recorded leak rates can affect how consistently therapy pressure is
+                maintained across the session.
               </p>
               <p>
-                Some machines and software (including OSCAR) separate these and show &ldquo;mask
-                leak&rdquo; directly. Others only report total leak.{' '}
-                <Link
-                  href="/blog/cpap-leak-rate-explained"
-                  className="text-primary hover:text-primary/80"
-                >
-                  Understanding your leak rate
-                </Link>{' '}
-                in detail can help you identify whether high-leak nights are a mask fit issue, a
-                positional issue, or a mouth-breathing issue &mdash; all of which have different
-                solutions.
+                Leak data is typically reported in litres per minute (L/min) or as a
+                95th-percentile figure. Every mask has some intentional vent flow to flush exhaled
+                CO&#x2082; — unintentional leak is what escapes around the seal.
               </p>
+              <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
+                <p className="text-xs font-semibold text-emerald-400">What AirwayLab shows</p>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  Leak rate trends across your recorded nights, with traffic-light colouring to
+                  help you see which sessions had higher or lower recorded leak levels.
+                </p>
+              </div>
+              <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  If your recorded leak data shows consistently elevated figures, this is the kind
+                  of data your clinician or equipment provider may ask about at your next
+                  appointment.
+                </p>
+              </div>
             </div>
           </div>
 
-          {/* Pressure */}
+          {/* Usage Hours */}
           <div>
-            <h3 className="text-lg font-bold text-foreground">Pressure</h3>
-            <div className="mt-3">
-              <p>
-                If you&apos;re on a fixed-pressure CPAP, your pressure is set and doesn&apos;t
-                change. If you&apos;re on APAP, your machine is adjusting throughout the night.
-                Reviewing your pressure data tells you how actively your machine is working. An APAP
-                machine frequently at the top of its pressure range is a pattern visible in your
-                data.
-              </p>
-            </div>
-          </div>
-
-          {/* Flow Limitation and RERAs */}
-          <div>
-            <h3 className="text-lg font-bold text-foreground">Flow Limitation and RERAs</h3>
+            <h3 className="text-lg font-bold text-foreground">Usage Hours</h3>
             <div className="mt-3 space-y-3">
               <p>
-                Flow limitation is visible in your waveform data as a flattening of the normal
-                breathing curve. RERAs (Respiratory Effort Related Arousals) are events where
-                increased breathing effort triggers an arousal, even without a scored apnoea or
-                hypopnoea. Not all machines score RERAs &mdash; some higher-end devices do, and
-                OSCAR can display the flow limitation waveform even when RERAs aren&apos;t scored
-                directly.
+                Usage hours records how long the machine was running during the night. This is the
+                period the machine was on and delivering pressure — distinct from total sleep time.
+              </p>
+              <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
+                <p className="text-xs font-semibold text-emerald-400">What AirwayLab shows</p>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  Nightly usage hours across your recorded history. Consistent usage data gives
+                  your clinician a clearer picture at review.
+                </p>
+              </div>
+              <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  Usage data is one of the metrics your clinician will typically reference at a
+                  follow-up appointment.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Pressure Data */}
+          <div>
+            <h3 className="text-lg font-bold text-foreground">Pressure Data</h3>
+            <div className="mt-3 space-y-3">
+              <p>
+                Your machine records the pressure it delivered throughout the night. For
+                fixed-pressure machines this is a flat line; for APAP/AutoCPAP machines the
+                pressure varies in response to detected events.
               </p>
               <p>
-                If you feel you&apos;re sleeping the expected number of hours but still waking up
-                unrefreshed, flow limitation and RERAs are worth reviewing in the context of your
-                data. Bring observations to your clinician rather than drawing conclusions from
-                them.
+                The 95th-percentile pressure figure (P95) is commonly referenced — it describes
+                the pressure level the machine was at or below for 95% of the session.
               </p>
+              <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
+                <p className="text-xs font-semibold text-emerald-400">What AirwayLab shows</p>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  Pressure trend charts over your recorded nights, including P95 figures and
+                  session-by-session variation.
+                </p>
+              </div>
+              <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  Pressure settings are determined by your clinician based on your titration study
+                  and clinical assessment. AirwayLab describes what pressures were recorded — it
+                  does not suggest pressure changes.
+                </p>
+              </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* How to Spot Patterns Over Multiple Nights */}
+      {/* Section 2: Flow Limitation and Breathing Patterns */}
       <section className="mt-10">
         <div className="flex items-center gap-2.5">
-          <TrendingUp className="h-5 w-5 text-cyan-400" />
+          <Wind className="h-5 w-5 text-blue-400" />
           <h2 className="text-xl font-bold sm:text-2xl">
-            How to Spot Patterns Over Multiple Nights
+            Going Deeper: Flow Limitation and Breathing Patterns
           </h2>
         </div>
         <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
           <p>
-            Single-night data is noisy. A bad night might be explained by a cold, a late meal,
-            position, or stress. What matters in CPAP data is trends.
+            Standard CPAP reports show AHI, leak, usage, and pressure. AirwayLab goes further by
+            analysing the shape of your breath waveforms from the raw EDF data on your SD card.
           </p>
-          <p>Things worth watching across multiple nights:</p>
+          <p>This analysis describes four patterns:</p>
           <div className="space-y-3">
             <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">AHI variability</p>
+              <p className="text-sm font-semibold text-foreground">Flow limitation — FL Score</p>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                Is your AHI consistently low, or does it spike on certain nights? Spikes on nights
-                when your pressure also went high, or when your leak was elevated, may suggest a
-                pattern worth noting.
+                The shape of individual breath curves, which can appear flat-topped rather than
+                rounded. AirwayLab&apos;s FL Score (0–100) quantifies this per breath.{' '}
+                <Link
+                  href="/blog/understanding-flow-limitation"
+                  className="text-primary hover:text-primary/80"
+                >
+                  Flow limitation and its relationship to upper airway resistance is explained in
+                  detail in our flow limitation guide
+                </Link>
+                .
               </p>
             </div>
             <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Leak consistency</p>
+              <p className="text-sm font-semibold text-foreground">RERAs (estimated)</p>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                Is high leak a regular occurrence at a particular time of night (e.g., always after
-                3am)? That&apos;s more useful information than a single average figure.
+                Runs of breaths with progressive flow limitation features that don&apos;t reach
+                the threshold of a scored apnoea or hypopnoea. AirwayLab&apos;s RERA detection
+                uses NED slope, recovery breath shape, and sigh detection from the EDF waveform —
+                it is a flow-based heuristic, not polysomnography-grade scoring.
               </p>
             </div>
             <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Pressure trends</p>
+              <p className="text-sm font-semibold text-foreground">
+                Glasgow Index (9-component breath shape score)
+              </p>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                On APAP, is your machine consistently comfortable in the middle of its range, or is
-                it frequently at its ceiling? Sustained high-pressure activity is a pattern worth
-                discussing.
+                An open-source methodology (GPL-3.0) scoring inspiratory flow shape across nine
+                components: skew, spike, flat top, top heavy, multi-peak, no pause, inspiration
+                rate, multi-breath, and variable amplitude. Scores range 0–9 per night.
               </p>
             </div>
             <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Event type distribution</p>
+              <p className="text-sm font-semibold text-foreground">
+                WAT Score — Wobble Analysis Tool
+              </p>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                If your events are predominantly central rather than obstructive, or if the ratio is
-                changing over time, that&apos;s the kind of observation to bring to a sleep
-                clinician.
+                Three breathing stability metrics: FL Score (flow limitation percentage),
+                Regularity (sample entropy of minute ventilation), and Periodicity Index (spectral
+                analysis detecting cyclical breathing in the 30–100 second range).
+              </p>
+            </div>
+          </div>
+          <p>
+            These metrics describe patterns in your breathing data that standard machine reports
+            don&apos;t surface. They are informational — your clinician can help interpret what
+            the patterns mean in your specific situation.
+          </p>
+        </div>
+      </section>
+
+      {/* Section 3: What AirwayLab Doesn't Do */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <XCircle className="h-5 w-5 text-red-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">What AirwayLab Doesn&apos;t Do</h2>
+        </div>
+        <div className="mt-4 space-y-3 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>This is as important as knowing what AirwayLab does show.</p>
+          <div className="space-y-2">
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                <strong className="text-foreground">AirwayLab does not diagnose.</strong> Pattern
+                descriptions in your data — elevated AHI, high FL Score, frequent RERA estimates
+                — are informational observations. They are not diagnostic findings.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                <strong className="text-foreground">
+                  AirwayLab does not suggest pressure changes.
+                </strong>{' '}
+                Pressure settings are a clinical decision. Nothing AirwayLab shows should be used
+                as the basis for self-adjusting your therapy.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                <strong className="text-foreground">
+                  AirwayLab does not interpret clinical context.
+                </strong>{' '}
+                Your data has meaning in the context of your medical history, symptoms, and
+                prescription — context that only your clinical team has.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                <strong className="text-foreground">
+                  AirwayLab does not currently support Philips Respironics or Fisher &amp; Paykel
+                  data formats.
+                </strong>{' '}
+                Analysis uses the ResMed EDF format (AirSense 10, AirSense 11, and AirCurve
+                devices). Support for additional manufacturers is planned.
               </p>
             </div>
           </div>
         </div>
       </section>
 
-      {/* How AirwayLab Visualises Your Therapy Data */}
+      {/* Section 4: How to Visualise */}
       <section className="mt-10">
         <div className="flex items-center gap-2.5">
-          <Wind className="h-5 w-5 text-primary" />
+          <HardDrive className="h-5 w-5 text-emerald-400" />
           <h2 className="text-xl font-bold sm:text-2xl">
-            How AirwayLab Visualises Your Therapy Data
+            How to Visualise Your CPAP Data in AirwayLab
           </h2>
         </div>
         <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
           <p>
-            AirwayLab is built specifically to make multi-night pattern review easier. After you
-            import your CPAP data (from an OSCAR export or direct SD card upload), it shows your
-            key metrics plotted over time so patterns become visible at a glance.
+            To start, copy the DATALOG folder from your ResMed SD card and open AirwayLab in your
+            browser. No account required.{' '}
+            <Link
+              href="/blog/resmed-airsense-10-sd-card"
+              className="text-primary hover:text-primary/80"
+            >
+              Step-by-step SD card setup for ResMed AirSense
+            </Link>{' '}
+            covers the full process if you&apos;re doing this for the first time.
           </p>
           <p>
-            You can overlay AHI, leak rate, flow limitation, and pressure on a shared timeline and
-            compare nights side by side. The goal is to help you notice &mdash; not to interpret
-            for you.
+            AirwayLab is browser-based and processes all data locally — your breathing data never
+            leaves your device. It complements OSCAR rather than replacing it: OSCAR excels at
+            detailed waveform browsing, while AirwayLab adds automated analysis across multiple
+            nights.{' '}
+            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+              See how AirwayLab and OSCAR compare
+            </Link>{' '}
+            if you&apos;re deciding which tools to use.
           </p>
           <p>
-            Everything runs in your browser. Your breathing data never leaves your device &mdash;
-            there&apos;s no cloud upload, no account required to get started. The analysis is free
-            and always will be. If you want to verify that for yourself, the source code is
-            published under GPL-3.0.
+            The core analysis is free and always will be. A premium tier adds AI-powered insights,
+            forum export, and PDF reports.
           </p>
-          <div className="mt-4">
+          <div className="mt-2">
             <Link
               href="/analyze"
               className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:text-primary/80"
@@ -353,97 +324,19 @@ export default function HowToReadCPAPDataPost() {
         </div>
       </section>
 
-      {/* What to Bring to Your Provider */}
-      <section className="mt-10">
-        <div className="flex items-center gap-2.5">
-          <Stethoscope className="h-5 w-5 text-amber-400" />
-          <h2 className="text-xl font-bold sm:text-2xl">What to Bring to Your Provider</h2>
-        </div>
-        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
-          <p>
-            Your data doesn&apos;t interpret itself &mdash; and it shouldn&apos;t. The observations
-            you make from reviewing your CPAP data are most useful as conversation material with
-            your equipment provider or sleep clinician, not as a basis for self-adjusting therapy.
-          </p>
-          <p>Useful things to bring to an appointment:</p>
-          <div className="space-y-3">
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Screenshots of patterns</p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                Not just averages. &ldquo;My AHI was 4.2 last month&rdquo; is less useful than
-                &ldquo;my AHI spikes to 8&ndash;12 every Thursday night and I can&apos;t figure
-                out why.&rdquo;
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">
-                Leak patterns if leak is elevated
-              </p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                Along with what you&apos;ve already tried (mask brand, cushion age, whether
-                you&apos;ve noticed mouth breathing).
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">
-                Pressure graphs if you&apos;re on APAP
-              </p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                Particularly if you&apos;re frequently hitting the top of your range.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/50 p-4">
-              <p className="text-sm font-semibold text-foreground">Event type breakdowns</p>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                If you have a high proportion of centrals or an unusual distribution.
-              </p>
-            </div>
-          </div>
-          <p>
-            Your equipment provider can adjust pressure ranges and mask recommendations. Your sleep
-            clinician can review your data in full clinical context.
-          </p>
-        </div>
-      </section>
-
-      {/* A Few Things Worth Knowing */}
-      <section className="mt-10">
-        <div className="flex items-center gap-2.5">
-          <BookOpen className="h-5 w-5 text-muted-foreground" />
-          <h2 className="text-xl font-bold sm:text-2xl">A Few Things Worth Knowing</h2>
-        </div>
-        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
-          <p>
-            Your CPAP machine is not a medical device in the sense that its data is diagnostic
-            &mdash; it&apos;s a therapeutic device whose monitoring data gives you and your care
-            team visibility into how therapy is going. The numbers it reports are useful reference
-            points, not verdicts.
-          </p>
-          <p>
-            The CPAP community is genuinely helpful for new users learning to read data. Forums,
-            subreddits, and OSCAR documentation have collectively built a large body of practical
-            knowledge. Tools like OSCAR and AirwayLab exist because the community wanted better
-            visibility into their own therapy.
-          </p>
-          <p>
-            Learning to read your data doesn&apos;t mean managing your therapy alone. It means
-            having more informed conversations with the people who are helping you get there.
-          </p>
-        </div>
-      </section>
-
-      {/* Medical disclaimer at bottom */}
+      {/* Bottom disclaimer */}
       <section className="mt-8">
         <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-5">
           <div className="flex items-center gap-2.5">
-            <Lightbulb className="h-4 w-4 text-amber-500" />
+            <AlertTriangle className="h-4 w-4 text-amber-500" />
             <p className="text-xs font-semibold text-foreground">Medical disclaimer</p>
           </div>
           <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
             The information in this article is for educational purposes only and does not
             constitute medical advice. AirwayLab does not diagnose, treat, or provide clinical
             recommendations. Always discuss CPAP therapy and data observations with your clinician
-            or equipment provider.
+            or equipment provider. Your clinician can help interpret these patterns in clinical
+            context.
           </p>
         </div>
       </section>
@@ -454,38 +347,35 @@ export default function HowToReadCPAPDataPost() {
         <div className="space-y-1 text-sm text-muted-foreground">
           <p>
             <Link
-              href="/blog/cpap-leak-rate-explained"
-              className="text-primary hover:text-primary/80"
-            >
-              CPAP Leak Rate Explained
-            </Link>{' '}
-            &mdash; what the numbers mean and how to reduce unintentional mask leak.
-          </p>
-          <p>
-            <Link
               href="/blog/understanding-flow-limitation"
               className="text-primary hover:text-primary/80"
             >
               Understanding Flow Limitation
             </Link>{' '}
-            &mdash; what flow limitation is, how it affects your sleep, and how it shows in your
-            data.
+            — what flow limitation is, how it appears in waveform data, and what it means for PAP
+            therapy.
           </p>
           <p>
-            <Link href="/blog/pap-data-privacy" className="text-primary hover:text-primary/80">
-              Your PAP Data Belongs to You
+            <Link href="/blog/why-ahi-is-lying" className="text-primary hover:text-primary/80">
+              Why Your AHI Is Lying to You
             </Link>{' '}
-            &mdash; who can see your sleep data and how to keep control of it.
+            — the limitations of AHI as a metric and what it misses.
+          </p>
+          <p>
+            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+              AirwayLab vs OSCAR
+            </Link>{' '}
+            — how the two open-source PAP tools compare and how to use both together.
           </p>
         </div>
       </section>
 
       {/* CTA */}
       <section className="mt-10 rounded-xl border border-primary/20 bg-primary/5 p-6 text-center">
-        <h3 className="text-lg font-bold">Analyse Your CPAP Data with AirwayLab</h3>
+        <h3 className="text-lg font-bold">Visualise Your CPAP Data with AirwayLab</h3>
         <p className="mt-2 text-sm text-muted-foreground">
-          Upload your CPAP data and see your key metrics plotted over time. Free, open source, and
-          your data never leaves your browser.
+          Free, browser-based, and private. Your data stays in your browser — no upload, no
+          account needed.
         </p>
         <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
           <Link
@@ -495,10 +385,10 @@ export default function HowToReadCPAPDataPost() {
             Analyse Your Data <ArrowRight className="h-4 w-4" />
           </Link>
           <Link
-            href="/getting-started"
+            href="/blog/resmed-airsense-10-sd-card"
             className="inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
           >
-            Getting Started Guide
+            Getting Started with ResMed
           </Link>
         </div>
       </section>

--- a/lib/blog-posts.ts
+++ b/lib/blog-posts.ts
@@ -579,35 +579,50 @@ export const blogPosts: BlogPost[] = [
   },
   {
     slug: 'how-to-read-cpap-data',
-    title: 'How to Read Your CPAP Data \u2014 A Beginner\u2019s Guide',
-    seoTitle: 'How to Read Your CPAP Data \u2014 A Beginner\u2019s Guide | AirwayLab',
+    title: 'What Your CPAP Data Actually Shows You',
+    seoTitle: 'How to Read Your CPAP Data | AirwayLab',
     description:
-      'Learn what your CPAP data actually shows you \u2014 AHI, leak rate, pressure, flow limitation \u2014 and how to start reading therapy patterns worth discussing with your clinician.',
-    date: '2026-04-16',
-    readTime: '10 min read',
-    tags: ['CPAP', 'Getting Started', 'AHI', 'Leak Rate', 'OSCAR', 'Beginner Guide'],
+      'Learn what AHI, leak rate, usage hours, and pressure data represent in your CPAP reports \u2014 and how to visualise them for free in AirwayLab.',
+    date: '2026-04-27',
+    readTime: '7 min read',
+    tags: ['CPAP', 'Getting Started', 'AHI', 'Leak Rate', 'Flow Limitation', 'OSCAR'],
     ogDescription:
-      'New to CPAP data? We explain what AHI, leak rate, pressure, and flow limitation mean \u2014 and how to start spotting patterns in your therapy report.',
+      'Learn what AHI, leak rate, usage hours, and pressure data represent in your CPAP reports \u2014 and how to visualise them for free in AirwayLab.',
     faqItems: [
       {
-        question: 'What does my CPAP machine record every night?',
-        answer: 'Your machine records usage hours, AHI (apnoeas and hypopnoeas per hour), leak rate, pressure, flow limitation, and a breakdown of event types. Not every machine records all of these \u2014 older or basic models may only report AHI and usage.',
+        question: 'What is AHI in CPAP data?',
+        answer:
+          'AHI (Apnoea-Hypopnoea Index) is the number of apnoeas (complete breathing pauses) and hypopnoeas (partial airflow reductions) recorded per hour of therapy. Your machine calculates this from its internal sensor data during the session. Therapy AHI reflects what the machine detected while running \u2014 it is not directly comparable to a diagnostic AHI from a sleep study, which measures untreated events.',
       },
       {
-        question: 'What is the difference between therapy AHI and diagnostic AHI?',
-        answer: 'Your therapy AHI is what your machine counts during treated sleep. A diagnostic AHI from a sleep study measures untreated events. They are not directly comparable.',
+        question: 'What AHI do clinicians reference for CPAP therapy?',
+        answer:
+          'AHI thresholds are clinically defined and interpreted in the context of your specific diagnosis, symptoms, and prescription. There is no universal number that applies to all patients \u2014 your clinician will interpret your therapy AHI alongside your clinical history and how you are feeling. AirwayLab shows your nightly AHI and trends over time; your care team interprets what those numbers mean for your therapy.',
       },
       {
-        question: 'How do I access my CPAP data beyond the app?',
-        answer: 'Remove the SD card from your machine, insert it into a card reader, and open the data with OSCAR (free desktop software for full waveform detail) or AirwayLab (browser-based for multi-night pattern review). No account required for either.',
+        question: 'What does CPAP leak rate mean?',
+        answer:
+          'Leak rate measures the air escaping from your mask system, in litres per minute (L/min). Every mask has some intentional vent flow to flush exhaled CO\u2082 \u2014 unintentional (mask) leak is what escapes around the seal. High unintentional leak can affect how accurately your machine detects breathing events, making AHI less reliable for that session. AirwayLab shows nightly leak trends with traffic-light colouring.',
       },
       {
-        question: 'What should I bring to my provider appointment?',
-        answer: 'Screenshots of patterns rather than just averages, leak data if elevated, pressure graphs if you are on APAP and frequently hitting the ceiling, and event type breakdowns if you have an unusual distribution. Your provider can adjust settings; your clinician can interpret the full picture.',
+        question: 'What does pressure data show on my CPAP?',
+        answer:
+          'Pressure data records the pressure your machine delivered throughout the night, measured in cmH\u2082O. For fixed-pressure CPAP machines, this is a flat line. For APAP machines, pressure adjusts in response to detected breathing events. The 95th-percentile pressure (P95) describes the level your machine was at or below for 95% of the session. Pressure settings are managed by your clinician.',
       },
       {
-        question: 'Does AirwayLab upload my data?',
-        answer: 'No. All analysis runs in your browser. Your breathing data never leaves your device \u2014 there is no cloud upload and no account required to get started.',
+        question: 'Does AirwayLab show all CPAP data formats?',
+        answer:
+          'AirwayLab reads detailed EDF files from ResMed SD cards and shows AHI, leak rate, usage hours, and pressure data alongside four advanced metrics: the Glasgow Index (9-component breath shape score), FL Score (flow limitation percentage), NED (Negative Effort Dependence), and estimated RERA detection. It does not currently support Philips Respironics or Fisher & Paykel data formats.',
+      },
+      {
+        question: 'Is AirwayLab free?',
+        answer:
+          'Yes. All core analysis \u2014 AHI, leak, pressure, flow limitation, Glasgow Index, WAT score, NED, and RERA detection \u2014 is free and always will be. A premium tier adds AI-powered insights via Claude. All analysis runs in your browser; nothing is uploaded to any server and no account is required to start.',
+      },
+      {
+        question: 'How is AirwayLab different from OSCAR or SleepHQ?',
+        answer:
+          'OSCAR is a desktop app that provides detailed waveform browsing and event-by-event review of PAP data. SleepHQ is a cloud-based platform with a shareable dashboard. AirwayLab is browser-based (no install, no account), privacy-first (all analysis runs locally), and adds four automated analysis engines for flow limitation and breathing pattern scoring that OSCAR and SleepHQ do not compute.',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Replaces the earlier draft of `how-to-read-cpap-data` with the AIR-798 quality-gate-PASS revision (approved 2026-04-27)
- Updated `lib/blog-posts.ts` with correct title, date, and 7 FAQ items (schema-ready JSON-LD)
- MDR Compliance PASS confirmed by Compliance Reviewer (AIR-886 thread)

## Key changes

- H2 keyword anchor: "How to Read Your CPAP Data: The Four Metrics Your Clinician Will Reference"
- Per-metric "What AirwayLab shows" callouts + clinical-deferral blocks (AHI, Leak, Usage Hours, Pressure)
- "Going Deeper" section covering all 4 engines with Glasgow Index component names listed
- "What AirwayLab Doesn't Do" section (no diagnosis, no pressure suggestions, no clinical context, Philips/F&P not supported — verified accurate)
- 4 internal links; 3 substituted for non-existent target slugs (noted in AIR-886)
- Dual medical disclaimers

## Pre-merge checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] E2e tests pass locally (for UI changes)
- [x] Bundle size impact checked (blog post content only — no impact)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [x] Self-review: no regressions, loading/error/empty states handled
- [x] PR contains one concern only

## Notes

- Publication gated on AIR-706 (GSC indexing fix) — this PR can merge independently
- Closes AIR-886

🤖 Generated with [Claude Code](https://claude.com/claude-code)