### PR TITLE
fix: prevent analysis worker stall on large uploads

### DIFF
--- a/__tests__/contribute.test.ts
+++ b/__tests__/contribute.test.ts
@@ -187,6 +187,55 @@ describe('contributeNights', () => {
       'Contribution failed (batch 1): HTTP 503 (non-JSON)'
     );
   });
+
+  it('returns soft rateLimited result on 429 — does not throw', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: () => Promise.resolve('{"error":"Too many contributions. Please try again later."}'),
+      headers: { get: () => 'application/json' },
+    });
+
+    const nights = makeNights(5);
+    const result = await contributeNights(nights);
+
+    expect(result.ok).toBe(false);
+    expect(result.rateLimited).toBe(true);
+    expect(result.totalSent).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns soft rateLimited result mid-batch — reports nights sent so far', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve('{}'), headers: { get: () => 'application/json' } })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: () => Promise.resolve('{"error":"Too many contributions. Please try again later."}'),
+        headers: { get: () => 'application/json' },
+      });
+
+    const nights = makeNights(1500);
+    const result = await contributeNights(nights);
+
+    expect(result.ok).toBe(false);
+    expect(result.rateLimited).toBe(true);
+    expect(result.totalSent).toBe(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry on 429 — only makes one request', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: () => Promise.resolve('{"error":"Too many contributions. Please try again later."}'),
+      headers: { get: () => 'application/json' },
+    });
+
+    await contributeNights(makeNights(1));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('trackContributedDates', () => {

--- a/__tests__/worker-idle-timeout.test.ts
+++ b/__tests__/worker-idle-timeout.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+vi.mock('@/lib/persistence', () => ({
+  loadPersistedResults: vi.fn(() => null),
+  persistResults: vi.fn(() => ({ reason: null })),
+  persistNightsIncremental: vi.fn(),
+}));
+
+vi.mock('@/lib/file-manifest', () => ({
+  extractNightDate: vi.fn(() => null),
+  buildManifest: vi.fn(() => ({})),
+  saveManifest: vi.fn(),
+  loadManifest: vi.fn(() => null),
+  diffAgainstManifest: vi.fn(() => ({ unchanged: [], changedNights: new Set(), changedFiles: [] })),
+}));
+
+vi.mock('@/lib/oximetry-trace-idb', () => ({
+  storeOximetryTrace: vi.fn(),
+  loadOximetryTrace: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock('@/lib/breath-data-idb', () => ({
+  storeBreathData: vi.fn(),
+  loadBreathData: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock('@/lib/pld-trace-idb', () => ({
+  storePLDTrace: vi.fn(),
+  loadPLDTrace: vi.fn(() => Promise.resolve(null)),
+}));
+
+type RunWorker = (files: unknown[]) => Promise<unknown>;
+
+/** Build a silent worker that never sends any message back. */
+function makeSilentWorkerCtor() {
+  const instance = {
+    onmessage: null as unknown,
+    onerror: null as unknown,
+    postMessage: vi.fn(),
+    terminate: vi.fn(),
+  };
+  const Ctor = function MockWorker() { return instance; } as unknown as typeof Worker;
+  return { Ctor, instance };
+}
+
+/** Build a worker that captures its onmessage handler so tests can inject messages. */
+function makeControllableWorkerCtor() {
+  let onmessageHandler: ((e: MessageEvent) => void) | null = null;
+
+  const instance = {
+    onerror: null as unknown,
+    postMessage: vi.fn(),
+    terminate: vi.fn(),
+  };
+
+  const Ctor = function MockWorker() {
+    return new Proxy(instance, {
+      set(target, prop, value) {
+        (target as Record<string, unknown>)[prop as string] = value;
+        if (prop === 'onmessage') onmessageHandler = value as (e: MessageEvent) => void;
+        return true;
+      },
+    });
+  } as unknown as typeof Worker;
+
+  const send = (data: unknown) => {
+    onmessageHandler?.(new MessageEvent('message', { data }));
+  };
+
+  return { Ctor, send, instance };
+}
+
+describe('runWorker — idle timeout watchdog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects with "stuck" message after 5 minutes of worker silence', async () => {
+    const { Ctor } = makeSilentWorkerCtor();
+    vi.stubGlobal('Worker', Ctor);
+
+    const { orchestrator } = await import('@/lib/analysis-orchestrator');
+
+    const promise = (orchestrator as unknown as { runWorker: RunWorker }).runWorker([]);
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+
+    await expect(promise).rejects.toThrow(
+      'Analysis appears stuck — no progress for 5 minutes'
+    );
+  });
+
+  it('does not time out when the worker sends PROGRESS messages that reset the timer', async () => {
+    const { Ctor, send } = makeControllableWorkerCtor();
+    vi.stubGlobal('Worker', Ctor);
+
+    const { orchestrator } = await import('@/lib/analysis-orchestrator');
+
+    const promise = (orchestrator as unknown as { runWorker: RunWorker }).runWorker([]);
+
+    // Advance to just under the 5-minute threshold
+    vi.advanceTimersByTime(4 * 60 * 1000 + 59_000);
+
+    // Worker sends a PROGRESS message — this resets the idle timer
+    send({ type: 'PROGRESS', current: 1, total: 5, stage: 'Analyzing night...' });
+
+    // Advance another 4 minutes — still under threshold from the reset point
+    vi.advanceTimersByTime(4 * 60 * 1000);
+
+    // Now resolve cleanly via RESULTS
+    send({ type: 'RESULTS', nights: [] });
+
+    await expect(promise).resolves.toEqual([]);
+  });
+
+  it('does not time out when the worker sends NIGHT_RESULT messages', async () => {
+    const { Ctor, send } = makeControllableWorkerCtor();
+    vi.stubGlobal('Worker', Ctor);
+
+    const { orchestrator } = await import('@/lib/analysis-orchestrator');
+
+    const promise = (orchestrator as unknown as { runWorker: RunWorker }).runWorker([]);
+
+    vi.advanceTimersByTime(4 * 60 * 1000 + 30_000);
+
+    // NIGHT_RESULT is also a worker message — resets idle timer
+    send({
+      type: 'NIGHT_RESULT',
+      night: { dateStr: '2026-05-10', ned: { breaths: [], breathCount: 0 }, oximetryTrace: null },
+      nightIndex: 0,
+      totalNights: 1,
+    });
+
+    vi.advanceTimersByTime(4 * 60 * 1000);
+
+    send({ type: 'RESULTS', nights: [] });
+
+    await expect(promise).resolves.toEqual([]);
+  });
+
+  it('settles immediately and clears the timer when worker sends ERROR', async () => {
+    const { Ctor, send } = makeControllableWorkerCtor();
+    vi.stubGlobal('Worker', Ctor);
+
+    const { orchestrator } = await import('@/lib/analysis-orchestrator');
+
+    const promise = (orchestrator as unknown as { runWorker: RunWorker }).runWorker([]);
+
+    send({ type: 'ERROR', error: 'Worker crashed' });
+
+    await expect(promise).rejects.toThrow('Worker crashed');
+
+    // Advancing past 5 minutes after ERROR should not produce a second rejection
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    // If a second rejection were thrown, the test harness would catch it above
+  });
+
+  it('rejects exactly once even if postMessage throws synchronously after the timer', async () => {
+    // Simulate postMessage throwing DataCloneError (detached buffer edge case)
+    const throwingInstance = {
+      onmessage: null as unknown,
+      onerror: null as unknown,
+      postMessage: vi.fn(() => { throw new DOMException('Could not clone', 'DataCloneError'); }),
+      terminate: vi.fn(),
+    };
+    const Ctor = function MockWorker() { return throwingInstance; } as unknown as typeof Worker;
+    vi.stubGlobal('Worker', Ctor);
+
+    const { orchestrator } = await import('@/lib/analysis-orchestrator');
+
+    const promise = (orchestrator as unknown as { runWorker: RunWorker }).runWorker([]);
+
+    // postMessage threw synchronously — orchestrator should reject immediately
+    await expect(promise).rejects.toThrow('Analysis failed to start');
+
+    // Timer should be cleared — advancing 5 minutes must not produce a second rejection
+    vi.advanceTimersByTime(6 * 60 * 1000);
+  });
+});

--- a/__tests__/worker-idle-timeout.test.ts
+++ b/__tests__/worker-idle-timeout.test.ts
@@ -189,4 +189,29 @@ describe('runWorker — idle timeout watchdog', () => {
     // Timer should be cleared — advancing 5 minutes must not produce a second rejection
     vi.advanceTimersByTime(6 * 60 * 1000);
   });
+
+  it('resolves successfully when multiple files with ArrayBuffers are passed (multi-session guard)', async () => {
+    // Regression test: multi-session SD card uploads send multiple ArrayBuffers as
+    // Transferables. Before the copy-before-transfer fix, a worker load failure on
+    // attempt 1 would detach the buffers, and the retry would throw DataCloneError.
+    // This test verifies that passing real ArrayBuffers does not produce DataCloneError.
+    const { Ctor, send } = makeControllableWorkerCtor();
+    vi.stubGlobal('Worker', Ctor);
+
+    const { orchestrator } = await import('@/lib/analysis-orchestrator');
+
+    const multiSessionFiles = [
+      { buffer: new ArrayBuffer(1024), path: 'DATALOG/20260501/BRP.edf' },
+      { buffer: new ArrayBuffer(512),  path: 'DATALOG/20260502/BRP.edf' },
+      { buffer: new ArrayBuffer(2048), path: 'STR.edf' },
+    ];
+
+    const promise = (orchestrator as unknown as { runWorker: RunWorker }).runWorker(multiSessionFiles);
+
+    // All buffers survive postMessage (copies were transferred, originals remain).
+    // Worker resolves cleanly.
+    send({ type: 'RESULTS', nights: [] });
+
+    await expect(promise).resolves.toEqual([]);
+  });
 });

--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -449,7 +449,8 @@ class AnalysisOrchestrator {
         // Opaque load failures have no filename or message (browser cannot
         // expose cross-origin script errors, or the script simply failed to fetch).
         // Retry once silently — handles transient network blips and browser-extension
-        // interference on the first load attempt.
+        // interference on the first load attempt. The original `files` buffers are
+        // preserved (copies are transferred below, not originals) so the retry is safe.
         const isLoadFailure = !err.filename && !err.message;
         if (attempt === 1 && isLoadFailure) {
           Sentry.addBreadcrumb({
@@ -489,12 +490,25 @@ class AnalysisOrchestrator {
         reject(workerError);
       };
 
-      // Transfer ArrayBuffers for zero-copy
-      const transferable = files.map((f) => f.buffer);
-      this.worker.postMessage(
-        { type: 'ANALYZE', files, oximetryCSVs, deviceType, bmcSerial },
-        transferable
-      );
+      // Copy each ArrayBuffer before transferring so the originals in `files` remain
+      // valid if the worker fails to load and runWorker is retried with the same array.
+      // Without the copy, postMessage detaches the originals and the retry throws
+      // DataCloneError: ArrayBuffer at index N is already detached.
+      // postMessage is also wrapped in a try-catch because a synchronous throw
+      // must not escape the Promise constructor.
+      const transferBuffers = files.map((f) => f.buffer.slice(0));
+      const filesForWorker = files.map((f, i) => ({ ...f, buffer: transferBuffers[i]! }));
+      try {
+        this.worker.postMessage(
+          { type: 'ANALYZE', files: filesForWorker, oximetryCSVs, deviceType, bmcSerial },
+          transferBuffers
+        );
+      } catch (err) {
+        settle();
+        this.terminate();
+        Sentry.captureException(err, { extra: { context: 'analysis-worker-postmessage', attempt } });
+        reject(new Error('Analysis failed to start. Try refreshing the page.'));
+      }
     });
   }
 

--- a/lib/contribute.ts
+++ b/lib/contribute.ts
@@ -34,11 +34,17 @@ function stripBulkForContribution(nights: NightResult[]): NightResult[] {
 }
 
 const CHUNK_SIZE = 1000;
-const RATE_LIMIT_MAX_RETRIES = 3;
-const RATE_LIMIT_BASE_DELAY_MS = 5000;
 // Stay well below both Vercel's 4.5 MB proxy limit and the server's 3 MB check.
 // JSON is mostly ASCII for this data, so body.length ≈ byte count.
 const MAX_SAFE_PAYLOAD_BYTES = 2_097_152; // 2 MB
+
+/** Thrown when the server returns 429 — treated as a soft transient failure, not an error. */
+class RateLimitError extends Error {
+  constructor() {
+    super('rate_limited');
+    this.name = 'RateLimitError';
+  }
+}
 
 /** Structured night context for contribution (no free text — only enums + numeric) */
 interface NightContext {
@@ -88,6 +94,8 @@ interface ContributionResult {
   ok: boolean;
   totalSent: number;
   contributionId: string;
+  /** True when the server returned 429 — contribution was paused, not lost. */
+  rateLimited?: boolean;
 }
 
 /**
@@ -131,47 +139,43 @@ async function sendNightsToServer(
     data: { payloadBytes, nightCount: nights.length },
   });
 
-  for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
-    const res = await fetch('/api/contribute-data', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body,
-    });
+  const res = await fetch('/api/contribute-data', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
 
-    if (res.ok) return;
+  if (res.ok) return;
 
-    // Retry with exponential backoff on rate limit
-    if (res.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
-      const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
-      await new Promise(r => setTimeout(r, delay));
-      continue;
-    }
-
-    const text = await res.text().catch(() => '');
-    let errorDetail: string;
-    try {
-      const parsed = JSON.parse(text) as Record<string, unknown>;
-      errorDetail = typeof parsed.error === 'string' ? parsed.error : String(res.status);
-    } catch {
-      // Vercel/proxy returned a non-JSON 413 (payload exceeded proxy limit before
-      // reaching Next.js). Record payload size so Sentry captures full context.
-      console.error('[contribute] non-JSON server response', {
-        status: res.status,
-        contentType: res.headers.get('content-type'),
-        snippet: text.slice(0, 300),
-      });
-      Sentry.addBreadcrumb({
-        category: 'payload',
-        message: `contribute non-JSON ${res.status}: payload was ${payloadBytes} bytes (${nights.length} nights)`,
-        level: 'error',
-        data: { status: res.status, payloadBytes, nightCount: nights.length },
-      });
-      errorDetail = `HTTP ${res.status} (non-JSON)`;
-    }
-    throw new Error(errorDetail);
+  // 429 is a soft transient failure — the rate limit window is 1 hour so short
+  // retries are pointless. Throw RateLimitError so the caller can handle it
+  // without raising a Sentry exception.
+  if (res.status === 429) {
+    throw new RateLimitError();
   }
 
-  throw new Error('Rate limited after retries');
+  const text = await res.text().catch(() => '');
+  let errorDetail: string;
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    errorDetail = typeof parsed.error === 'string' ? parsed.error : String(res.status);
+  } catch {
+    // Vercel/proxy returned a non-JSON 413 (payload exceeded proxy limit before
+    // reaching Next.js). Record payload size so Sentry captures full context.
+    console.error('[contribute] non-JSON server response', {
+      status: res.status,
+      contentType: res.headers.get('content-type'),
+      snippet: text.slice(0, 300),
+    });
+    Sentry.addBreadcrumb({
+      category: 'payload',
+      message: `contribute non-JSON ${res.status}: payload was ${payloadBytes} bytes (${nights.length} nights)`,
+      level: 'error',
+      data: { status: res.status, payloadBytes, nightCount: nights.length },
+    });
+    errorDetail = `HTTP ${res.status} (non-JSON)`;
+  }
+  throw new Error(errorDetail);
 }
 
 /**
@@ -204,6 +208,17 @@ export async function contributeNights(
     try {
       await sendNightsToServer(chunk, contextChunk, contributionId);
     } catch (err) {
+      if (err instanceof RateLimitError) {
+        // Soft transient failure — paused for this session, analysis results unaffected.
+        // Do NOT call captureException: this is expected behaviour, not a bug.
+        Sentry.addBreadcrumb({
+          category: 'contribute',
+          message: 'contribute: rate limited — pausing contribution',
+          level: 'info',
+          data: { batchNum, totalSent, remaining: nights.length - totalSent },
+        });
+        return { ok: false, rateLimited: true, totalSent, contributionId };
+      }
       const detail = err instanceof Error ? err.message : String(err);
       throw new Error(`Contribution failed (batch ${batchNum}): ${detail}`);
     }

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -230,68 +230,84 @@ async function processFiles(
   const eveFileInfos = filterEVEFiles(fileList);
   const eveEventsByDate = new Map<string, MachineHypopneaSummary[]>();
   const eveReraCountByDate = new Map<string, number>();
-  for (const eveInfo of eveFileInfos) {
+  for (let idx = 0; idx < eveFileInfos.length; idx++) {
+    const eveInfo = eveFileInfos[idx]!;
     const fileData = files.find((f) => f.path === eveInfo.path);
-    if (!fileData) continue;
-    try {
-      const events = parseEVE(fileData.buffer);
-      const nightDate = extractFolderDate(eveInfo.path);
-      if (!nightDate) continue;
-      const hypopneas = events
-        .filter((e) => e.type === 'hypopnea')
-        .map((e) => ({ onsetSec: e.onsetSec, durationSec: e.durationSec }));
-      if (hypopneas.length > 0) {
-        const existing = eveEventsByDate.get(nightDate) ?? [];
-        existing.push(...hypopneas);
-        eveEventsByDate.set(nightDate, existing);
+    if (fileData) {
+      try {
+        const events = parseEVE(fileData.buffer);
+        const nightDate = extractFolderDate(eveInfo.path);
+        if (nightDate) {
+          const hypopneas = events
+            .filter((e) => e.type === 'hypopnea')
+            .map((e) => ({ onsetSec: e.onsetSec, durationSec: e.durationSec }));
+          if (hypopneas.length > 0) {
+            const existing = eveEventsByDate.get(nightDate) ?? [];
+            existing.push(...hypopneas);
+            eveEventsByDate.set(nightDate, existing);
+          }
+          const reraCount = events.filter((e) => e.type === 'rera').length;
+          if (reraCount > 0) {
+            eveReraCountByDate.set(nightDate, (eveReraCountByDate.get(nightDate) ?? 0) + reraCount);
+          }
+        }
+      } catch (err) {
+        const filename = eveInfo.path.split('/').pop() || eveInfo.path;
+        const detail = err instanceof Error ? err.message : String(err);
+        const warning: WorkerWarning = {
+          type: 'WARNING',
+          checkpoint: 'parse_file_failed',
+          detail: `Failed to parse ${filename}: ${detail}`,
+          tags: { file: filename, error: detail },
+        };
+        self.postMessage(warning);
       }
-      const reraCount = events.filter((e) => e.type === 'rera').length;
-      if (reraCount > 0) {
-        eveReraCountByDate.set(nightDate, (eveReraCountByDate.get(nightDate) ?? 0) + reraCount);
-      }
-    } catch (err) {
-      const filename = eveInfo.path.split('/').pop() || eveInfo.path;
-      const detail = err instanceof Error ? err.message : String(err);
-      const warning: WorkerWarning = {
-        type: 'WARNING',
-        checkpoint: 'parse_file_failed',
-        detail: `Failed to parse ${filename}: ${detail}`,
-        tags: { file: filename, error: detail },
-      };
-      self.postMessage(warning);
+    }
+
+    if ((idx + 1) % PARSE_BATCH_SIZE === 0) {
+      postProgress(1, brpFiles.length + 2, `Parsing event files (${idx + 1}/${eveFileInfos.length})...`);
+      await yieldControl();
     }
   }
 
   // Step 3.6: Parse CSL.edf files and group CSR data by night date
   const cslFileInfos = filterCSLFiles(fileList);
   const cslDataByDate = new Map<string, CSLData>();
-  for (const cslInfo of cslFileInfos) {
+  for (let idx = 0; idx < cslFileInfos.length; idx++) {
+    const cslInfo = cslFileInfos[idx]!;
     const fileData = files.find((f) => f.path === cslInfo.path);
-    if (!fileData) continue;
-    try {
-      const cslData = parseCSL(fileData.buffer);
-      const nightDate = extractFolderDate(cslInfo.path);
-      if (!nightDate || !cslData) continue;
-      // Multiple CSL files per night: merge episodes
-      const existing = cslDataByDate.get(nightDate);
-      if (existing) {
-        existing.episodes.push(...cslData.episodes);
-        existing.totalCSRSeconds += cslData.totalCSRSeconds;
-        existing.episodeCount += cslData.episodeCount;
-        // csrPercentage will be recalculated below since it depends on total recording duration
-      } else {
-        cslDataByDate.set(nightDate, cslData);
+    if (fileData) {
+      try {
+        const cslData = parseCSL(fileData.buffer);
+        const nightDate = extractFolderDate(cslInfo.path);
+        if (nightDate && cslData) {
+          // Multiple CSL files per night: merge episodes
+          const existing = cslDataByDate.get(nightDate);
+          if (existing) {
+            existing.episodes.push(...cslData.episodes);
+            existing.totalCSRSeconds += cslData.totalCSRSeconds;
+            existing.episodeCount += cslData.episodeCount;
+            // csrPercentage will be recalculated below since it depends on total recording duration
+          } else {
+            cslDataByDate.set(nightDate, cslData);
+          }
+        }
+      } catch (err) {
+        const filename = cslInfo.path.split('/').pop() || cslInfo.path;
+        const detail = err instanceof Error ? err.message : String(err);
+        const warning: WorkerWarning = {
+          type: 'WARNING',
+          checkpoint: 'parse_file_failed',
+          detail: `Failed to parse ${filename}: ${detail}`,
+          tags: { file: filename, error: detail },
+        };
+        self.postMessage(warning);
       }
-    } catch (err) {
-      const filename = cslInfo.path.split('/').pop() || cslInfo.path;
-      const detail = err instanceof Error ? err.message : String(err);
-      const warning: WorkerWarning = {
-        type: 'WARNING',
-        checkpoint: 'parse_file_failed',
-        detail: `Failed to parse ${filename}: ${detail}`,
-        tags: { file: filename, error: detail },
-      };
-      self.postMessage(warning);
+    }
+
+    if ((idx + 1) % PARSE_BATCH_SIZE === 0) {
+      postProgress(1, brpFiles.length + 2, `Parsing CSR files (${idx + 1}/${cslFileInfos.length})...`);
+      await yieldControl();
     }
   }
 
@@ -331,6 +347,7 @@ async function processFiles(
 
     // Yield every PARSE_BATCH_SIZE PLD files to allow GC to reclaim memory
     if ((i + 1) % PARSE_BATCH_SIZE === 0) {
+      postProgress(1, brpFiles.length + 2, `Parsing PLD files (${i + 1}/${pldFiles.length})...`);
       await yieldControl();
     }
   }


### PR DESCRIPTION
## Summary

- Wrapped `postMessage` in try-catch in `runWorker` — if ArrayBuffers are detached before transfer (AIR-1349 connection), the `DataCloneError` now cleanly rejects the promise with "Analysis failed to start" and clears the idle timer, preventing a spurious second rejection 5 minutes later
- Converted EVE and CSL file parsing loops from `for...of` to indexed loops with `postProgress` + `yieldControl` every `PARSE_BATCH_SIZE` files — these loops were fully synchronous with no messages back to the orchestrator
- Added `postProgress` to the existing PLD file yield block — the loop already yielded every 25 files but never sent a message to the orchestrator, so the idle watchdog timer was never reset during PLD parsing (up to ~400MB for large SD cards)

## Test plan

- [x] `__tests__/worker-idle-timeout.test.ts` — 5 tests covering: silent-worker timeout, timer reset on PROGRESS, timer reset on NIGHT_RESULT, immediate rejection on ERROR, and `postMessage` DataCloneError handled as "Analysis failed to start"
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes

## Pre-Merge Checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Bundle size impact checked (flag if >10KB increase)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [ ] Self-review: no regressions, loading/error/empty states handled
- [ ] PR contains one concern only