### PR TITLE
fix(idb): guard breath-data write against structured-clone OOM

### DIFF
--- a/__tests__/breath-data-idb.test.ts
+++ b/__tests__/breath-data-idb.test.ts
@@ -140,11 +140,26 @@ describe('breath-data-idb error handling', () => {
     }
   });
 
-  it('does not send IndexedDB errors to Sentry (graceful degradation)', async () => {
+  it('adds Sentry breadcrumb before IDB write for observability', async () => {
     const { readFileSync } = await import('fs');
     const { resolve } = await import('path');
     const source = readFileSync(resolve(__dirname, '../lib/breath-data-idb.ts'), 'utf-8');
-    expect(source).not.toContain("import * as Sentry from '@sentry/nextjs'");
+    expect(source).toContain("import * as Sentry from '@sentry/nextjs'");
+    expect(source).toContain('Sentry.addBreadcrumb');
+    expect(source).toContain('estimatedBytes');
+  });
+});
+
+// -- Test 8b: Size guard for OOM prevention ---------------------------
+
+describe('breath-data-idb size guard', () => {
+  it('Test 8b: source has MAX_IDB_BYTES guard before put()', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve } = await import('path');
+    const source = readFileSync(resolve(__dirname, '../lib/breath-data-idb.ts'), 'utf-8');
+    expect(source).toContain('MAX_IDB_BYTES');
+    expect(source).toContain('estimatedBytes > MAX_IDB_BYTES');
+    expect(source).toContain('BYTES_PER_COMPACT_BREATH');
   });
 });
 

--- a/lib/breath-data-idb.ts
+++ b/lib/breath-data-idb.ts
@@ -5,12 +5,18 @@
 // version invalidation, non-fatal on failure.
 // ============================================================
 
+import * as Sentry from '@sentry/nextjs';
 import type { Breath } from './types';
 import { openDB } from './waveform-idb';
 import { ENGINE_VERSION } from './engine-version';
 
 const STORE_NAME = 'breath-data';
 const TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+// Structured-clone OOM guard: ~256 bytes per compact breath (JSON ~120 chars × 2).
+// IDB quota is disk-based, but the clone algorithm itself can OOM under memory pressure
+// with very large objects — see Sentry JAVASCRIPT-NEXTJS-64.
+const MAX_IDB_BYTES = 20 * 1024 * 1024; // 20 MB
+const BYTES_PER_COMPACT_BREATH = 256;
 
 /**
  * Compact per-breath representation for IndexedDB.
@@ -66,10 +72,26 @@ export async function storeBreathData(
   samplingRate: number
 ): Promise<void> {
   try {
+    const compact = toCompactBreaths(breaths, samplingRate);
+    const estimatedBytes = compact.length * BYTES_PER_COMPACT_BREATH;
+
+    Sentry.addBreadcrumb({
+      message: 'breath-data-idb: storing breath data',
+      category: 'idb',
+      data: { dateStr, breathCount: compact.length, estimatedBytes },
+    });
+
+    if (estimatedBytes > MAX_IDB_BYTES) {
+      console.warn(
+        `[breath-data-idb] breath data too large for IDB (est. ${estimatedBytes} bytes / ${compact.length} breaths) — skipping write to avoid structured-clone OOM`
+      );
+      return;
+    }
+
     const db = await openDB();
     const stored: StoredBreathData = {
       dateStr,
-      breaths: toCompactBreaths(breaths, samplingRate),
+      breaths: compact,
       breathCount: breaths.length,
       samplingRate,
       storedAt: Date.now(),


### PR DESCRIPTION
## Summary
- Adds a size pre-check before `storeBreathData()` calls `put()` on the breath-data IDB store
- Estimates payload size at 256 bytes/breath; skips the write if it would exceed 20 MB, preventing `DataCloneError` OOM seen in Sentry JAVASCRIPT-NEXTJS-64
- Adds a Sentry breadcrumb on every write for field observability of typical payload sizes

## Pre-Merge Checklist
- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] E2e tests pass locally (for UI changes)
- [ ] Bundle size impact checked (flag if >10KB increase)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [ ] Self-review: no regressions, loading/error/empty states handled
- [ ] PR contains one concern only

Closes AIR-1170. Cherry-picked from AIR-1139 PR #692 commit 5f37665.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
