### PR TITLE
Add artifact naming guidance to agent rules

### DIFF
--- a/.claude/rules/mdr-compliance.md
+++ b/.claude/rules/mdr-compliance.md
@@ -26,12 +26,23 @@ These rules apply to ALL code changes in user-facing features. Airwaylab is posi
 
 5. **AI system prompts MUST NOT instruct the model to suggest actions, adjustments, or investigations.** The AI describes what the data shows. Period.
 
+6. **NEVER expose compliance verdicts or regulatory framework names in public artifact names.** Branch names, PR titles, and commit message subjects are publicly indexed and discoverable. Names containing regulatory or audit language create self-incriminating evidence and reveal internal compliance posture. This rule applies to indexed public artifacts only; internal files, Paperclip tickets, PR description bodies, and audit documents are out of scope and may reference frameworks freely.
+   - **Forbidden substrings in branch name / PR title / commit subject:** `MDR`, `GDPR`, `SaMD`, `medical device`, `diagnostic`, `effectiveness claim`, `violation`, `compliance`, `positioning audit`, `competitive`
+   - BAD branch: `fix/mdr-gdpr-violation`, `audit/samd-compliance-fixes`, `fix/air-123-mdr-effectiveness-violations`
+   - GOOD branch: `fix/air-123-remove-effectiveness-language`
+   - BAD PR title: `Fix MDR MUST violations in insights copy`
+   - GOOD PR title: `Remove effectiveness judgment from insights copy`
+   - BAD commit subject: `fix(mdr): remove SaMD diagnostic claim from email template`
+   - GOOD commit subject: `fix: update email template copy to directional language`
+   - **Neutral-alternative guide:** `fix(mdr):` → `fix:` · `effectiveness-claim` → `pressure-description` · `mdr-violation` → `copy-update` · `compliance-fix` → `language-update`
+   - **Rationale:** out-of-scope carve-out for internal files is intentional — we are open about compliance internally and want rules enforced rigorously there. Only the externally-indexed namespace (branch, commit subject, PR title) must remain neutral to avoid creating discoverable regulatory admissions.
+
 ## SHOULD Rules (best practice)
 
-6. Every component showing clinical metrics SHOULD have a point-of-use disclaimer.
-7. Email templates SHOULD include a medical disclaimer.
-8. Traffic light labels SHOULD use directional language ("lower"/"typical"/"higher") rather than clinical judgment language in user-facing display.
-9. Community benchmarks SHOULD note that comparisons are informational, not clinical reference ranges.
+7. Every component showing clinical metrics SHOULD have a point-of-use disclaimer.
+8. Email templates SHOULD include a medical disclaimer.
+9. Traffic light labels SHOULD use directional language ("lower"/"typical"/"higher") rather than clinical judgment language in user-facing display.
+10. Community benchmarks SHOULD note that comparisons are informational, not clinical reference ranges.
 
 ## PR Checklist
 
@@ -44,6 +55,7 @@ Before merging any PR that touches insights, AI prompts, thresholds, community f
 - [ ] AI system prompts describe data only, never suggest actions
 - [ ] Point-of-use disclaimers present on clinical feature components
 - [ ] Email content has medical disclaimer
+- [ ] Branch name, PR title, and commit subjects contain no regulatory/compliance terminology (MDR, GDPR, SaMD, "violation", "compliance")
 
 ## Background
 


### PR DESCRIPTION
## Summary

Codeifies the artifact naming rule from AGENTS.md into `.claude/rules/mdr-compliance.md` as a formal MUST rule. Closes [AIR-772](/AIR/issues/AIR-772).

**What changed:**
- Added MUST Rule 6: public artifact names (branch, PR title, commit subject) must not contain regulatory/audit terminology
- Renumbered SHOULD rules 6–9 → 7–10
- Added PR checklist item for artifact naming review

**Rule details:**
Branch names, PR titles, and commit subjects are publicly indexed. Names referencing MDR, GDPR, SaMD, "violation", etc. create discoverable regulatory admissions. Internal files, Paperclip tickets, and PR bodies are explicitly out of scope.

**Neutral-alternative guide:**
- `fix(mdr):` → `fix:`
- `effectiveness-claim` → `pressure-description`
- `mdr-violation` → `copy-update`

## Test plan
- [x] All 1990 unit tests pass
- [x] Branch/PR title/commit subject contain no forbidden terms
- [x] Change confined to `.claude/rules/mdr-compliance.md`