### PR TITLE
chore: restore feedback-processor cron entry to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,10 @@
     {
       "path": "/api/cron/subscription-drift",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/feedback-processor",
+      "schedule": "0 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Re-adds `/api/cron/feedback-processor` (`0 7 * * *` = 07:00 UTC daily) to `vercel.json`. Removed during the AIR-861 emergency consent pause. Consent filter confirmed live (PR #644, 2026-05-06), CEO approved re-enabling.

**Scope:** 1 file, 4 lines added — config only, no logic changes.

## Checklist

- [x] 1981 tests passed on push
- [x] Single concern
- [x] After merge: verify entry in Vercel Settings → Cron Jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)