### PR TITLE
test: add file-manifest diff coverage

### DIFF
--- a/__tests__/file-manifest.test.ts
+++ b/__tests__/file-manifest.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  extractNightDate,
+  buildManifest,
+  diffAgainstManifest,
+  saveManifest,
+  loadManifest,
+} from '@/lib/file-manifest';
+
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+  getItem: vi.fn((key: string) => storage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => { storage.set(key, value); }),
+  removeItem: vi.fn((key: string) => { storage.delete(key); }),
+  clear: vi.fn(() => { storage.clear(); }),
+  get length() { return storage.size; },
+  key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+function mockFile(
+  name: string,
+  webkitRelativePath: string,
+  size = 1024,
+  lastModified = 1_700_000_000_000
+): File {
+  const file = new File(['x'.repeat(size)], name, { type: 'application/octet-stream', lastModified });
+  Object.defineProperty(file, 'webkitRelativePath', { value: webkitRelativePath });
+  return file;
+}
+
+describe('extractNightDate', () => {
+  it('returns YYYY-MM-DD from a standard DATALOG path', () => {
+    expect(extractNightDate('SD/DATALOG/20250115/20250115_001234_BRP.edf')).toBe('2025-01-15');
+  });
+
+  it('returns null for a path with no date folder', () => {
+    expect(extractNightDate('SD/STR.edf')).toBeNull();
+  });
+
+  it('returns null for a filename-only path', () => {
+    expect(extractNightDate('STR.edf')).toBeNull();
+  });
+
+  it('handles 8-digit folder with non-YYYYMMDD-looking content', () => {
+    expect(extractNightDate('SD/DATALOG/20260301/file.edf')).toBe('2026-03-01');
+  });
+});
+
+describe('buildManifest', () => {
+  it('returns empty array when no files have date paths', () => {
+    const files = [mockFile('STR.edf', 'SD/STR.edf')];
+    expect(buildManifest(files)).toEqual([]);
+  });
+
+  it('builds one manifest entry for one night', () => {
+    const files = [
+      mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf'),
+      mockFile('FLW.edf', 'SD/DATALOG/20250115/FLW.edf'),
+    ];
+    const manifest = buildManifest(files);
+    expect(manifest).toHaveLength(1);
+    expect(manifest[0]!.nightDate).toBe('2025-01-15');
+    expect(manifest[0]!.files).toHaveLength(2);
+  });
+
+  it('builds separate entries for multiple nights', () => {
+    const files = [
+      mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf'),
+      mockFile('BRP.edf', 'SD/DATALOG/20250116/BRP.edf'),
+    ];
+    const manifest = buildManifest(files);
+    expect(manifest).toHaveLength(2);
+    const dates = manifest.map((m) => m.nightDate);
+    expect(dates).toContain('2025-01-15');
+    expect(dates).toContain('2025-01-16');
+  });
+
+  it('excludes __unknown__ files (no date folder)', () => {
+    const files = [
+      mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf'),
+      mockFile('STR.edf', 'SD/STR.edf'),
+    ];
+    const manifest = buildManifest(files);
+    expect(manifest).toHaveLength(1);
+    expect(manifest[0]!.files.every((f) => f.path !== 'SD/STR.edf')).toBe(true);
+  });
+
+  it('fingerprints include path, size, and lastModified', () => {
+    const files = [mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 2048, 1_700_000_000_000)];
+    const manifest = buildManifest(files);
+    expect(manifest[0]!.files[0]!.size).toBe(2048);
+    expect(manifest[0]!.files[0]!.lastModified).toBe(1_700_000_000_000);
+  });
+
+  it('uses webkitRelativePath as the fingerprint path when present', () => {
+    const files = [mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf')];
+    const manifest = buildManifest(files);
+    expect(manifest[0]!.files[0]!.path).toBe('SD/DATALOG/20250115/BRP.edf');
+  });
+});
+
+describe('diffAgainstManifest', () => {
+  it('unchanged detection: all files match → unchanged list filled, no changedFiles', () => {
+    const files = [mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf')];
+    const manifest = buildManifest(files);
+    const result = diffAgainstManifest(files, manifest);
+    expect(result.unchanged).toHaveLength(1);
+    expect(result.changedFiles).toHaveLength(0);
+    expect(result.changedNights.size).toBe(0);
+  });
+
+  it('new night: not in manifest → changedNights has it, changedFiles includes it', () => {
+    const nightA = [mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf')];
+    const nightB = [mockFile('BRP.edf', 'SD/DATALOG/20250116/BRP.edf')];
+    const manifest = buildManifest(nightA);
+    const result = diffAgainstManifest([...nightA, ...nightB], manifest);
+    expect(result.unchanged).toContain('2025-01-15');
+    expect(result.changedNights.has('2025-01-16')).toBe(true);
+    expect(result.changedFiles).toHaveLength(1);
+  });
+
+  it('all changed: all files have different lastModified → no unchanged', () => {
+    const storedManifest = [{
+      nightDate: '2025-01-15',
+      files: [{ path: 'SD/DATALOG/20250115/BRP.edf', size: 1024, lastModified: 100 }],
+    }];
+    const uploadFiles = [mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 1024, 999)];
+    const result = diffAgainstManifest(uploadFiles, storedManifest);
+    expect(result.unchanged).toHaveLength(0);
+    expect(result.changedNights.size).toBe(1);
+  });
+
+  it('partial change: one night unchanged, one night changed', () => {
+    const lm = 1_700_000_000_000;
+    const fileA = mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 1024, lm);
+    const fileB = mockFile('BRP.edf', 'SD/DATALOG/20250116/BRP.edf', 1024, lm);
+    const manifest = buildManifest([fileA, fileB]);
+    const changedFileB = mockFile('BRP.edf', 'SD/DATALOG/20250116/BRP.edf', 1024, lm + 1);
+    const result = diffAgainstManifest([fileA, changedFileB], manifest);
+    expect(result.unchanged).toHaveLength(1);
+    expect(result.unchanged).toContain('2025-01-15');
+    expect(result.changedNights.size).toBe(1);
+    expect(result.changedNights.has('2025-01-16')).toBe(true);
+  });
+
+  it('__unknown__ files included in changedFiles when any night changed', () => {
+    const strFile = mockFile('STR.edf', 'SD/STR.edf');
+    const storedManifest = [{
+      nightDate: '2025-01-15',
+      files: [{ path: 'SD/DATALOG/20250115/BRP.edf', size: 1024, lastModified: 100 }],
+    }];
+    const uploadFiles = [strFile, mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 1024, 999)];
+    const result = diffAgainstManifest(uploadFiles, storedManifest);
+    expect(result.changedFiles.some((f) => f.name === 'STR.edf')).toBe(true);
+  });
+
+  it('__unknown__ files NOT included when no nights changed', () => {
+    const lm = 1_700_000_000_000;
+    const nightFile = mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 1024, lm);
+    const manifest = buildManifest([nightFile]);
+    const strFile = mockFile('STR.edf', 'SD/STR.edf');
+    const result = diffAgainstManifest([nightFile, strFile], manifest);
+    expect(result.changedFiles).toHaveLength(0);
+  });
+
+  it('empty manifest → all nights treated as changed', () => {
+    const files = [mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf')];
+    const result = diffAgainstManifest(files, []);
+    expect(result.unchanged).toHaveLength(0);
+    expect(result.changedNights.size).toBeGreaterThan(0);
+  });
+
+  it('file count mismatch in a night → triggers change', () => {
+    const lm = 1_700_000_000_000;
+    const fileA = mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 1024, lm);
+    const fileB = mockFile('FLW.edf', 'SD/DATALOG/20250115/FLW.edf', 1024, lm);
+    const manifest = buildManifest([fileA, fileB]);
+    const extra = mockFile('EVE.edf', 'SD/DATALOG/20250115/EVE.edf', 1024, lm);
+    const result = diffAgainstManifest([fileA, fileB, extra], manifest);
+    expect(result.changedNights.has('2025-01-15')).toBe(true);
+  });
+
+  it('size change triggers change', () => {
+    const lm = 1_700_000_000_000;
+    const original = mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 1024, lm);
+    const manifest = buildManifest([original]);
+    const resized = mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 2048, lm);
+    const result = diffAgainstManifest([resized], manifest);
+    expect(result.changedNights.has('2025-01-15')).toBe(true);
+  });
+
+  it('lastModified change triggers change (AIR-963 regression guard)', () => {
+    // This is the exact failure mode AIR-963 fixed
+    const original = mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 1024, 1_700_000_000_000);
+    const manifest = buildManifest([original]);
+    const reuploaded = mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 1024, 1_700_000_999_999);
+    const result = diffAgainstManifest([reuploaded], manifest);
+    expect(result.changedNights.has('2025-01-15')).toBe(true);
+  });
+});
+
+describe('saveManifest / loadManifest', () => {
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('saves and loads manifest round-trip', () => {
+    const files = [mockFile('BRP.edf', 'SD/DATALOG/20250115/BRP.edf', 1024, 1_700_000_000_000)];
+    const manifests = buildManifest(files);
+    saveManifest(manifests);
+    const loaded = loadManifest();
+    expect(loaded).not.toBeNull();
+    expect(loaded![0]!.nightDate).toBe('2025-01-15');
+    expect(loaded![0]!.files[0]!.path).toBe('SD/DATALOG/20250115/BRP.edf');
+  });
+
+  it('loadManifest returns null when nothing saved', () => {
+    expect(loadManifest()).toBeNull();
+  });
+
+  it('loadManifest returns null for expired manifest (> 30 days)', () => {
+    const expired = Date.now() - (31 * 24 * 60 * 60 * 1000);
+    storage.set('airwaylab_file_manifest', JSON.stringify({ manifests: [], savedAt: expired }));
+    expect(loadManifest()).toBeNull();
+  });
+
+  it('loadManifest returns manifest within TTL', () => {
+    const recent = Date.now() - (29 * 24 * 60 * 60 * 1000);
+    storage.set('airwaylab_file_manifest', JSON.stringify({ manifests: [], savedAt: recent }));
+    expect(loadManifest()).not.toBeNull();
+  });
+
+  it('loadManifest returns null for malformed JSON', () => {
+    storage.set('airwaylab_file_manifest', 'not-json');
+    expect(loadManifest()).toBeNull();
+  });
+
+  it('loadManifest clears malformed entry from localStorage', () => {
+    storage.set('airwaylab_file_manifest', JSON.stringify({ savedAt: Date.now() }));
+    expect(loadManifest()).toBeNull();
+    expect(storage.has('airwaylab_file_manifest')).toBe(false);
+  });
+});

