### PR TITLE
feat(email): analysis window announcement send list + trigger

### DIFF
--- a/__tests__/analysis-window-email.test.ts
+++ b/__tests__/analysis-window-email.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// ── Mocks ────────────────────────────────────────────────────
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}))
+
+vi.mock('@/lib/email/unsubscribe-token', () => ({
+  getUnsubscribeUrl: vi.fn((userId: string) => `https://airwaylab.app/api/email/unsubscribe?token=${userId}`),
+}))
+
+const mockSendEmail = vi.fn()
+vi.mock('@/lib/email/send', () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}))
+
+// Chainable mock builder for Supabase queries
+type ChainableMock = Record<string, ReturnType<typeof vi.fn>> & {
+  mockResolvedValue: (val: unknown) => ChainableMock
+}
+
+function makeChain(terminal?: unknown): ChainableMock {
+  const terminalPromise = terminal !== undefined ? Promise.resolve(terminal) : Promise.resolve({ data: [], error: null })
+  const chain: ChainableMock = {} as ChainableMock
+  const proxy = new Proxy(chain, {
+    get(target, prop) {
+      if (prop === 'then') return (cb: (v: unknown) => unknown) => terminalPromise.then(cb)
+      if (prop === 'catch') return (cb: (v: unknown) => unknown) => terminalPromise.catch(cb)
+      if (prop === 'finally') return (cb: () => void) => terminalPromise.finally(cb)
+      const key = prop as string
+      if (!target[key]) target[key] = vi.fn().mockReturnValue(proxy)
+      return target[key]
+    },
+  })
+  return proxy
+}
+
+let mockFromImpl: (table: string) => unknown
+const mockFrom = vi.fn((table: string) => mockFromImpl(table))
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseServiceRole: vi.fn(() => ({
+    from: (t: string) => mockFrom(t),
+  })),
+}))
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeRequest(body: unknown, adminSecret = 'test-secret'): NextRequest {
+  return new NextRequest('http://localhost/api/admin/email/analysis-window', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-admin-secret': adminSecret,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('POST /api/admin/email/analysis-window', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('ADMIN_API_KEY', 'test-secret')
+    vi.stubEnv('RESEND_API_KEY', 'test-resend-key')
+    mockSendEmail.mockResolvedValue('resend-id-123')
+  })
+
+  it('returns 401 when admin secret is missing', async () => {
+    const { POST } = await import('@/app/api/admin/email/analysis-window/route')
+    const req = makeRequest({ dryRun: true }, '')
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when admin secret is wrong', async () => {
+    const { POST } = await import('@/app/api/admin/email/analysis-window/route')
+    const req = makeRequest({ dryRun: true }, 'wrong-secret')
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns dry-run results without sending emails', async () => {
+    mockFromImpl = (table) => {
+      if (table === 'user_nights') {
+        return makeChain({ data: [{ user_id: 'user-1' }, { user_id: 'user-2' }], error: null })
+      }
+      if (table === 'profiles') {
+        return makeChain({
+          data: [
+            { id: 'user-1', email: 'a@example.com' },
+            { id: 'user-2', email: 'b@example.com' },
+          ],
+          error: null,
+        })
+      }
+      // email_log
+      return makeChain({ data: [], error: null })
+    }
+
+    const { POST } = await import('@/app/api/admin/email/analysis-window/route')
+    const req = makeRequest({ dryRun: true })
+    const res = await POST(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.dryRun).toBe(true)
+    expect(body.would_send).toBe(2)
+    expect(body.already_sent).toBe(0)
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('defaults to dry-run when dryRun is not specified', async () => {
+    mockFromImpl = (_table) => makeChain({ data: [], error: null })
+
+    const { POST } = await import('@/app/api/admin/email/analysis-window/route')
+    const req = makeRequest({})
+    const res = await POST(req)
+    const body = await res.json()
+
+    expect(body.dryRun).toBe(true)
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns empty audience when no users have old nights', async () => {
+    mockFromImpl = (_table) => makeChain({ data: [], error: null })
+
+    const { POST } = await import('@/app/api/admin/email/analysis-window/route')
+    const req = makeRequest({ dryRun: true })
+    const res = await POST(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.audience).toBe(0)
+    expect(body.would_send).toBe(0)
+  })
+
+  it('skips users who already received the broadcast (idempotency)', async () => {
+    mockFromImpl = (table) => {
+      if (table === 'user_nights') {
+        return makeChain({ data: [{ user_id: 'user-1' }, { user_id: 'user-2' }], error: null })
+      }
+      if (table === 'profiles') {
+        return makeChain({
+          data: [
+            { id: 'user-1', email: 'a@example.com' },
+            { id: 'user-2', email: 'b@example.com' },
+          ],
+          error: null,
+        })
+      }
+      // email_log — user-1 already sent
+      return makeChain({ data: [{ to_email: 'a@example.com' }], error: null })
+    }
+
+    const { POST } = await import('@/app/api/admin/email/analysis-window/route')
+    const req = makeRequest({ dryRun: true })
+    const res = await POST(req)
+    const body = await res.json()
+
+    expect(body.audience).toBe(2)
+    expect(body.already_sent).toBe(1)
+    expect(body.would_send).toBe(1)
+  })
+
+  it('sends emails in live mode and returns sent count', async () => {
+    mockFromImpl = (table) => {
+      if (table === 'user_nights') {
+        return makeChain({ data: [{ user_id: 'user-1' }], error: null })
+      }
+      if (table === 'profiles') {
+        return makeChain({ data: [{ id: 'user-1', email: 'a@example.com' }], error: null })
+      }
+      return makeChain({ data: [], error: null })
+    }
+
+    const { POST } = await import('@/app/api/admin/email/analysis-window/route')
+    const req = makeRequest({ dryRun: false })
+    const res = await POST(req)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.dryRun).toBe(false)
+    expect(body.sent).toBe(1)
+    expect(body.errors).toBe(0)
+    expect(mockSendEmail).toHaveBeenCalledOnce()
+
+    const callArgs = mockSendEmail.mock.calls[0]![0]
+    expect(callArgs.to).toBe('a@example.com')
+    expect(callArgs.subject).toBe('Heads up: history visibility change coming May 27')
+    expect(callArgs.metadata.emailType).toBe('broadcast_analysis_window_announcement')
+    expect(callArgs.metadata.userId).toBe('user-1')
+    expect(callArgs.unsubscribeUrl).toContain('/api/email/unsubscribe')
+  })
+
+  it('only targets community-tier opted-in users', async () => {
+    // Query on profiles must include .eq('tier', 'community') and .eq('email_opt_in', true)
+    // We verify via the call chain that the filter was applied.
+    const profilesEqMock = vi.fn().mockReturnValue(makeChain({ data: [], error: null }))
+    const profilesSelectMock = vi.fn().mockReturnValue({ eq: profilesEqMock })
+
+    mockFromImpl = (table) => {
+      if (table === 'user_nights') {
+        return makeChain({ data: [{ user_id: 'user-1' }], error: null })
+      }
+      if (table === 'profiles') {
+        return { select: profilesSelectMock }
+      }
+      return makeChain({ data: [], error: null })
+    }
+
+    const { POST } = await import('@/app/api/admin/email/analysis-window/route')
+    await POST(makeRequest({ dryRun: true }))
+
+    // First .eq call should be tier = community
+    expect(profilesEqMock).toHaveBeenCalledWith('tier', 'community')
+  })
+
+  it('returns 500 when user_nights query fails', async () => {
+    mockFromImpl = (table) => {
+      if (table === 'user_nights') {
+        return makeChain({ data: null, error: { message: 'DB error' } })
+      }
+      return makeChain({ data: [], error: null })
+    }
+
+    const { POST } = await import('@/app/api/admin/email/analysis-window/route')
+    const req = makeRequest({ dryRun: true })
+    const res = await POST(req)
+
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('Database query failed')
+  })
+
+  it('dry-run response includes subject line', async () => {
+    mockFromImpl = (table) => {
+      if (table === 'user_nights') {
+        return makeChain({ data: [{ user_id: 'user-1' }], error: null })
+      }
+      if (table === 'profiles') {
+        return makeChain({ data: [{ id: 'user-1', email: 'a@example.com' }], error: null })
+      }
+      return makeChain({ data: [], error: null })
+    }
+
+    const { POST } = await import('@/app/api/admin/email/analysis-window/route')
+    const req = makeRequest({ dryRun: true })
+    const res = await POST(req)
+    const body = await res.json()
+
+    expect(body.subject).toBe('Heads up: history visibility change coming May 27')
+    expect(body.sample_html).toContain('May 27')
+    expect(body.sample_html).toContain('$9/month')
+  })
+})
+
+describe('analysis_window_announcement template', () => {
+  it('renders correct subject', async () => {
+    const { BROADCAST_TEMPLATES } = await import('@/lib/email/broadcast')
+    const t = BROADCAST_TEMPLATES['analysis_window_announcement']!
+    const { subject } = t.getTemplate('https://example.com/unsub', 'A')
+    expect(subject).toBe('Heads up: history visibility change coming May 27')
+  })
+
+  it('includes $9/month price in HTML body', async () => {
+    const { BROADCAST_TEMPLATES } = await import('@/lib/email/broadcast')
+    const t = BROADCAST_TEMPLATES['analysis_window_announcement']!
+    const { html } = t.getTemplate('https://example.com/unsub', 'A')
+    expect(html).toContain('$9/month')
+  })
+
+  it('includes unsubscribe link in HTML body', async () => {
+    const { BROADCAST_TEMPLATES } = await import('@/lib/email/broadcast')
+    const t = BROADCAST_TEMPLATES['analysis_window_announcement']!
+    const unsubUrl = 'https://airwaylab.app/api/email/unsubscribe?token=test123'
+    const { html } = t.getTemplate(unsubUrl, 'A')
+    expect(html).toContain(unsubUrl)
+  })
+
+  it('includes CTA to /analyze', async () => {
+    const { BROADCAST_TEMPLATES } = await import('@/lib/email/broadcast')
+    const t = BROADCAST_TEMPLATES['analysis_window_announcement']!
+    const { html } = t.getTemplate('https://example.com/unsub', 'A')
+    expect(html).toContain('/analyze')
+  })
+
+  it('includes medical disclaimer', async () => {
+    const { BROADCAST_TEMPLATES } = await import('@/lib/email/broadcast')
+    const t = BROADCAST_TEMPLATES['analysis_window_announcement']!
+    const { html } = t.getTemplate('https://example.com/unsub', 'A')
+    expect(html.toLowerCase()).toMatch(/medical advice|medical device/)
+  })
+})

