### PR TITLE
fix(contribute): structured error responses for non-JSON failures (AIR-961)

### DIFF
--- a/__tests__/contribute.test.ts
+++ b/__tests__/contribute.test.ts
@@ -150,14 +150,42 @@ describe('contributeNights', () => {
 
   it('throws on chunk failure but previous chunks were sent', async () => {
     fetchMock
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
-      .mockResolvedValueOnce({ ok: false, status: 500, json: () => Promise.resolve({ error: 'Server error' }) });
+      .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve('{}'), headers: { get: () => 'application/json' } })
+      .mockResolvedValueOnce({ ok: false, status: 500, text: () => Promise.resolve('{"error":"Server error"}'), headers: { get: () => 'application/json' } });
 
     const nights = makeNights(1500);
     await expect(contributeNights(nights)).rejects.toThrow('Contribution failed (batch 2): Server error');
 
     // First chunk was still sent
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws with HTTP status when server returns non-JSON response', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('<html>Internal Server Error</html>'),
+      headers: { get: () => 'text/html' },
+    });
+
+    const nights = makeNights(1);
+    await expect(contributeNights(nights)).rejects.toThrow(
+      'Contribution failed (batch 1): HTTP 500 (non-JSON)'
+    );
+  });
+
+  it('throws with HTTP status when server returns empty body', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve(''),
+      headers: { get: () => null },
+    });
+
+    const nights = makeNights(1);
+    await expect(contributeNights(nights)).rejects.toThrow(
+      'Contribution failed (batch 1): HTTP 503 (non-JSON)'
+    );
   });
 });
 

--- a/app/api/contribute-data/route.ts
+++ b/app/api/contribute-data/route.ts
@@ -230,11 +230,11 @@ function anonymiseNight(n: NightResult, index: number, nightContext?: NightConte
 */
 
 export async function POST(request: NextRequest) {
-  if (!validateOrigin(request)) {
-    return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
-  }
-
   try {
+    if (!validateOrigin(request)) {
+      return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
+    }
+
     const ip = getRateLimitKey(request);
     if (await limiter.isLimited(ip)) {
       console.error('[contribute-data] 429 rate limited', { ip });

--- a/lib/contribute.ts
+++ b/lib/contribute.ts
@@ -139,10 +139,23 @@ export async function contributeNights(
         continue;
       }
 
-      const body = await res.json().catch(() => ({ error: 'Unknown error' }));
-      throw new Error(
-        `Contribution failed (batch ${batchNum}): ${body.error || res.status}`
-      );
+      const text = await res.text().catch(() => '');
+      let errorDetail: string;
+      try {
+        const body = JSON.parse(text) as Record<string, unknown>;
+        errorDetail = typeof body.error === 'string' ? body.error : String(res.status);
+      } catch {
+        // Server returned a non-JSON response (e.g. Next.js plain-text 500 from
+        // an unhandled exception outside the route try/catch). Log the snippet so
+        // Sentry captures the actual HTTP status and body for diagnosis.
+        console.error('[contribute] non-JSON server response', {
+          status: res.status,
+          contentType: res.headers.get('content-type'),
+          snippet: text.slice(0, 300),
+        });
+        errorDetail = `HTTP ${res.status} (non-JSON)`;
+      }
+      throw new Error(`Contribution failed (batch ${batchNum}): ${errorDetail}`);
     }
 
     if (!success) {


### PR DESCRIPTION
Closes AIR-961. Moves validateOrigin inside try/catch, replaces res.json().catch with res.text()+JSON.parse so non-JSON responses surface HTTP status to Sentry instead of opaque 'Unknown error'. CTO-reviewed, build green.