### PR TITLE
fix(feedback-processor): filter to opted-in rows and add query-filter test

### DIFF
--- a/__tests__/feedback-processor.test.ts
+++ b/__tests__/feedback-processor.test.ts
@@ -3,9 +3,21 @@ import {
   normaliseEmail,
   groupByEmail,
   buildDraftBody,
+  processFeedback,
   type FeedbackRow,
 } from '@/lib/services/feedback-processor'
 import { getGmailConfig, refreshAccessToken, createGmailDraft } from '@/lib/gmail/client'
+
+// ── Module mocks (hoisted) ────────────────────────────────────
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}))
+
+const mockFrom = vi.fn()
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseAdmin: vi.fn(() => ({ from: (...args: unknown[]) => mockFrom(...args) })),
+}))
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -212,5 +224,28 @@ describe('createGmailDraft', () => {
         body: 'Test',
       }),
     ).rejects.toThrow('Gmail draft creation failed')
+  })
+})
+
+// ── Test 7: processFeedback consent filter ────────────────────
+
+describe('processFeedback consent filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('queries only rows where contact_ok is true', async () => {
+    // Chainable builder — order() is the terminal call (resolves the promise)
+    const builder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }
+    mockFrom.mockReturnValue(builder)
+
+    const config = { clientId: 'cid', clientSecret: 'csec', refreshToken: 'rtoken' }
+    await processFeedback(config)
+
+    expect(builder.eq).toHaveBeenCalledWith('contact_ok', true)
   })
 })

--- a/lib/services/feedback-processor.ts
+++ b/lib/services/feedback-processor.ts
@@ -109,11 +109,12 @@ export async function processFeedback(gmailConfig: GmailConfig): Promise<Process
     throw new Error('Supabase not configured')
   }
 
-  // Step 1: Fetch all unprocessed feedback
+  // Step 1: Fetch all unprocessed feedback where the user consented to contact
   const { data: rows, error: fetchError } = await supabase
     .from('feedback')
     .select('id, message, email, type, page, created_at, metadata')
     .eq('processed', false)
+    .eq('contact_ok', true)
     .order('created_at', { ascending: true })
 
   if (fetchError) {


### PR DESCRIPTION
## Summary

- Adds `.eq("contact_ok", true)` to the Supabase query in `processFeedback` so the daily cron only creates Gmail drafts for users who consented to follow-up contact
- Adds `describe("processFeedback consent filter")` unit test ([AIR-937](/AIR/issues/AIR-937)) to `__tests__/feedback-processor.test.ts` asserting the filter is applied to the query chain

## Test plan

- [x] `npm test -- feedback-processor` — 19 tests pass (including new consent filter test)
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — clean
- [x] `npm run build` — full production build passes
- [x] All 1942 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)