### PR TITLE
feat(analyze): enforce 14-day history window for community tier

### DIFF
--- a/__tests__/analysis-window-tier-gate.test.tsx
+++ b/__tests__/analysis-window-tier-gate.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// ── localStorage mock ────────────────────────────────────────────
+const storage = new Map<string, string>();
+const localStorageMock: Storage = {
+  getItem: vi.fn((key: string) => storage.get(key) ?? null),
+  setItem: vi.fn((key: string, value: string) => { storage.set(key, value); }),
+  removeItem: vi.fn((key: string) => { storage.delete(key); }),
+  clear: vi.fn(() => { storage.clear(); }),
+  get length() { return storage.size; },
+  key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+};
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true });
+
+// ── Tier state for component tests ────────────────────────────────
+let mockTier = 'community';
+
+vi.mock('@/lib/auth/auth-context', () => ({
+  useAuth: () => ({ tier: mockTier }),
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  events: {
+    upgradeNudgeDismissed: vi.fn(),
+    upgradeNudgeClicked: vi.fn(),
+  },
+}));
+
+// ── Imports after mocks ───────────────────────────────────────────
+import { getAnalysisWindowDays } from '@/lib/auth/feature-gate';
+import { HistoryExpiryWarning } from '@/components/dashboard/history-expiry-warning';
+import type { NightResult } from '@/lib/types';
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function daysAgoStr(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+function makeNight(dateStr: string): NightResult {
+  return {
+    dateStr,
+    ahi: 2,
+    ahiBreakdown: { obstructive: 1, central: 0.5, hypopnea: 0.5 },
+    leakStats: { median: 0, p95: 0 },
+    pressureStats: { median: 8, p95: 10, min: 6, max: 12 },
+    minutesAboveLeakThreshold: 0,
+    totalMinutes: 480,
+    therapyMode: 'CPAP',
+    tidalVolume: null,
+    minuteVentilation: null,
+    respiratoryRate: null,
+    ieRatio: null,
+    flowLimitIndex: null,
+    snoreIndex: null,
+    oximetry: null,
+    glasgow: null,
+    engineVersion: 'test',
+  } as unknown as NightResult;
+}
+
+// ── Tests: getAnalysisWindowDays ──────────────────────────────────
+
+describe('getAnalysisWindowDays', () => {
+  it('returns 14 for community tier', () => {
+    expect(getAnalysisWindowDays('community')).toBe(14);
+  });
+
+  it('returns 90 for supporter tier', () => {
+    expect(getAnalysisWindowDays('supporter')).toBe(90);
+  });
+
+  it('returns Infinity for champion tier', () => {
+    expect(getAnalysisWindowDays('champion')).toBe(Infinity);
+  });
+});
+
+// ── Tests: 14-day filter logic ────────────────────────────────────
+
+describe('14-day community window filter logic', () => {
+  it('keeps nights within 14 days and drops older ones', () => {
+    const raw = [
+      makeNight(daysAgoStr(7)),
+      makeNight(daysAgoStr(10)),
+      makeNight(daysAgoStr(20)),
+      makeNight(daysAgoStr(30)),
+    ];
+
+    const windowDays = getAnalysisWindowDays('community');
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - windowDays);
+    const cutoffStr = cutoff.toISOString().slice(0, 10);
+
+    const filtered = raw.filter((n) => n.dateStr >= cutoffStr);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((n) => n.dateStr)).toEqual([
+      daysAgoStr(7),
+      daysAgoStr(10),
+    ]);
+  });
+});
+
+// ── Tests: HistoryExpiryWarning community variant ─────────────────
+
+describe('HistoryExpiryWarning — community variant', () => {
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+    mockTier = 'community';
+  });
+
+  it('renders community banner when tier=community and hiddenNightCount=3', () => {
+    render(<HistoryExpiryWarning nights={[makeNight(daysAgoStr(3))]} hiddenNightCount={3} />);
+    expect(screen.getByText(/viewing the last 14 days/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /see full history/i })).toHaveAttribute('href', '/pricing');
+  });
+
+  it('does not render community banner when hiddenNightCount=0', () => {
+    render(<HistoryExpiryWarning nights={[makeNight(daysAgoStr(3))]} hiddenNightCount={0} />);
+    expect(screen.queryByText(/viewing the last 14 days/i)).not.toBeInTheDocument();
+  });
+
+  it('does not render community banner when hiddenNightCount is omitted', () => {
+    render(<HistoryExpiryWarning nights={[makeNight(daysAgoStr(3))]} />);
+    expect(screen.queryByText(/viewing the last 14 days/i)).not.toBeInTheDocument();
+  });
+
+  it('dismisses community banner and stores timestamp in localStorage', () => {
+    render(<HistoryExpiryWarning nights={[makeNight(daysAgoStr(3))]} hiddenNightCount={2} />);
+    fireEvent.click(screen.getByLabelText(/dismiss for now/i));
+    expect(screen.queryByText(/viewing the last 14 days/i)).not.toBeInTheDocument();
+    expect(storage.get('airwaylab_community_window_dismissed')).toBeDefined();
+  });
+});
+
+// ── Tests: HistoryExpiryWarning supporter variant (regression) ────
+
+describe('HistoryExpiryWarning — supporter expiry warning (regression)', () => {
+  beforeEach(() => {
+    storage.clear();
+    vi.clearAllMocks();
+    mockTier = 'supporter';
+  });
+
+  it('does not render supporter warning when no nights are near expiry', () => {
+    // All nights are very recent — nowhere near the 90-day window
+    const nights = [makeNight(daysAgoStr(1)), makeNight(daysAgoStr(2))];
+    render(<HistoryExpiryWarning nights={nights} />);
+    expect(screen.queryByText(/expire/i)).not.toBeInTheDocument();
+  });
+
+  it('renders supporter expiry warning when oldest night is within 15 days of 90-day limit', () => {
+    // Night that is 77 days old (90 - 77 = 13 days left → within 15-day warning window)
+    const nights = [makeNight(daysAgoStr(77))];
+    render(<HistoryExpiryWarning nights={nights} />);
+    expect(screen.getByText(/expire/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /keep your history/i })).toHaveAttribute('href', '/pricing');
+  });
+});

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -16,6 +16,7 @@ import { ReturningUserNudge } from '@/components/dashboard/returning-user-nudge'
 import { CommunityJoinPrompt } from '@/components/dashboard/community-join-prompt';
 import { AuthModal } from '@/components/auth/auth-modal';
 import { useAuth } from '@/lib/auth/auth-context';
