### PR TITLE
fix(discord): surface role-assignment HTTP status and stop silently marking users as resolved when syncRole fails

### DIFF
--- a/app/api/cron/discord-sync/route.ts
+++ b/app/api/cron/discord-sync/route.ts
@@ -144,16 +144,35 @@ export async function GET(request: NextRequest) {
         }).eq('id', profile.id);
 
         // Assign role
-        await syncRole(result.discordId, profile.tier);
+        const syncResult = await syncRole(result.discordId, profile.tier);
 
-        // Audit log
+        // Audit log — record outcome including failure details for diagnostics
         await supabase.from('discord_role_events').insert({
           user_id: profile.id,
           discord_id: result.discordId,
           role_id: profile.tier,
-          action: 'assign',
+          action: syncResult.ok ? 'assign' : 'assign_failed',
           reason: 'cron_auto_resolve',
+          http_status: syncResult.httpStatus ?? null,
+          error_message: syncResult.errorBody?.slice(0, 500) ?? null,
         });
+
+        if (!syncResult.ok) {
+          errors++;
+          console.error(
+            `[discord-sync] Role assign failed for ${profile.discord_username} ` +
+            `(HTTP ${syncResult.httpStatus}): ${syncResult.errorBody}`
+          );
+          // Revert the discord_id write — user is linked in DB but has no role,
+          // which is worse than being unlinked (cron would otherwise stop retrying).
+          await supabase.from('profiles').update({
+            discord_id: null,
+            discord_linked_at: null,
+            discord_sync_error_count: (profile.discord_sync_error_count ?? 0) + 1,
+            discord_sync_last_error: new Date().toISOString(),
+          }).eq('id', profile.id);
+          continue;
+        }
 
         // Clean up pending roles
         await supabase.from('discord_pending_roles').delete().eq('user_id', profile.id);

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -72,16 +72,18 @@ async function syncDiscordForUser(
       .maybeSingle();
 
     if (profile?.discord_id) {
-      await syncRole(profile.discord_id, tier);
+      const syncResult = await syncRole(profile.discord_id, tier);
+      const baseAction = tier === 'community' ? 'revoke' : 'assign';
 
-      // Log the role event
       await supabase.from('discord_role_events').insert({
         user_id: userId,
         discord_id: profile.discord_id,
         role_id: tier,
-        action: tier === 'community' ? 'revoke' : 'assign',
+        action: syncResult.ok ? baseAction : `${baseAction}_failed`,
         reason: `stripe_tier_change_to_${tier}`,
         stripe_event_id: stripeEventId ?? null,
+        http_status: syncResult.httpStatus ?? null,
+        error_message: syncResult.errorBody?.slice(0, 500) ?? null,
       });
     } else {
       // User hasn't linked Discord yet — try to auto-resolve if they saved a username
@@ -101,15 +103,18 @@ async function syncDiscordForUser(
             discord_linked_at: new Date().toISOString(),
           }).eq('id', userId);
 
-          await syncRole(searchResult.discordId, tier);
+          const syncResult = await syncRole(searchResult.discordId, tier);
+          const baseAction = tier === 'community' ? 'revoke' : 'assign';
 
           await supabase.from('discord_role_events').insert({
             user_id: userId,
             discord_id: searchResult.discordId,
             role_id: tier,
-            action: tier === 'community' ? 'revoke' : 'assign',
+            action: syncResult.ok ? baseAction : `${baseAction}_failed`,
             reason: `stripe_auto_resolve_${tier}`,
             stripe_event_id: stripeEventId ?? null,
+            http_status: syncResult.httpStatus ?? null,
+            error_message: syncResult.errorBody?.slice(0, 500) ?? null,
           });
 
           // Clean up any pending roles

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -57,24 +57,36 @@ function getAllPaidRoleIds(): string[] {
   return [c.supporterRoleId, c.championRoleId].filter(Boolean);
 }
 
+export type RoleOpResult = { ok: boolean; httpStatus: number; errorBody?: string };
+
 /** Add a role to a guild member. */
-export async function addMemberRole(discordId: string, roleId: string): Promise<boolean> {
+export async function addMemberRole(discordId: string, roleId: string): Promise<RoleOpResult> {
   const { guildId } = getConfig();
   const res = await discordFetch(
     `/guilds/${guildId}/members/${discordId}/roles/${roleId}`,
     'PUT'
   );
-  return res.ok || res.status === 204;
+  const ok = res.ok || res.status === 204;
+  if (!ok) {
+    const errorBody = await res.text().catch(() => '');
+    return { ok: false, httpStatus: res.status, errorBody };
+  }
+  return { ok: true, httpStatus: res.status };
 }
 
 /** Remove a role from a guild member. */
-export async function removeMemberRole(discordId: string, roleId: string): Promise<boolean> {
+export async function removeMemberRole(discordId: string, roleId: string): Promise<RoleOpResult> {
   const { guildId } = getConfig();
   const res = await discordFetch(
     `/guilds/${guildId}/members/${discordId}/roles/${roleId}`,
     'DELETE'
   );
-  return res.ok || res.status === 204;
+  const ok = res.ok || res.status === 204;
+  if (!ok) {
+    const errorBody = await res.text().catch(() => '');
+    return { ok: false, httpStatus: res.status, errorBody };
+  }
+  return { ok: true, httpStatus: res.status };
 }
 
 /**
@@ -112,42 +124,57 @@ export async function addMemberToGuild(
   return false;
 }
 
+export type SyncRoleResult = { ok: boolean; httpStatus?: number; errorBody?: string };
+
 /**
  * Sync a user's Discord roles to match their subscription tier.
  * Removes all paid roles first, then adds the correct one.
  */
-export async function syncRole(discordId: string, tier: string): Promise<boolean> {
-  if (!isDiscordConfigured()) return false;
+export async function syncRole(discordId: string, tier: string): Promise<SyncRoleResult> {
+  if (!isDiscordConfigured()) return { ok: false };
 
   try {
     const allPaidRoles = getAllPaidRoleIds();
     const targetRoleId = getTierRoleId(tier);
 
-    // Remove all paid roles
+    // Remove all paid roles — log failures but don't abort (best-effort cleanup)
     for (const roleId of allPaidRoles) {
-      await removeMemberRole(discordId, roleId);
+      const result = await removeMemberRole(discordId, roleId);
+      if (!result.ok && result.httpStatus !== 404) {
+        console.error(`[discord] removeMemberRole failed (${result.httpStatus}): ${result.errorBody}`);
+      }
     }
 
     // Add the correct role (if any -- community tier gets no role)
     if (targetRoleId) {
-      return await addMemberRole(discordId, targetRoleId);
+      const result = await addMemberRole(discordId, targetRoleId);
+      if (!result.ok) {
+        console.error(`[discord] addMemberRole failed (${result.httpStatus}): ${result.errorBody}`);
+        Sentry.captureMessage(`Discord role assignment failed: HTTP ${result.httpStatus}`, {
+          level: 'error',
+          tags: { action: 'discord-sync-role', httpStatus: String(result.httpStatus) },
+          extra: { discordId, tier, errorBody: result.errorBody?.slice(0, 500) },
+        });
+        return { ok: false, httpStatus: result.httpStatus, errorBody: result.errorBody };
+      }
+      return { ok: true, httpStatus: result.httpStatus };
     }
 
-    return true;
+    return { ok: true };
   } catch (err) {
     console.error('[discord] syncRole failed:', err);
     Sentry.captureException(err, {
       tags: { action: 'discord-sync-role' },
       extra: { discordId, tier },
     });
-    return false;
+    return { ok: false };
   }
 }
 
 /**
  * Remove all paid roles from a user (on subscription cancellation).
  */
-export async function revokeAllPaidRoles(discordId: string): Promise<boolean> {
+export async function revokeAllPaidRoles(discordId: string): Promise<SyncRoleResult> {
   return syncRole(discordId, 'community');
 }
 

--- a/supabase/migrations/041_discord_role_events_observability.sql
+++ b/supabase/migrations/041_discord_role_events_observability.sql
@@ -1,0 +1,17 @@
+-- Add observability columns to discord_role_events so failed role
+-- assignments are distinguishable from successful ones.
+--
+-- http_status: Discord API HTTP status code (200/204 = success, 403 = hierarchy, 401 = token, etc.)
+-- error_message: raw error body from Discord API for diagnosis
+-- Expand action CHECK to allow 'assign_failed' and 'revoke_failed'
+
+ALTER TABLE discord_role_events
+  ADD COLUMN IF NOT EXISTS http_status INTEGER,
+  ADD COLUMN IF NOT EXISTS error_message TEXT;
+
+ALTER TABLE discord_role_events
+  DROP CONSTRAINT IF EXISTS discord_role_events_action_check;
+
+ALTER TABLE discord_role_events
+  ADD CONSTRAINT discord_role_events_action_check
+    CHECK (action IN ('assign', 'revoke', 'assign_failed', 'revoke_failed'));


### PR DESCRIPTION
## Summary

- `addMemberRole`/`removeMemberRole` now return `{ ok, httpStatus, errorBody }` instead of `boolean` — HTTP status surfaces to all callers
- `syncRole` returns `SyncRoleResult` and fires Sentry with `httpStatus` tag on failure
- **Cron**: reverts `discord_id` write when role assign fails so user stays in retry queue; logs `assign_failed` with HTTP status to `discord_role_events`
- **Stripe webhook**: same — logs `assign_failed`/`revoke_failed` with HTTP status
- **Migration 041**: adds `http_status INTEGER` + `error_message TEXT` to `discord_role_events`; expands action CHECK to include `assign_failed`/`revoke_failed`

Fixes the silent-failure bug in AIR-1139 where a Discord 403 (role hierarchy) caused the cron to mark users as resolved while no role was actually assigned.

## Test plan

- [ ] TypeScript typecheck passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] Build passes (`npm run build`)
- [ ] Vercel preview deploy verified by Demian
- [ ] Post-deploy: run `SELECT * FROM discord_role_events WHERE action = 'assign_failed'` and confirm empty (or that failures are now visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)