### PR TITLE
fix(analyze): poll refreshProfile after checkout to surface premium tier

### DIFF
--- a/__tests__/analyze-checkout-activation.test.tsx
+++ b/__tests__/analyze-checkout-activation.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Tests for the post-purchase tier activation polling on /analyze?checkout=success
+ * Verifies that refreshProfile is polled after Stripe checkout redirect so that
+ * newly subscribed users see their updated tier without a manual page reload.
+ * AIR-1126 / AIR-1134
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..');
+const src = fs.readFileSync(path.join(ROOT, 'app/analyze/page.tsx'), 'utf-8');
+
+describe('checkout=success: refreshProfile polling', () => {
+  it('destructures refreshProfile from useAuth alongside user and tier', () => {
+    expect(src).toMatch(/const\s*\{[^}]*refreshProfile[^}]*\}\s*=\s*useAuth\(\)/);
+  });
+
+  it('uses a tierRef to avoid stale closure inside the polling interval', () => {
+    expect(src).toContain('tierRef.current = tier');
+    expect(src).toContain("tierRef.current !== 'community'");
+  });
+
+  it('calls refreshProfile inside a setInterval when checkout=success', () => {
+    expect(src).toContain('await refreshProfile()');
+    expect(src).toContain('setInterval');
+  });
+
+  it('caps polling at 15 attempts (30 seconds at 2s intervals)', () => {
+    expect(src).toContain('attempts >= 15');
+  });
+
+  it('guards the effect so polling only starts on checkout=success', () => {
+    expect(src).toContain("searchParams.get('checkout') !== 'success'");
+  });
+
+  it('returns a cleanup function that clears the interval on unmount', () => {
+    expect(src).toContain('return () => clearInterval(poll)');
+  });
+});
+
+describe('checkout=success: activated banner copy', () => {
+  it('tracks bannerActivated state and sets it true when tier upgrades', () => {
+    expect(src).toContain('bannerActivated');
+    expect(src).toContain('setBannerActivated(true)');
+  });
+
+  it('shows "Subscription activated!" copy once tier has upgraded', () => {
+    expect(src).toContain('Subscription activated!');
+  });
+
+  it('falls back to "is activating" copy while polling is in progress', () => {
+    expect(src).toContain('Your subscription is activating');
+  });
+});

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -131,9 +131,12 @@ function AnalyzePageInner() {
   const [engineUpgraded, setEngineUpgraded] = useState(false);
   const [activeTab, setActiveTab] = useState('overview');
   const tabScrollRef = useRef<HTMLDivElement>(null);
-  const { user, tier } = useAuth();
+  const { user, tier, refreshProfile } = useAuth();
   const userRef = useRef(user);
   useEffect(() => { userRef.current = user; }, [user]);
+  const tierRef = useRef(tier);
+  useEffect(() => { tierRef.current = tier; }, [tier]);
+  const [bannerActivated, setBannerActivated] = useState(false);
   const hasTriggeredAutoUpload = useRef(false);
   const thresholdModalRef = useRef<ThresholdSettingsModalHandle>(null);
 
@@ -191,15 +194,30 @@ function AnalyzePageInner() {
     if (searchParams.get('checkout') !== 'success') return;
 
     setShowPurchaseBanner(true);
+    setBannerActivated(false);
     events.subscriptionStarted('unknown', 'unknown', 'checkout_redirect');
+
+    let attempts = 0;
+    const poll = setInterval(async () => {
+      attempts++;
+      await refreshProfile();
+      if (tierRef.current !== 'community' || attempts >= 15) {
+        clearInterval(poll);
+        if (tierRef.current !== 'community') {
+          setBannerActivated(true);
+        }
+      }
+    }, 2000);
 
     const params = new URLSearchParams(searchParams.toString());
     params.delete('checkout');
-    const cleanUrl = params.toString()
+    window.history.replaceState({}, '', params.toString()
       ? `${window.location.pathname}?${params.toString()}`
-      : window.location.pathname;
-    window.history.replaceState({}, '', cleanUrl);
-  }, [searchParams]);
+      : window.location.pathname);
+
+    return () => clearInterval(poll);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]); // refreshProfile is stable (useCallback with no deps in auth context)
 
   // Load lifetime night count from localStorage
   useEffect(() => {
@@ -539,7 +557,9 @@ function AnalyzePageInner() {
         <div className="mb-4 flex items-start gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
           <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-400" />
           <span className="flex-1">
-            Your subscription is activating. AI insights will appear automatically — discuss any questions about your data with your clinician.
+            {bannerActivated
+              ? 'Subscription activated! Your premium access is now live — discuss any questions about your data with your clinician.'
+              : 'Your subscription is activating. AI insights will appear automatically — discuss any questions about your data with your clinician.'}
           </span>
           <button
             onClick={() => setShowPurchaseBanner(false)}

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -217,7 +217,7 @@ function AnalyzePageInner() {
 
     return () => clearInterval(poll);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]); // refreshProfile is stable (useCallback with no deps in auth context)
+  }, [searchParams]); // refreshProfile omitted: stable post-login (user doesn't change mid-flow)
 
   // Load lifetime night count from localStorage
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes AIR-1126: stale auth context after Stripe redirect prevented newly subscribed users from seeing premium features.

- Poll `refreshProfile()` every 2s (up to 15 attempts / 30s) after `?checkout=success`
- Uses `tierRef` to avoid stale closure inside the interval callback
- Banner copy updates to "Subscription activated!" once tier reflects the webhook write

## Changes

- `app/analyze/page.tsx` — destructure `refreshProfile` from `useAuth()`, add `tierRef` + polling effect, update banner copy
- `__tests__/analyze-checkout-activation.test.tsx` — source-read tests verifying polling contract

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 1990/1990 passed
- [ ] Vercel preview: subscribe in test mode, verify `?checkout=success` shows activating → activated without reload
- [ ] Banner dismiss (X) still works
- [ ] Non-checkout page loads show no banner

Parent: AIR-1126 | Task: AIR-1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)