### PR TITLE
chore(air-1008): add credential validation script and ops inventory

### DIFF
--- a/docs/ops/credentials.md
+++ b/docs/ops/credentials.md
@@ -1,0 +1,61 @@
+# Credential Inventory
+
+Authoritative record of all shared secrets in the AirwayLab system.
+Checked weekly by the **Credential Rotation Reminder** routine (Mon 09:00 CET).
+Update this file whenever a credential is rotated.
+
+## Inventory
+
+| Name | Owner | Stored In | Cadence | Last Rotated | Next Rotation Due | Status |
+|------|-------|-----------|---------|--------------|-------------------|--------|
+| `SENTRY_AUTH_TOKEN` | CTO / Board | Vercel env var `SENTRY_AUTH_TOKEN` | 90 days | 2026-04-22† | 2026-07-21 | active |
+| `GITHUB_PAT` (airwaylab-dev) | Board (Demian) | Cortis `.netrc` / git remote URL | 90 days | 2026-04-20 | **2026-04-20 (EXPIRED)** | EXPIRED |
+
+†Estimated from [AIR-927](/AIR/issues/AIR-927) fix date — verify actual expiry in Sentry dashboard and update this row.
+
+---
+
+## Rotation Instructions
+
+### SENTRY_AUTH_TOKEN
+
+1. Sentry → Settings → Account → API Tokens → Create token
+2. Required scopes: `project:releases`, `org:read`, `project:read`, `project:write`
+3. Update `SENTRY_AUTH_TOKEN` in Vercel environment (Production + Preview + Development)
+4. Update `Last Rotated` and `Next Rotation Due` in the table above
+5. Comment on the rotation ticket with the new expiry date
+
+### GITHUB_PAT (airwaylab-dev)
+
+1. Board action — log in to GitHub as `airwaylab-dev`
+2. Settings → Developer Settings → Personal Access Tokens → Fine-grained
+3. Required scopes: `Contents: Read & Write`, `Pull requests: Read & Write`, `Workflows: Read & Write`
+4. Set expiry: 90 days from today
+5. Update the Cortis server `.netrc` entry and any embedded PAT in the git remote URL:
+   ```
+   git remote set-url origin https://airwaylab-dev:<NEW_PAT>@github.com/airwaylab-app/airwaylab.git
+   ```
+6. Update `Last Rotated` and `Next Rotation Due` in the table above
+7. Comment on the rotation ticket confirming the new expiry date
+
+---
+
+## How the Rotation Reminder Routine Works
+
+Each Monday at 09:00 CET, the `Credential Rotation Reminder` routine fires and creates an execution issue
+assigned to the CTO. The CTO agent picks up the issue and:
+
+1. Reads this file
+2. For each entry where `Next Rotation Due <= today + 14 days`, creates a **HIGH-priority** ticket:
+   - Title: `Credential rotation due: <NAME>`
+   - Assignee: CTO (to triage/escalate to board as needed)
+   - Links to rotation instructions in this document
+3. Marks the execution issue `done` with a summary
+
+---
+
+## Test Entry (dry-run only — remove after AIR-931 verification)
+
+| Name | Owner | Stored In | Cadence | Last Rotated | Next Rotation Due | Status |
+|------|-------|-----------|---------|--------------|-------------------|--------|
+| `DRY_RUN_TEST_TOKEN` | CTO | test-only | 90 days | 2026-02-05 | 2026-05-06 | test |

--- a/scripts/validate-github-credentials.sh
+++ b/scripts/validate-github-credentials.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/validate-github-credentials.sh
+#
+# Pre-flight validation for GitHub credentials. Run at the start of any
+# heartbeat that depends on git push. Returns exit code 0 if credentials
+# are valid, 1 if invalid or missing.
+#
+# Usage:
+#   source scripts/validate-github-credentials.sh
+#   if ! validate_github_credentials; then
+#     # handle gracefully — skip push-dependent work, escalate
+#   fi
+#
+# Or standalone:
+#   scripts/validate-github-credentials.sh && echo "ok" || echo "bad"
+
+set -euo pipefail
+
+validate_github_credentials() {
+  local remote_url pat http_code
+
+  remote_url=$(git remote get-url origin 2>/dev/null) || {
+    echo "CREDENTIAL_CHECK: No git remote 'origin' configured" >&2
+    return 1
+  }
+
+  pat=$(echo "$remote_url" | sed -n 's|.*x-access-token:\([^@]*\)@.*|\1|p')
+
+  if [ -z "$pat" ]; then
+    echo "CREDENTIAL_CHECK: No PAT found in remote URL" >&2
+    return 1
+  fi
+
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+    --max-time 10 \
+    -H "Authorization: Bearer $pat" \
+    "https://api.github.com/rate_limit") || {
+    echo "CREDENTIAL_CHECK: GitHub API unreachable (network error)" >&2
+    return 1
+  }
+
+  if [ "$http_code" = "200" ]; then
+    echo "CREDENTIAL_CHECK: PAT valid (HTTP $http_code)" >&2
+    return 0
+  elif [ "$http_code" = "401" ]; then
+    echo "CREDENTIAL_CHECK: PAT expired or revoked (HTTP 401)" >&2
+    return 1
+  else
+    echo "CREDENTIAL_CHECK: Unexpected response (HTTP $http_code)" >&2
+    return 1
+  fi
+}
+
+# When run as a standalone script (not sourced), execute the check
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  validate_github_credentials
+fi


### PR DESCRIPTION
## Summary

- `scripts/validate-github-credentials.sh`: pre-flight PAT health check used by agent heartbeats before push-dependent work (from AIR-741 branch)
- `docs/ops/credentials.md`: credential inventory read by the Credential Rotation Reminder routine weekly (from AIR-931 branch)

Consolidates two previously separate unmerged branches into a single PR.

## Test plan
- [ ] `bash scripts/validate-github-credentials.sh` exits 0 with valid PAT
- [ ] `docs/ops/credentials.md` opens correctly and inventory table is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)