--- a/app/api/admin/email/analysis-window/route.ts
+++ b/app/api/admin/email/analysis-window/route.ts
@@ -1,0 +1,219 @@
+/**
+ * One-time send: analysis window history cap announcement (AIR-1087).
+ *
+ * Audience: community-tier users who opted in to product updates AND have
+ * at least one synced night older than 14 days (i.e. affected by the window).
+ * Users whose entire history falls within 14 days see no change and are excluded.
+ *
+ * DO NOT TRIGGER until AIR-1086 compliance review returns PASS.
+ *
+ * Usage (dry run — safe to call anytime):
+ *   curl -X POST https://airwaylab.app/api/admin/email/analysis-window \
+ *     -H "x-admin-secret: $ADMIN_API_KEY" \
+ *     -H "Content-Type: application/json" \
+ *     -d '{"dryRun": true}'
+ *
+ * Live send (requires compliance clearance):
+ *   curl -X POST https://airwaylab.app/api/admin/email/analysis-window \
+ *     -H "x-admin-secret: $ADMIN_API_KEY" \
+ *     -H "Content-Type: application/json" \
+ *     -d '{"dryRun": false}'
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import * as Sentry from '@sentry/nextjs'
+import { z } from 'zod'
+import { getSupabaseServiceRole } from '@/lib/supabase/server'
+import { sendEmail } from '@/lib/email/send'
+import { getUnsubscribeUrl } from '@/lib/email/unsubscribe-token'
+import { BROADCAST_TEMPLATES } from '@/lib/email/broadcast'
+
+const TEMPLATE_ID = 'analysis_window_announcement'
+const EMAIL_TYPE = `broadcast_${TEMPLATE_ID}`
+const HISTORY_CUTOFF_DAYS = 14
+const BATCH_SIZE = 10
+const BATCH_DELAY_MS = 1000
+
+const RequestSchema = z.object({
+  dryRun: z.boolean().default(true),
+})
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms))
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const secret = request.headers.get('x-admin-secret')
+  const adminSecret = process.env.ADMIN_API_KEY
+
+  if (!adminSecret || secret !== adminSecret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const rawBody = await request.json().catch(() => null)
+  const parsed = RequestSchema.safeParse(rawBody)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? 'Invalid request.' },
+      { status: 400 }
+    )
+  }
+
+  const { dryRun } = parsed.data
+
+  const supabase = getSupabaseServiceRole()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 503 })
+  }
+
+  const template = BROADCAST_TEMPLATES[TEMPLATE_ID]
+  if (!template) {
+    return NextResponse.json({ error: `Template not found: ${TEMPLATE_ID}` }, { status: 500 })
+  }
+
+  try {
+    // Step 1: users with at least one synced night older than the cutoff
+    const cutoffDate = new Date(Date.now() - HISTORY_CUTOFF_DAYS * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split('T')[0]
+
+    const { data: nightRows, error: nightsError } = await supabase
+      .from('user_nights')
+      .select('user_id')
+      .lt('night_date', cutoffDate)
+
+    if (nightsError) {
+      console.error('[analysis-window-email] Failed to query user_nights:', nightsError)
+      Sentry.captureException(nightsError, { tags: { route: 'analysis-window-email', action: 'query-nights' } })
+      return NextResponse.json({ error: 'Database query failed' }, { status: 500 })
+    }
+
+    const eligibleUserIds = [...new Set((nightRows ?? []).map(r => r.user_id))]
+
+    if (eligibleUserIds.length === 0) {
+      return NextResponse.json({
+        dryRun,
+        audience: 0,
+        already_sent: 0,
+        would_send: 0,
+        message: 'No users with synced nights older than 14 days.',
+      })
+    }
+
+    // Step 2: community-tier users who opted in, filtered to eligible set
+    const { data: users, error: profilesError } = await supabase
+      .from('profiles')
+      .select('id, email')
+      .eq('tier', 'community')
+      .eq('email_opt_in', true)
+      .not('email', 'is', null)
+      .in('id', eligibleUserIds)
+
+    if (profilesError) {
+      console.error('[analysis-window-email] Failed to query profiles:', profilesError)
+      Sentry.captureException(profilesError, { tags: { route: 'analysis-window-email', action: 'query-profiles' } })
+      return NextResponse.json({ error: 'Database query failed' }, { status: 500 })
+    }
+
+    const audience = users ?? []
+
+    if (audience.length === 0) {
+      return NextResponse.json({
+        dryRun,
+        audience: 0,
+        already_sent: 0,
+        would_send: 0,
+        message: 'No eligible community users with opt-in and qualifying history.',
+      })
+    }
+
+    // Step 3: idempotency — skip addresses that already received this broadcast
+    const { data: alreadySentRows } = await supabase
+      .from('email_log')
+      .select('to_email')
+      .eq('email_type', EMAIL_TYPE)
+
+    const alreadySentEmails = new Set((alreadySentRows ?? []).map(r => r.to_email))
+    const toSend = audience.filter(u => !alreadySentEmails.has(u.email))
+    const alreadySentCount = audience.length - toSend.length
+
+    if (dryRun) {
+      const sampleUnsubscribeUrl = `https://airwaylab.app/api/email/unsubscribe?token=SAMPLE`
+      const { subject, html: sampleHtml } = template.getTemplate(sampleUnsubscribeUrl, 'A')
+      return NextResponse.json({
+        dryRun: true,
+        template_id: TEMPLATE_ID,
+        audience: audience.length,
+        already_sent: alreadySentCount,
+        would_send: toSend.length,
+        subject,
+        sample_html: sampleHtml,
+      })
+    }
+
+    // Step 4: live send
+    let sent = 0
+    const errors: string[] = []
+
+    for (let i = 0; i < toSend.length; i += BATCH_SIZE) {
+      const batch = toSend.slice(i, i + BATCH_SIZE)
+
+      await Promise.all(
+        batch.map(async (user) => {
+          try {
+            const unsubscribeUrl = getUnsubscribeUrl(user.id)
+            const { subject, html } = template.getTemplate(unsubscribeUrl, 'A')
+
+            await sendEmail({
+              to: user.email,
+              subject,
+              html,
+              replyTo: 'dev@airwaylab.app',
+              unsubscribeUrl,
+              metadata: {
+                emailType: EMAIL_TYPE,
+                userId: user.id,
+              },
+            })
+            sent++
+          } catch (err) {
+            const msg = `Failed for ${user.email}: ${err}`
+            console.error(`[analysis-window-email] ${msg}`)
+            errors.push(msg)
+          }
+        })
+      )
+
+      if (i + BATCH_SIZE < toSend.length) {
+        await sleep(BATCH_DELAY_MS)
+      }
+    }
+
+    if (errors.length > 0) {
+      Sentry.captureMessage(`analysis_window_announcement: ${errors.length} send failures`, {
+        level: 'warning',
+        extra: { errors, sent, skipped: alreadySentCount },
+      })
+    }
+
+    console.error('[analysis-window-email] Send complete', {
+      sent,
+      skipped: alreadySentCount,
+      errors: errors.length,
+      audience: audience.length,
+    })
+
+    return NextResponse.json({
+      dryRun: false,
+      template_id: TEMPLATE_ID,
+      audience: audience.length,
+      sent,
+      skipped: alreadySentCount,
+      errors: errors.length,
+    })
+  } catch (err) {
+    console.error('[analysis-window-email] Unexpected error:', err)
+    Sentry.captureException(err, { tags: { route: 'analysis-window-email' } })
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+  }
+}

--- a/lib/email/broadcast.ts
+++ b/lib/email/broadcast.ts
@@ -98,14 +98,14 @@ function analysisWindowAnnouncement(unsubscribeUrl: string, _subjectVariant: Bro
   return {
     subject: 'Heads up: history visibility change coming May 27',
     html: broadcastLayout(`
-      ${paragraph('Starting <strong>May 27</strong>, AirwayLab free accounts will display your <strong>7 most recent nights</strong> in the analysis view. Nights outside that window aren\'t deleted — they stay in your account — but they won\'t be visible on the free tier after that date.')}
+      ${paragraph('Starting <strong>May 27</strong>, AirwayLab free accounts will display the <strong>last 14 days</strong> of analysis history. Nights outside that window aren\'t deleted — they stay in your account — but they won\'t be visible on the free tier after that date.')}
 
       ${subheading('Why?')}
       ${paragraph('AirwayLab has always intended to limit free history visibility to keep the project sustainable. That limit was never enforced. This is us finally shipping it.')}
 
       ${subheading('What this means for you')}
       <ul style="margin:0 0 16px 0;padding-left:20px;">
-        <li style="font-size:14px;color:#a1a1aa;line-height:1.7;margin-bottom:8px;"><strong style="color:#fff;">Stay on the free tier</strong> — you\'ll see your 7 most recent nights. Older nights sit in your account, ready if you ever upgrade.</li>
+        <li style="font-size:14px;color:#a1a1aa;line-height:1.7;margin-bottom:8px;"><strong style="color:#fff;">Stay on the free tier</strong> — you\'ll see the last 14 days of history. Older nights sit in your account, ready if you ever upgrade.</li>
         <li style="font-size:14px;color:#a1a1aa;line-height:1.7;margin-bottom:8px;"><strong style="color:#fff;">Upgrade to Supporter ($9/month)</strong> — see the last 90 days.</li>
         <li style="font-size:14px;color:#a1a1aa;line-height:1.7;margin-bottom:8px;"><strong style="color:#fff;">Upgrade to Premium or Champion</strong> — see your full history.</li>
       </ul>

--- a/lib/email/broadcast.ts
+++ b/lib/email/broadcast.ts
@@ -89,6 +89,42 @@ function march2026Update(unsubscribeUrl: string, subjectVariant: BroadcastSubjec
   }
 }
 
+// ── Analysis window announcement (May 2026) ──────────────────
+
+function analysisWindowAnnouncement(unsubscribeUrl: string, _subjectVariant: BroadcastSubjectVariant): { subject: string; html: string } {
+  const ANALYZE_URL = `${BASE_URL}/analyze?utm_source=email&utm_medium=broadcast&utm_campaign=history_window_may_2026`
+  const PRICING_URL = `${BASE_URL}/pricing?utm_source=email&utm_medium=broadcast&utm_campaign=history_window_may_2026`
+
+  return {
+    subject: 'Heads up: history visibility change coming May 27',
+    html: broadcastLayout(`
+      ${paragraph('Starting <strong>May 27</strong>, AirwayLab free accounts will display your <strong>7 most recent nights</strong> in the analysis view. Nights outside that window aren\'t deleted — they stay in your account — but they won\'t be visible on the free tier after that date.')}
+
+      ${subheading('Why?')}
+      ${paragraph('AirwayLab has always intended to limit free history visibility to keep the project sustainable. That limit was never enforced. This is us finally shipping it.')}
+
+      ${subheading('What this means for you')}
+      <ul style="margin:0 0 16px 0;padding-left:20px;">
+        <li style="font-size:14px;color:#a1a1aa;line-height:1.7;margin-bottom:8px;"><strong style="color:#fff;">Stay on the free tier</strong> — you\'ll see your 7 most recent nights. Older nights sit in your account, ready if you ever upgrade.</li>
+        <li style="font-size:14px;color:#a1a1aa;line-height:1.7;margin-bottom:8px;"><strong style="color:#fff;">Upgrade to Supporter ($9/month)</strong> — see the last 90 days.</li>
+        <li style="font-size:14px;color:#a1a1aa;line-height:1.7;margin-bottom:8px;"><strong style="color:#fff;">Upgrade to Premium or Champion</strong> — see your full history.</li>
+      </ul>
+
+      ${paragraph('There\'s no rush. Your data isn\'t going anywhere. If you upgrade later, everything will be there waiting.')}
+
+      ${ctaButton('Go to Analysis', ANALYZE_URL)}
+
+      ${paragraph('If you have questions, reply to this email.')}
+
+      ${paragraph('<span style="color:#a1a1aa;">— The AirwayLab team</span>')}
+
+      ${smallText('<a href="' + PRICING_URL + '" style="color:#5eead4;text-decoration:underline;">See pricing</a> for full history access.')}
+
+      ${smallText('AirwayLab is a data visualisation tool. It does not provide medical advice. Always discuss your therapy with your sleep physician.')}
+    `, unsubscribeUrl),
+  }
+}
+
 // ── Template registry ────────────────────────────────────────
 
 export interface BroadcastTemplate {
@@ -102,5 +138,10 @@ export const BROADCAST_TEMPLATES: Record<string, BroadcastTemplate> = {
     id: 'march_2026_update',
     description: 'March 2026 founder letter: IFL Risk, multi-device support, vision, Discord community',
     getTemplate: march2026Update,
+  },
+  analysis_window_announcement: {
+    id: 'analysis_window_announcement',
+    description: 'May 2026 history window cap: community tier 7-night limit shipping May 27',
+    getTemplate: analysisWindowAnnouncement,
   },
 }


### PR DESCRIPTION
## Summary

- Adds analysis_window_announcement email template to lib/email/broadcast.ts with MDR-compliant approved copy (subject: Heads up: history visibility change coming May 27, $9/month Supporter price, CTA to /analyze)
- New admin endpoint POST /api/admin/email/analysis-window: targeted audience query — community tier + email_opt_in=true + user_nights older than 14 days
- Idempotent via email_log; defaults to dryRun: true; batched sends (10/s, 1s delay)
- 15 tests covering auth, audience segmentation, idempotency, live send, template rendering

**Do not trigger until AIR-1086 compliance review returns PASS.**

## Test plan

- [ ] npx tsc --noEmit passes
- [ ] npm run lint passes
- [ ] npm test — 1994/1994 tests pass
- [ ] npm run build passes
- [ ] Dry-run curl returns audience count and sample subject
- [ ] Verify 401 without correct x-admin-secret
