### PR TITLE
fix(parsers): PLD allocation guard + summary-only worker map (AIR-960)

### DIFF
--- a/__tests__/pld-parser.test.ts
+++ b/__tests__/pld-parser.test.ts
@@ -317,6 +317,34 @@ describe('PLD Parser', () => {
       writeField(252, 4, '0'); // 0 signals
       expect(parsePLD(emptyBuffer, 'test.edf')).toBeNull();
     });
+    it('throws with a descriptive message (not OOM) when header implies excessive allocation', () => {
+      // Regression for Sentry NEXTJS-5H: corrupt 2023 PLD files with huge numSamples
+      // caused `Array buffer allocation failed` (unrecoverable OOM) in the worker.
+      // The allocation guard should throw a descriptive error before any Float32Array
+      // allocation, which the worker catches and logs as a WorkerWarning instead.
+      const channels: TestChannel[] = [
+        { label: 'Leak', data: [0.2], physicalMin: 0, physicalMax: 2, unit: 'L/s' },
+      ];
+      const originalBuffer = makePLDBuffer(channels);
+
+      // numSamples section offset for signal 0 (one signal in header)
+      const numSamplesOffset = 256 + 1 * (16 + 80 + 8 + 8 + 8 + 8 + 8 + 80);
+      const enc = new TextEncoder();
+
+      // Use 500_001 samples — just over MAX_SAMPLES_PER_CHANNEL (500_000)
+      const hugeNumSamples = 500_001;
+
+      // Extend the buffer to satisfy the truncation check (need ≥1 complete record):
+      // bytesPerRecord = hugeNumSamples × 2; headerBytes = 512 (256 fixed + 1×256 signal)
+      const requiredSize = 512 + hugeNumSamples * 2;
+      const extendedBuffer = new ArrayBuffer(requiredSize);
+      new Uint8Array(extendedBuffer).set(new Uint8Array(originalBuffer));
+      new Uint8Array(extendedBuffer, numSamplesOffset, 8).set(enc.encode('500001  '));
+
+      // Must throw with a descriptive message, NOT an unhandled `Array buffer allocation failed`
+      expect(() => parsePLD(extendedBuffer, 'corrupt_large_PLD.edf')).toThrow(/allocation limit/i);
+    });
+
     it('does not throw on negative numSamples in signal header (corrupt PLD)', () => {
       // Regression test for Sentry errors:
       //   "Invalid typed array length: -30" (Variant A)

--- a/lib/parsers/pld-parser.ts
+++ b/lib/parsers/pld-parser.ts
@@ -289,6 +289,19 @@ export function parsePLD(buffer: ArrayBuffer, _filePath: string): PLDData | null
     actualNumRecords = completeRecords;
   }
 
+  // Guard against corrupted headers producing excessive allocation.
+  // A valid 8-hour PLD night at 0.5 Hz produces ~14,400 samples/channel.
+  // 500,000 samples (>277 hours at 0.5 Hz) is far beyond any legitimate file.
+  const MAX_SAMPLES_PER_CHANNEL = 500_000;
+  for (const m of mappings) {
+    const samplesForChannel = actualNumRecords * m.signal.numSamples;
+    if (samplesForChannel > MAX_SAMPLES_PER_CHANNEL) {
+      throw new Error(
+        `PLD allocation limit: channel '${m.signal.label.trim()}' would need ${samplesForChannel} samples`
+      );
+    }
+  }
+
   // --- Precompute scaling factors for each mapped channel ---
   interface ChannelReader {
     key: keyof Omit<PLDData, 'samplingRate' | 'durationSeconds' | 'startTime'>;

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -39,7 +39,6 @@ import type {
   OximetryTraceData,
   CrossDeviceResults,
   CSLData,
-  PLDData,
   PLDSummary,
 } from '../lib/types';
 
@@ -287,10 +286,13 @@ async function processFiles(
     }
   }
 
-  // Step 3.7: Parse PLD.edf files and group by night date
+  // Step 3.7: Parse PLD.edf files and compute summaries immediately per file.
+  // Raw PLDData (Float32Arrays) is discarded right after computePLDSummary to
+  // avoid holding ~0.8MB per file × 499 files in the worker heap simultaneously.
   const pldFiles = filterPLDFiles(fileList);
-  const pldByDate = new Map<string, PLDData[]>();
-  for (const pldInfo of pldFiles) {
+  const pldSummaryByDate = new Map<string, PLDSummary>();
+  for (let i = 0; i < pldFiles.length; i++) {
+    const pldInfo = pldFiles[i]!;
     const fileData = files.find((f) => f.path === pldInfo.path);
     if (!fileData) continue;
     try {
@@ -299,9 +301,13 @@ async function processFiles(
       // Determine night date from folder path or filename
       const nightDate = extractFolderDate(pldInfo.path) ?? extractPLDFilenameDate(pldInfo.path);
       if (!nightDate) continue;
-      const existing = pldByDate.get(nightDate) ?? [];
-      existing.push(pld);
-      pldByDate.set(nightDate, existing);
+      // Compute summary immediately — raw Float32Arrays are released after this call
+      const summary = computePLDSummary(pld);
+      // Keep the longest-duration summary per night date
+      const existing = pldSummaryByDate.get(nightDate);
+      if (!existing || summary.durationSeconds > existing.durationSeconds) {
+        pldSummaryByDate.set(nightDate, summary);
+      }
     } catch (err) {
       const filename = pldInfo.path.split('/').pop() || pldInfo.path;
       const detail = err instanceof Error ? err.message : String(err);
@@ -312,6 +318,11 @@ async function processFiles(
         tags: { file: filename, error: detail },
       };
       self.postMessage(warning);
+    }
+
+    // Yield every PARSE_BATCH_SIZE PLD files to allow GC to reclaim memory
+    if ((i + 1) % PARSE_BATCH_SIZE === 0) {
+      await yieldControl();
     }
   }
 
@@ -504,17 +515,8 @@ async function processFiles(
         : 0,
     } : null;
 
-    // PLD summary: match by night date, merge multiple PLD files per night
-    let pldSummary: PLDSummary | null = null;
-    const nightPldFiles = pldByDate.get(group.nightDate);
-    if (nightPldFiles && nightPldFiles.length > 0) {
-      // Use first PLD file for the night (typically one PLD per session)
-      // If multiple, pick the longest one
-      const bestPld = nightPldFiles.reduce((best, current) =>
-        current.durationSeconds > best.durationSeconds ? current : best
-      );
-      pldSummary = computePLDSummary(bestPld);
-    }
+    // PLD summary: already computed and keyed by night date during parsing
+    const pldSummary: PLDSummary | null = pldSummaryByDate.get(group.nightDate) ?? null;
 
     nights.push({
       date: recordingDate,


### PR DESCRIPTION
Closes AIR-960. Three-part fix: PLD allocation guard, summary-only map in worker, descriptive WorkerWarning instead of OOM. CTO-authored, build green.