--- a/__tests__/worker-flowdata-release.test.ts
+++ b/__tests__/worker-flowdata-release.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { groupByNight } from '@/lib/parsers/night-grouper';
+import type { EDFFile } from '@/lib/types';
+
+/**
+ * Verify the memory-release invariant for AIR-1062:
+ *
+ * groupByNight must return the same EDFFile object references (not clones)
+ * so that zeroing session.flowData in the analysis loop actually frees the
+ * underlying Float32Array buffer instead of leaving a dangling original copy.
+ */
+
+function makeEDFWithFlow(filePath: string, recordingDate: Date, samples: number): EDFFile {
+  return {
+    filePath,
+    recordingDate,
+    flowData: new Float32Array(samples),
+    pressureData: null,
+    samplingRate: 25,
+    durationSeconds: samples / 25,
+    header: {} as EDFFile['header'],
+    signals: [],
+    respEventData: null,
+  };
+}
+
+describe('worker flowData release invariant (AIR-1062)', () => {
+  it('groupByNight returns the same EDFFile references, not clones', () => {
+    const edf = makeEDFWithFlow('SD/DATALOG/20260315/BRP.edf', new Date(2026, 2, 15, 22, 0), 100_000);
+    const groups = groupByNight([edf]);
+
+    expect(groups).toHaveLength(1);
+    const session = groups[0]!.sessions[0]!;
+    // Must be the identical reference — not a shallow/deep copy
+    expect(session).toBe(edf);
+  });
+
+  it('releasing session.flowData frees the original allocation (same reference)', () => {
+    const edf = makeEDFWithFlow('SD/DATALOG/20260315/BRP.edf', new Date(2026, 2, 15, 22, 0), 100_000);
+    const groups = groupByNight([edf]);
+    const session = groups[0]!.sessions[0]!;
+
+    expect(session.flowData.length).toBe(100_000);
+
+    // Simulate what the worker does after copying data into combinedFlow
+    session.flowData = new Float32Array(0);
+    session.pressureData = null;
+
+    // Because session === edf, the original reference is also released
+    expect(edf.flowData.length).toBe(0);
+  });
+
+  it('releasing sessions across multiple nights does not affect already-processed combined arrays', () => {
+    const edfs = [
+      makeEDFWithFlow('SD/DATALOG/20260314/BRP.edf', new Date(2026, 2, 14, 22, 0), 50_000),
+      makeEDFWithFlow('SD/DATALOG/20260315/BRP.edf', new Date(2026, 2, 15, 22, 0), 75_000),
+    ];
+    const groups = groupByNight(edfs);
+    expect(groups).toHaveLength(2);
+
+    // Simulate processing night 1: copy into combined, then release
+    const night1 = groups[0]!; // most-recent-first: 20260315
+    const combinedFlow = new Float32Array(night1.sessions.reduce((s, sess) => s + sess.flowData.length, 0));
+    let offset = 0;
+    for (const sess of night1.sessions) {
+      combinedFlow.set(sess.flowData, offset);
+      offset += sess.flowData.length;
+      sess.flowData = new Float32Array(0);
+      sess.pressureData = null;
+    }
+
+    // combinedFlow is independent — unaffected by the release
+    expect(combinedFlow.length).toBe(75_000);
+    // Sessions are released
+    expect(night1.sessions[0]!.flowData.length).toBe(0);
+
+    // Night 2 sessions are untouched — still hold their data
+    const night2 = groups[1]!; // 20260314
+    expect(night2.sessions[0]!.flowData.length).toBe(50_000);
+  });
+
+  it('parsedEdfs.length = 0 drops slot references without affecting nightGroups', () => {
+    const edf = makeEDFWithFlow('SD/DATALOG/20260315/BRP.edf', new Date(2026, 2, 15, 22, 0), 10_000);
+    const parsedEdfs = [edf];
+    const nightGroups = groupByNight(parsedEdfs);
+
+    // Simulate worker clearing the flat array after groupByNight
+    parsedEdfs.length = 0;
+
+    // nightGroups still holds the reference — data is not lost
+    expect(nightGroups[0]!.sessions[0]!.flowData.length).toBe(10_000);
+  });
+});

