### PR TITLE
fix: handle 429 rate limit on contribution endpoint gracefully

### DIFF
--- a/__tests__/contribute.test.ts
+++ b/__tests__/contribute.test.ts
@@ -253,6 +253,41 @@ describe('contributeNights', () => {
     expect(caughtErr instanceof Error && caughtErr.message).not.toMatch('Contribution failed');
     vi.useRealTimers();
   });
+
+  it('skips retries immediately when Retry-After header exceeds 60s', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: () => Promise.resolve('{"error":"Too many contributions. Please try again later."}'),
+      headers: { get: (name: string) => name === 'Retry-After' ? '3600' : null },
+    });
+
+    const nights = makeNights(1);
+    await expect(contributeNights(nights)).rejects.toBeInstanceOf(ContributionRateLimitedError);
+    // Long Retry-After must bypass the retry loop — exactly 1 fetch call, not 4
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses Retry-After delay when ≤60s instead of exponential backoff', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: () => Promise.resolve('{}'),
+        headers: { get: (name: string) => name === 'Retry-After' ? '5' : null },
+      })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+    const nights = makeNights(1);
+    const promise = contributeNights(nights);
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
 });
 
 describe('trackContributedDates', () => {

--- a/__tests__/contribute.test.ts
+++ b/__tests__/contribute.test.ts
@@ -20,7 +20,7 @@ Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, wri
 // ── Mock crypto.randomUUID ──────────────────────────────────
 vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid-1234' });
 
-import { contributeNights, trackContributedDates } from '@/lib/contribute';
+import { contributeNights, trackContributedDates, ContributionRateLimitedError } from '@/lib/contribute';
 
 // ── Helpers ─────────────────────────────────────────────────
 function makeNight(dateStr: string): NightResult {
@@ -186,6 +186,72 @@ describe('contributeNights', () => {
     await expect(contributeNights(nights)).rejects.toThrow(
       'Contribution failed (batch 1): HTTP 503 (non-JSON)'
     );
+  });
+
+  it('throws ContributionRateLimitedError when all 429 retries exhausted', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: () => Promise.resolve('{"error":"Too many contributions. Please try again later."}'),
+      headers: { get: () => 'application/json' },
+    });
+
+    const nights = makeNights(1);
+    const promise = contributeNights(nights);
+    // Suppress unhandled-rejection while fake timers advance; assertion below handles it
+    promise.catch(() => { /* test-only: handled by expect().rejects below */ });
+    await vi.runAllTimersAsync();
+
+    await expect(promise).rejects.toBeInstanceOf(ContributionRateLimitedError);
+    // 1 initial + 3 retries = 4 total fetch calls
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    vi.useRealTimers();
+  });
+
+  it('succeeds after initial 429s are retried and server recovers', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 429, text: () => Promise.resolve('{}'), headers: { get: () => 'application/json' } })
+      .mockResolvedValueOnce({ ok: false, status: 429, text: () => Promise.resolve('{}'), headers: { get: () => 'application/json' } })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+
+    const nights = makeNights(1);
+    const promise = contributeNights(nights);
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.ok).toBe(true);
+    expect(result.totalSent).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+
+  it('ContributionRateLimitedError propagates unwrapped through contributeNights', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: () => Promise.resolve('{"error":"Too many contributions."}'),
+      headers: { get: () => 'application/json' },
+    });
+
+    const nights = makeNights(1);
+    const promise = contributeNights(nights);
+    // Suppress unhandled-rejection while fake timers advance; error is caught below
+    promise.catch(() => { /* test-only: error checked in try/catch block below */ });
+    await vi.runAllTimersAsync();
+
+    // Error must be ContributionRateLimitedError, NOT wrapped in "Contribution failed (batch N):"
+    let caughtErr: unknown;
+    try {
+      await promise;
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr).toBeInstanceOf(ContributionRateLimitedError);
+    expect(caughtErr instanceof Error && caughtErr.message).not.toMatch('Contribution failed');
+    vi.useRealTimers();
   });
 });
 

--- a/__tests__/upload-hash-cache.test.ts
+++ b/__tests__/upload-hash-cache.test.ts
@@ -54,7 +54,7 @@ describe('HashCache', () => {
     expect(result).toBeUndefined();
   });
 
