### PR TITLE
fix(lint): ignore .claude/ and .next/ subtree paths in ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import tsConfig from 'eslint-config-next/typescript';
 import noSilentCatch from './scripts/eslint-rules/no-silent-catch.mjs';
 
 const config = [
+  { ignores: ['.claude/', '.next/', '**/.next/'] },
   ...nextConfig,
   ...coreWebVitals,
   ...tsConfig,


### PR DESCRIPTION
## Summary

- Adds  as the first element in 
- Prevents ESLint from scanning  build artifacts inside  subdirectories
- Fixes spurious errors (, , ) from minified bundle files

Resolves AIR-970. Discovered during AIR-961 review.

## Test plan

- [ ] npx tsc --noEmit — passes
- [ ] npm run lint — exits 0, no output
- [ ] npm test — 1941 tests pass
- [ ] npm run build — passes
- [ ] Source-file lint errors still surface normally (not silenced)

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [x] PR contains one concern only

Generated with Claude Code