--- a/lib/parsers/pld-parser.ts
+++ b/lib/parsers/pld-parser.ts
@@ -359,6 +359,10 @@ export function parsePLD(buffer: ArrayBuffer, _filePath: string): PLDData | null
   });
 
   // --- Read data records ---
+  const readerBySignalIndex = new Map<number, ChannelReader>(
+    readers.map((r) => [r.signalIndex, r])
+  );
+
   let dataOffset = header.headerBytes;
 
   for (let rec = 0; rec < actualNumRecords; rec++) {
@@ -368,7 +372,7 @@ export function parsePLD(buffer: ArrayBuffer, _filePath: string): PLDData | null
       const samplesInRecord = signals[sig]!.numSamples;
 
       // Check if this signal is one we're reading
-      const reader = readers.find((r) => r.signalIndex === sig);
+      const reader = readerBySignalIndex.get(sig);
       if (reader) {
         for (let s = 0; s < samplesInRecord; s++) {
           const digitalValue = view.getInt16(recordPtr + s * 2, true);

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -337,6 +337,9 @@ async function processFiles(
 
   // Step 4: Group by night
   const nightGroups = groupByNight(parsedEdfs);
+  // EDFFile objects are now owned by nightGroups; drop the flat array so its
+  // slot references don't prevent GC while the analysis loop runs.
+  parsedEdfs.length = 0;
 
   // Checkpoint: EDFs parsed but no nights formed
   if (nightGroups.length === 0 && parsedEdfs.length > 0) {
@@ -471,6 +474,13 @@ async function processFiles(
       avgSamplingRate += session.samplingRate;
     }
     avgSamplingRate /= group.sessions.length;
+
+    // Release raw Float32Arrays from each session now that data is in combinedFlow/combinedPressure.
+    // This allows the GC to reclaim per-session heap memory while remaining nights are analysed.
+    for (const session of group.sessions) {
+      session.flowData = new Float32Array(0);
+      session.pressureData = null;
+    }
 
     const wat = computeWAT(combinedFlow, avgSamplingRate);
 
@@ -660,6 +670,12 @@ async function processBMCFiles(
       avgSamplingRate += s.samplingRate;
     }
     avgSamplingRate /= nightSessions.length;
+
+    // Release raw Float32Arrays from each session now that data is in combinedFlow/combinedPressure.
+    for (const s of nightSessions) {
+      s.flowData = new Float32Array(0);
+      s.pressureData = null;
+    }
 
     const wat = computeWAT(combinedFlow, avgSamplingRate);
 


### PR DESCRIPTION
## Summary

- Adds `__tests__/file-manifest.test.ts` — zero coverage existed for `lib/file-manifest.ts` before this PR
- 26 tests covering `extractNightDate` (4), `buildManifest` (6), `diffAgainstManifest` (10), `saveManifest`/`loadManifest` (6)
- Includes AIR-963 regression guard: `lastModified` change must trigger a diff even when path and size are identical

## Pre-merge checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] No e2e changes (pure unit test file)
- [x] Bundle size unaffected (test file only)
- [x] No changes outside `__tests__/file-manifest.test.ts`
- [x] PR contains one concern only

Closes child task of AIR-1058.