### PR TITLE
fix: use DemoCTA for fresh users to restore E2E test coverage

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -71,7 +71,6 @@ import {
   HardDrive,
   Settings2,
   RefreshCw,
-  Play,
 } from 'lucide-react';
 
 export default function AnalyzePage() {
@@ -633,26 +632,7 @@ function AnalyzePageInner() {
               </Link>
             </p>
 
-            {/* Demo CTA — shown immediately after upload for discoverability */}
-            <div className="mt-6 flex flex-col items-center gap-2">
-              <div className="flex items-center gap-3 text-[11px] text-muted-foreground/50">
-                <div className="h-px flex-1 bg-border/50" />
-                <span>or</span>
-                <div className="h-px flex-1 bg-border/50" />
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={loadDemo}
-                className="gap-2 text-muted-foreground hover:text-foreground"
-              >
-                <Play className="h-3.5 w-3.5" />
-                See sample data
-              </Button>
-              <p className="text-[11px] text-muted-foreground/50">
-                See what AirwayLab looks like with 7 nights of example data
-              </p>
-            </div>
+            <DemoCTA onLoadDemo={loadDemo} />
           </div>
         ) : (
           <div className="mx-auto max-w-lg">


### PR DESCRIPTION
## Summary

Fixes E2E test failures that have been failing since 2026-04-20 (18 days). PR #538 extracted the demo CTA into a `DemoCTA` component but left fresh users (no localStorage results) with an inline 'See sample data' button. E2E tests check for 'Try sample data' (the DemoCTA label), so every test running with a clean browser context timed out.

**Root cause:** Fresh-user branch had an inline button with different text than the shared `DemoCTA` component used for returning users.

**Fix:** Replace the 20-line inline button in the fresh-user upload branch with `<DemoCTA onLoadDemo={loadDemo} />` — identical to the returning-user branch.

**Affected specs fixed:**
- `free-user-flow.spec.ts`
- `demo-flow.spec.ts`
- `returning-user.spec.ts` (4 tests)
- `session-persistence.spec.ts`

## Checklist

- [x] Full pipeline passes (1981 unit tests pass)
- [x] Single concern
- [x] 1 file changed, 1 insertion, 21 deletions
- [ ] E2E suite verified green after merge (requires CI run)

Resolves: AIR-940

🤖 Generated with [Claude Code](https://claude.com/claude-code)