### PR TITLE
fix(contribute): add client-side payload size guard to prevent HTTP 413

### DIFF
--- a/lib/contribute.ts
+++ b/lib/contribute.ts
@@ -4,6 +4,7 @@
 // No night count cap — large datasets are chunked automatically.
 // ============================================================
 
+import * as Sentry from '@sentry/nextjs';
 import type { NightResult, NightNotes } from './types';
 import { loadNightNotes } from './night-notes';
 
@@ -35,6 +36,9 @@ function stripBulkForContribution(nights: NightResult[]): NightResult[] {
 const CHUNK_SIZE = 1000;
 const RATE_LIMIT_MAX_RETRIES = 3;
 const RATE_LIMIT_BASE_DELAY_MS = 5000;
+// Stay well below both Vercel's 4.5 MB proxy limit and the server's 3 MB check.
+// JSON is mostly ASCII for this data, so body.length ≈ byte count.
+const MAX_SAFE_PAYLOAD_BYTES = 2_097_152; // 2 MB
 
 /** Structured night context for contribution (no free text — only enums + numeric) */
 interface NightContext {
@@ -87,6 +91,90 @@ interface ContributionResult {
 }
 
 /**
+ * Send a slice of stripped nights to the server, splitting recursively if the
+ * serialised payload would exceed Vercel's proxy limit before reaching Next.js.
+ * Throws a plain error message (no batch label — caller adds context).
+ */
+async function sendNightsToServer(
+  nights: NightResult[],
+  contextChunk: (NightContext | null)[],
+  contributionId: string,
+): Promise<void> {
+  const hasAnyContext = contextChunk.some((c) => c !== null);
+  const body = JSON.stringify({
+    nights,
+    contributionId,
+    ...(hasAnyContext && { nightContexts: contextChunk }),
+  });
+  const payloadBytes = body.length; // JSON data is ASCII — length ≈ UTF-8 byte count
+
+  // Split if the serialised payload would exceed the safe threshold. We split
+  // before the request rather than retrying after 413 to avoid wasting bandwidth
+  // on payloads that the Vercel proxy rejects before Next.js can handle them.
+  if (payloadBytes > MAX_SAFE_PAYLOAD_BYTES && nights.length > 1) {
+    Sentry.addBreadcrumb({
+      category: 'payload',
+      message: `contribute: splitting oversized payload (${payloadBytes} bytes, ${nights.length} nights)`,
+      level: 'warning',
+      data: { payloadBytes, nightCount: nights.length, limitBytes: MAX_SAFE_PAYLOAD_BYTES },
+    });
+    const mid = Math.ceil(nights.length / 2);
+    await sendNightsToServer(nights.slice(0, mid), contextChunk.slice(0, mid), contributionId);
+    await sendNightsToServer(nights.slice(mid), contextChunk.slice(mid), contributionId);
+    return;
+  }
+
+  Sentry.addBreadcrumb({
+    category: 'payload',
+    message: `contribute: sending ${payloadBytes} bytes (${nights.length} nights)`,
+    level: 'info',
+    data: { payloadBytes, nightCount: nights.length },
+  });
+
+  for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+    const res = await fetch('/api/contribute-data', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+
+    if (res.ok) return;
+
+    // Retry with exponential backoff on rate limit
+    if (res.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
+      const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
+      await new Promise(r => setTimeout(r, delay));
+      continue;
+    }
+
+    const text = await res.text().catch(() => '');
+    let errorDetail: string;
+    try {
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      errorDetail = typeof parsed.error === 'string' ? parsed.error : String(res.status);
+    } catch {
+      // Vercel/proxy returned a non-JSON 413 (payload exceeded proxy limit before
+      // reaching Next.js). Record payload size so Sentry captures full context.
+      console.error('[contribute] non-JSON server response', {
+        status: res.status,
+        contentType: res.headers.get('content-type'),
+        snippet: text.slice(0, 300),
+      });
+      Sentry.addBreadcrumb({
+        category: 'payload',
+        message: `contribute non-JSON ${res.status}: payload was ${payloadBytes} bytes (${nights.length} nights)`,
+        level: 'error',
+        data: { status: res.status, payloadBytes, nightCount: nights.length },
+      });
+      errorDetail = `HTTP ${res.status} (non-JSON)`;
+    }
+    throw new Error(errorDetail);
+  }
+
+  throw new Error('Rate limited after retries');
+}
+
+/**
  * Contribute anonymised night data to the community dataset.
  * Automatically chunks large datasets into multiple requests
  * sharing a single contributionId for grouping.
@@ -111,55 +199,13 @@ export async function contributeNights(
   for (let i = 0; i < strippedNights.length; i += CHUNK_SIZE) {
     const chunk = strippedNights.slice(i, i + CHUNK_SIZE);
     const contextChunk = allNightContexts.slice(i, i + CHUNK_SIZE);
-    // Only include nightContexts if at least one has data
-    const hasAnyContext = contextChunk.some((c) => c !== null);
     const batchNum = Math.floor(i / CHUNK_SIZE) + 1;
-    let success = false;
 
-    for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
-      const res = await fetch('/api/contribute-data', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          nights: chunk,
-          contributionId,
-          ...(hasAnyContext && { nightContexts: contextChunk }),
-        }),
-      });
-
-      if (res.ok) {
-        success = true;
-        break;
-      }
-
-      // Retry with exponential backoff on rate limit
-      if (res.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
-        const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
-        await new Promise(r => setTimeout(r, delay));
-        continue;
-      }
-
-      const text = await res.text().catch(() => '');
-      let errorDetail: string;
-      try {
-        const body = JSON.parse(text) as Record<string, unknown>;
-        errorDetail = typeof body.error === 'string' ? body.error : String(res.status);
-      } catch {
-        // Server returned a non-JSON response (e.g. Next.js plain-text 500 from
-        // an unhandled exception outside the route try/catch). Log the snippet so
-        // Sentry captures the actual HTTP status and body for diagnosis.
-        console.error('[contribute] non-JSON server response', {
-          status: res.status,
-          contentType: res.headers.get('content-type'),
-          snippet: text.slice(0, 300),
-        });
-        errorDetail = `HTTP ${res.status} (non-JSON)`;
-      }
-      throw new Error(`Contribution failed (batch ${batchNum}): ${errorDetail}`);
-    }
-
-    if (!success) {
-      throw new Error(`Contribution failed (batch ${batchNum}): Rate limited after retries`);
+    try {
+      await sendNightsToServer(chunk, contextChunk, contributionId);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Contribution failed (batch ${batchNum}): ${detail}`);
     }
 
     totalSent += chunk.length;


### PR DESCRIPTION
## Summary

- 7 users hitting HTTP 413 on data contribution (JAVASCRIPT-NEXTJS-5Y, AIR-1160)
- Root cause: 1000-night batches serialise to 4–5 MB, exceeding Vercel's 4.5 MB proxy limit before Next.js runs — the proxy returns non-JSON 413 before the server's own 3 MB check fires
- Fix: pre-flight byte measurement before each fetch; if JSON body > 2 MB, recursively bisect the chunk until sub-batches fit
- Sentry breadcrumbs at every send point and on non-JSON failures

## Changes

- `lib/contribute.ts`: extract `sendNightsToServer()` with size guard + recursive bisect; Sentry breadcrumbs added

## Pre-merge checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] Bundle size impact checked — no new dependencies
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked
- [x] Self-review: no regressions
- [x] PR contains one concern only