+import { getAnalysisWindowDays } from '@/lib/auth/feature-gate';
 import { storeAnalysisData } from '@/lib/analysis-data-client';
 import { uploadOrchestrator } from '@/lib/storage/upload-orchestrator';
 import { DataContribution, type AutoSubmitStatus } from '@/components/dashboard/data-contribution';
@@ -129,7 +130,7 @@ function AnalyzePageInner() {
   const [engineUpgraded, setEngineUpgraded] = useState(false);
   const [activeTab, setActiveTab] = useState('overview');
   const tabScrollRef = useRef<HTMLDivElement>(null);
-  const { user } = useAuth();
+  const { user, tier } = useAuth();
   const userRef = useRef(user);
   useEffect(() => { userRef.current = user; }, [user]);
   const hasTriggeredAutoUpload = useRef(false);
@@ -477,14 +478,29 @@ function AnalyzePageInner() {
   const { status, progress, error, warning, persistenceWarning, warnings } = state;
 
   // Memoize derived data to stabilize references across renders
-  const nights = useMemo<NightResult[]>(() =>
-    isDemo
+  const nights = useMemo<NightResult[]>(() => {
+    const raw = isDemo
       ? SAMPLE_NIGHTS
       : state.nights.length > 0
         ? state.nights
-        : persistedData?.nights ?? [],
-    [isDemo, state.nights, persistedData?.nights]
-  );
+        : persistedData?.nights ?? [];
+
+    const windowDays = getAnalysisWindowDays(tier);
+    if (isDemo || !isFinite(windowDays) || windowDays <= 0) return raw;
+
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - windowDays);
+    const cutoffStr = cutoff.toISOString().slice(0, 10);
+    return raw.filter((n) => n.dateStr >= cutoffStr);
+  }, [isDemo, state.nights, persistedData?.nights, tier]);
+
+  const hiddenNightCount = useMemo<number>(() => {
+    if (isDemo) return 0;
+    const windowDays = getAnalysisWindowDays(tier);
+    if (!isFinite(windowDays) || windowDays <= 0) return 0;
+    const raw = state.nights.length > 0 ? state.nights : persistedData?.nights ?? [];
+    return Math.max(0, raw.length - nights.length);
+  }, [isDemo, tier, state.nights, persistedData?.nights, nights]);
   const therapyChangeDate = useMemo<string | null>(() =>
     isDemo
       ? SAMPLE_THERAPY_CHANGE_DATE
@@ -1077,7 +1093,7 @@ function AnalyzePageInner() {
             }} />
             <GuidedWalkthrough isComplete={isComplete} />
             {!isDemo && <PostAnalysisUpgrade isComplete={isComplete} />}
-            {!isDemo && <HistoryExpiryWarning nights={nights} />}
+            {!isDemo && <HistoryExpiryWarning nights={nights} hiddenNightCount={hiddenNightCount} />}
             {!isDemo && <EmailOptInNudge />}
             <DataContribution
               nights={nights}

--- a/components/dashboard/history-expiry-warning.tsx
+++ b/components/dashboard/history-expiry-warning.tsx
@@ -10,24 +10,43 @@ import type { NightResult } from '@/lib/types';
 
 const STORAGE_KEY = 'airwaylab_history_expiry_dismissed';
 const DISMISS_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+const COMMUNITY_STORAGE_KEY = 'airwaylab_community_window_dismissed';
+const COMMUNITY_DISMISS_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+
 const WARNING_WINDOW_DAYS = 15;
 
 interface Props {
   nights: NightResult[];
+  hiddenNightCount?: number;
 }
 
 /**
  * Amber banner warning Supporter-tier users when their oldest analyses
  * approach the 90-day history window. Nudges toward Champion (lifetime).
  * Shows 15 days before first expiry. Dismissible with 7-day TTL.
+ *
+ * Also renders a slate/blue informational banner for Community-tier users
+ * when nights are hidden by the 14-day window.
  */
-export function HistoryExpiryWarning({ nights }: Props) {
+export function HistoryExpiryWarning({ nights, hiddenNightCount }: Props) {
   const { tier } = useAuth();
+
   const [dismissed, setDismissed] = useState(() => {
     try {
       const ts = localStorage.getItem(STORAGE_KEY);
       if (!ts) return false;
       return Date.now() - Number(ts) < DISMISS_TTL_MS;
+    } catch {
+      return false;
+    }
+  });
+
+  const [communityDismissed, setCommunityDismissed] = useState(() => {
+    try {
+      const ts = localStorage.getItem(COMMUNITY_STORAGE_KEY);
+      if (!ts) return false;
+      return Date.now() - Number(ts) < COMMUNITY_DISMISS_TTL_MS;
     } catch {
       return false;
     }
@@ -65,6 +84,50 @@ export function HistoryExpiryWarning({ nights }: Props) {
     }
     setDaysLeft(Math.max(0, remaining));
   }, [tier, nights]);
+
+  // Community banner
+  if (tier === 'community' && (hiddenNightCount ?? 0) > 0 && !communityDismissed) {
+    const dismissCommunity = () => {
+      setCommunityDismissed(true);
+      try {
+        localStorage.setItem(COMMUNITY_STORAGE_KEY, String(Date.now()));
+      } catch { /* noop */ }
+      events.upgradeNudgeDismissed('community_window');
+    };
+
+    return (
+      <div className="animate-fade-in-up rounded-xl border border-blue-500/20 bg-blue-500/[0.06] px-4 py-4">
+        <div className="flex items-start gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
+            <Clock className="h-4 w-4 text-blue-400" />
+          </div>
+          <div className="flex-1">
+            <div className="flex items-start justify-between">
+              <h3 className="text-sm font-semibold text-foreground">
+                You&apos;re viewing the last 14 days of history. Upgrade to Supporter to see 90 days.
+              </h3>
+              <button
+                onClick={dismissCommunity}
+                className="rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-muted-foreground"
+                aria-label="Dismiss for now"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <div className="mt-3">
+              <Link
+                href="/pricing"
+                className="inline-flex items-center gap-1.5 rounded-md bg-blue-500/10 px-3 py-1.5 text-xs font-medium text-blue-400 transition-colors hover:bg-blue-500/20"
+                onClick={() => events.upgradeNudgeClicked('community_window')}
+              >
+                See full history
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (tier !== 'supporter' || daysLeft === null || dismissed) return null;
 

--- a/lib/auth/feature-gate.ts
+++ b/lib/auth/feature-gate.ts
@@ -99,5 +99,5 @@ export function incrementAIUsage(): void {
 export function getAnalysisWindowDays(tier: Tier): number {
   if (tier === 'champion') return Infinity;
   if (tier === 'supporter') return 90;
-  return 0; // community: current session only
+  return 14; // community: most recent 14 days
 }


### PR DESCRIPTION
## Summary

- getAnalysisWindowDays community returns 14 (was 0)
- app/analyze filters nights useMemo by window; adds hiddenNightCount
- HistoryExpiryWarning renders community info banner when nights hidden
- 10 new tests

## Test plan

- [x] tsc, lint, test, build all green (1979 tests pass)
- [ ] Community user with >14-day history sees filtered nights + banner
- [ ] Supporter and Champion unaffected

Closes AIR-1064