-  it('prunes oldest entries when exceeding size cap', () => {
+  it('prunes oldest entries when exceeding size cap', { timeout: 15000 }, () => {
     // Fill cache with entries that exceed the 500KB cap
     // Each entry key ~50 chars + hash 64 chars + overhead ~30 chars = ~150 bytes
     // 500KB / 150 bytes = ~3400 entries. Write 4000 to trigger pruning.

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -43,7 +43,7 @@ import { SAMPLE_NIGHTS, SAMPLE_THERAPY_CHANGE_DATE } from '@/lib/sample-data';
 import type { AnalysisState, NightResult } from '@/lib/types';
 import { loadPersistedResults } from '@/lib/persistence';
 import { events } from '@/lib/analytics';
-import { contributeNights, trackContributedDates } from '@/lib/contribute';
+import { contributeNights, trackContributedDates, ContributionRateLimitedError } from '@/lib/contribute';
 import { contributeWaveformsBackground } from '@/lib/contribute-waveforms';
 import { contributeOximetryTraceBackground } from '@/lib/contribute-oximetry-trace';
 import { safeGetItem } from '@/lib/safe-local-storage';
@@ -430,6 +430,15 @@ function AnalyzePageInner() {
         ).catch(() => { /* logged in contributeOximetryTraceBackground */ });
       })
       .catch((err) => {
+        if (err instanceof ContributionRateLimitedError) {
+          Sentry.addBreadcrumb({
+            category: 'contribution',
+            message: 'Auto-contribution rate limited — suppressed as soft failure',
+            level: 'info',
+          });
+          setAutoSubmitStatus('paused');
+          return;
+        }
         Sentry.captureException(err, { tags: { action: 'auto-contribution' } });
         setAutoSubmitStatus('error');
       });

--- a/app/api/contribute-data/route.ts
+++ b/app/api/contribute-data/route.ts
@@ -240,7 +240,10 @@ export async function POST(request: NextRequest) {
       console.error('[contribute-data] 429 rate limited', { ip });
       return NextResponse.json(
         { error: 'Too many contributions. Please try again later.' },
-        { status: 429 }
+        {
+          status: 429,
+          headers: { 'Retry-After': '3600' },
+        }
       );
     }
 

--- a/components/dashboard/data-contribution.tsx
+++ b/components/dashboard/data-contribution.tsx
@@ -5,13 +5,13 @@ import * as Sentry from '@sentry/nextjs';
 import { Users, Loader2, X, Shield, Heart, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { events } from '@/lib/analytics';
-import { contributeNights, trackContributedDates } from '@/lib/contribute';
+import { contributeNights, trackContributedDates, ContributionRateLimitedError } from '@/lib/contribute';
 import { getConsentState, setConsentState } from '@/components/upload/contribution-consent-utils';
 import type { NightResult } from '@/lib/types';
 
 const DISMISS_KEY = 'airwaylab_contribute_dismissed';
 
-export type AutoSubmitStatus = 'idle' | 'sending' | 'success' | 'error';
+export type AutoSubmitStatus = 'idle' | 'sending' | 'success' | 'error' | 'paused';
 
 interface Props {
   nights: NightResult[];
@@ -90,12 +90,12 @@ export function DataContribution({
       // Persist opt-in so the user isn't prompted again on future visits
       setConsentState(true);
     } catch (err) {
-      // Rate limit errors are expected behavior — only report unexpected failures to Sentry
-      const isRateLimit = err instanceof Error &&
-        (err.message.includes('Rate limited') || err.message.includes('Too many'));
-      if (!isRateLimit) {
-        Sentry.captureException(err, { tags: { action: 'contribute-data' } });
+      if (err instanceof ContributionRateLimitedError) {
+        // Soft transient failure — reset to idle silently, analysis is unaffected
+        setStatus('idle');
+        return;
       }
+      Sentry.captureException(err, { tags: { action: 'contribute-data' } });
       setStatus('error');
     }
   }, [nights]);
@@ -136,6 +136,20 @@ export function DataContribution({
 
   // ── Opted-in path: show auto-contribution status ──────────
   if (isOptedIn) {
+    // Auto-submit rate limited — soft informational message, not an error
+    if (autoSubmitStatus === 'paused') {
+      return (
+        <div aria-live="polite" className="rounded-lg border border-primary/10 bg-primary/[0.02] px-4 py-3 animate-fade-in-up">
+          <div className="flex items-center gap-2.5">
+            <Heart className="h-4 w-4 text-primary/40" />
+            <p className="text-sm text-muted-foreground">
+              Data contribution paused — your analysis results are unaffected.
+            </p>
+          </div>
+        </div>
+      );
+    }
+
     // Auto-submit in flight
     if (autoSubmitStatus === 'sending') {
       return (

--- a/lib/contribute.ts
+++ b/lib/contribute.ts
@@ -8,6 +8,13 @@ import * as Sentry from '@sentry/nextjs';
 import type { NightResult, NightNotes } from './types';
 import { loadNightNotes } from './night-notes';
 
+export class ContributionRateLimitedError extends Error {
+  constructor() {
+    super('Contribution rate limited — try again later');
+    this.name = 'ContributionRateLimitedError';
+  }
+}
+
 /**
  * Strip bulky per-breath/trace arrays from NightResult before contribution.
  * The server's anonymiseNight() only reads scalar summary fields, so bulk
@@ -140,11 +147,14 @@ async function sendNightsToServer(
 
     if (res.ok) return;
 
-    // Retry with exponential backoff on rate limit
-    if (res.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
-      const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
-      await new Promise(r => setTimeout(r, delay));
-      continue;
+    if (res.status === 429) {
+      if (attempt < RATE_LIMIT_MAX_RETRIES) {
+        const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
+        await new Promise(r => setTimeout(r, delay));
+        continue;
+      }
+      // All retries exhausted on rate limit — soft transient failure, not an error
+      throw new ContributionRateLimitedError();
     }
 
     const text = await res.text().catch(() => '');
@@ -171,7 +181,7 @@ async function sendNightsToServer(
     throw new Error(errorDetail);
   }
 
-  throw new Error('Rate limited after retries');
+  throw new ContributionRateLimitedError();
 }
 
 /**
@@ -204,6 +214,8 @@ export async function contributeNights(
     try {
       await sendNightsToServer(chunk, contextChunk, contributionId);
     } catch (err) {
+      // Pass rate limit errors through unwrapped so callers can detect and handle silently
+      if (err instanceof ContributionRateLimitedError) throw err;
       const detail = err instanceof Error ? err.message : String(err);
       throw new Error(`Contribution failed (batch ${batchNum}): ${detail}`);
     }

--- a/lib/contribute.ts
+++ b/lib/contribute.ts
@@ -148,8 +148,17 @@ async function sendNightsToServer(
     if (res.ok) return;
 
     if (res.status === 429) {
+      const retryAfterHeader = res.headers.get('Retry-After');
+      const retryAfterSeconds = retryAfterHeader ? parseInt(retryAfterHeader, 10) : NaN;
+      // Long Retry-After (>60s) signals a per-window rate limit, not a transient spike.
+      // Skip retries entirely and surface a soft failure — no Sentry noise.
+      if (!isNaN(retryAfterSeconds) && retryAfterSeconds > 60) {
+        throw new ContributionRateLimitedError();
+      }
       if (attempt < RATE_LIMIT_MAX_RETRIES) {
-        const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
+        const delay = !isNaN(retryAfterSeconds) && retryAfterSeconds > 0
+          ? retryAfterSeconds * 1000
+          : RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
         await new Promise(r => setTimeout(r, delay));
         continue;
       }


### PR DESCRIPTION
## Summary

- **`lib/contribute.ts`** — Exports `ContributionRateLimitedError`; thrown when contribution endpoint rate-limits instead of surfacing a generic error to Sentry. When `Retry-After > 60s` the client skips retries immediately; short `Retry-After` values (≤60s) replace exponential backoff with the server-specified delay.
- **`app/api/contribute-data/route.ts`** — 429 response now includes `Retry-After: 3600` header (matches the 1-hour rate-limit window).
- **`components/dashboard/data-contribution.tsx`** — Soft "Data contribution paused" banner instead of error when rate-limited.
- **`app/analyze/page.tsx`** — Auto-submit catch path adds Sentry breadcrumb instead of `captureException` on rate limit.
- **`__tests__/contribute.test.ts`** — 5 new tests covering all rate-limit code paths.
- **`__tests__/upload-hash-cache.test.ts`** — Increased timeout for slow pruning test (intermittent 5s failure under parallel load).

Fixes Sentry JAVASCRIPT-NEXTJS-66. Closes AIR-1350.

## Test plan

- [ ] Upload SD card on preview → data contribution flow completes without error
- [ ] With rate limit mocked to 429 + `Retry-After: 3600` → soft "paused" banner appears, no Sentry exception
- [ ] All 2097 tests pass locally
- [ ] No regressions to normal contribution flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)