### PR TITLE
fix: handle contribution endpoint rate limit responses gracefully

### DIFF
--- a/__tests__/contribute.test.ts
+++ b/__tests__/contribute.test.ts
@@ -20,7 +20,7 @@ Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, wri
 // ── Mock crypto.randomUUID ──────────────────────────────────
 vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid-1234' });
 
-import { contributeNights, trackContributedDates } from '@/lib/contribute';
+import { contributeNights, trackContributedDates, RateLimitError } from '@/lib/contribute';
 
 // ── Helpers ─────────────────────────────────────────────────
 function makeNight(dateStr: string): NightResult {
@@ -186,6 +186,72 @@ describe('contributeNights', () => {
     await expect(contributeNights(nights)).rejects.toThrow(
       'Contribution failed (batch 1): HTTP 503 (non-JSON)'
     );
+  });
+
+  it('throws RateLimitError (not generic Error) on 429 response', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: { get: (_key: string) => null },
+    });
+
+    const nights = makeNights(1);
+    await expect(contributeNights(nights)).rejects.toBeInstanceOf(RateLimitError);
+  });
+
+  it('RateLimitError carries retryAfterMs from Retry-After header', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: { get: (key: string) => key === 'Retry-After' ? '3600' : null },
+    });
+
+    const nights = makeNights(1);
+    let thrown: unknown;
+    try {
+      await contributeNights(nights);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(RateLimitError);
+    expect((thrown as RateLimitError).retryAfterMs).toBe(3_600_000);
+  });
+
+  it('RateLimitError message includes "Too many" so existing UI checks keep working', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: { get: () => null },
+    });
+
+    const nights = makeNights(1);
+    let thrown: unknown;
+    try {
+      await contributeNights(nights);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(RateLimitError);
+    expect((thrown as RateLimitError).message).toContain('Too many');
+  });
+
+  it('RateLimitError does not get wrapped in "Contribution failed (batch N)" prefix', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      headers: { get: () => null },
+    });
+
+    const nights = makeNights(1);
+    let thrown: unknown;
+    try {
+      await contributeNights(nights);
+    } catch (err) {
+      thrown = err;
+    }
+    // Must be RateLimitError, not a generic Error wrapping the message
+    expect(thrown).toBeInstanceOf(RateLimitError);
+    expect((thrown as Error).message).not.toContain('Contribution failed');
   });
 });
 

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -43,7 +43,7 @@ import { SAMPLE_NIGHTS, SAMPLE_THERAPY_CHANGE_DATE } from '@/lib/sample-data';
 import type { AnalysisState, NightResult } from '@/lib/types';
 import { loadPersistedResults } from '@/lib/persistence';
 import { events } from '@/lib/analytics';
-import { contributeNights, trackContributedDates } from '@/lib/contribute';
+import { contributeNights, trackContributedDates, RateLimitError } from '@/lib/contribute';
 import { contributeWaveformsBackground } from '@/lib/contribute-waveforms';
 import { contributeOximetryTraceBackground } from '@/lib/contribute-oximetry-trace';
 import { safeGetItem } from '@/lib/safe-local-storage';
@@ -430,7 +430,10 @@ function AnalyzePageInner() {
         ).catch(() => { /* logged in contributeOximetryTraceBackground */ });
       })
       .catch((err) => {
-        Sentry.captureException(err, { tags: { action: 'auto-contribution' } });
+        // Rate limit is a soft transient failure — no Sentry, no alarming UI
+        if (!(err instanceof RateLimitError)) {
+          Sentry.captureException(err, { tags: { action: 'auto-contribution' } });
+        }
         setAutoSubmitStatus('error');
       });
   }, []);

--- a/app/api/contribute-data/route.ts
+++ b/app/api/contribute-data/route.ts
@@ -241,7 +241,7 @@ export async function POST(request: NextRequest) {
       console.error('[contribute-data] 429 rate limited', { ip });
       return NextResponse.json(
         { error: 'Too many contributions. Please try again later.' },
-        { status: 429 }
+        { status: 429, headers: { 'Retry-After': '3600' } }
       );
     }
 

--- a/lib/contribute.ts
+++ b/lib/contribute.ts
@@ -8,6 +8,15 @@ import * as Sentry from '@sentry/nextjs';
 import type { NightResult, NightNotes } from './types';
 import { loadNightNotes } from './night-notes';
 
+export class RateLimitError extends Error {
+  retryAfterMs?: number;
+  constructor(retryAfterMs?: number) {
+    super('Too many contributions. Please try again later.');
+    this.name = 'RateLimitError';
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
 /**
  * Strip bulky per-breath/trace arrays from NightResult before contribution.
  * The server's anonymiseNight() only reads scalar summary fields, so bulk
@@ -34,8 +43,6 @@ function stripBulkForContribution(nights: NightResult[]): NightResult[] {
 }
 
 const CHUNK_SIZE = 1000;
-const RATE_LIMIT_MAX_RETRIES = 3;
-const RATE_LIMIT_BASE_DELAY_MS = 5000;
 // Stay well below both Vercel's 4.5 MB proxy limit and the server's 3 MB check.
 // JSON is mostly ASCII for this data, so body.length ≈ byte count.
 const MAX_SAFE_PAYLOAD_BYTES = 2_097_152; // 2 MB
@@ -131,47 +138,43 @@ async function sendNightsToServer(
     data: { payloadBytes, nightCount: nights.length },
   });
 
-  for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
-    const res = await fetch('/api/contribute-data', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body,
-    });
+  const res = await fetch('/api/contribute-data', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
 
-    if (res.ok) return;
+  if (res.ok) return;
 
-    // Retry with exponential backoff on rate limit
-    if (res.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
-      const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
-      await new Promise(r => setTimeout(r, delay));
-      continue;
-    }
-
-    const text = await res.text().catch(() => '');
-    let errorDetail: string;
-    try {
-      const parsed = JSON.parse(text) as Record<string, unknown>;
-      errorDetail = typeof parsed.error === 'string' ? parsed.error : String(res.status);
-    } catch {
-      // Vercel/proxy returned a non-JSON 413 (payload exceeded proxy limit before
-      // reaching Next.js). Record payload size so Sentry captures full context.
-      console.error('[contribute] non-JSON server response', {
-        status: res.status,
-        contentType: res.headers.get('content-type'),
-        snippet: text.slice(0, 300),
-      });
-      Sentry.addBreadcrumb({
-        category: 'payload',
-        message: `contribute non-JSON ${res.status}: payload was ${payloadBytes} bytes (${nights.length} nights)`,
-        level: 'error',
-        data: { status: res.status, payloadBytes, nightCount: nights.length },
-      });
-      errorDetail = `HTTP ${res.status} (non-JSON)`;
-    }
-    throw new Error(errorDetail);
+  // 429 is a soft transient failure — respect Retry-After and throw RateLimitError
+  // so callers can suppress Sentry reporting and show a friendly message.
+  if (res.status === 429) {
+    const retryAfterHeader = res.headers.get('Retry-After');
+    const retryAfterMs = retryAfterHeader ? parseInt(retryAfterHeader, 10) * 1000 : undefined;
+    throw new RateLimitError(retryAfterMs);
   }
 
-  throw new Error('Rate limited after retries');
+  const text = await res.text().catch(() => '');
+  let errorDetail: string;
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    errorDetail = typeof parsed.error === 'string' ? parsed.error : String(res.status);
+  } catch {
+    // Vercel/proxy returned a non-JSON response (e.g. 413 proxy rejection before Next.js).
+    console.error('[contribute] non-JSON server response', {
+      status: res.status,
+      contentType: res.headers.get('content-type'),
+      snippet: text.slice(0, 300),
+    });
+    Sentry.addBreadcrumb({
+      category: 'payload',
+      message: `contribute non-JSON ${res.status}: payload was ${payloadBytes} bytes (${nights.length} nights)`,
+      level: 'error',
+      data: { status: res.status, payloadBytes, nightCount: nights.length },
+    });
+    errorDetail = `HTTP ${res.status} (non-JSON)`;
+  }
+  throw new Error(errorDetail);
 }
 
 /**
@@ -204,6 +207,9 @@ export async function contributeNights(
     try {
       await sendNightsToServer(chunk, contextChunk, contributionId);
     } catch (err) {
+      // RateLimitError is a soft transient failure — propagate as-is so callers
+      // can suppress Sentry and show an informative message.
+      if (err instanceof RateLimitError) throw err;
       const detail = err instanceof Error ? err.message : String(err);
       throw new Error(`Contribution failed (batch ${batchNum}): ${detail}`);
     }


### PR DESCRIPTION
## Summary

- **Root cause**: The client-side contributeNights threw a generic Error on 429, which the auto-submit handler in analyze/page.tsx then passed to Sentry.captureException, generating JAVASCRIPT-NEXTJS-66 (4 events, 2 users).
- Adds a named RateLimitError class exported from lib/contribute.ts; on 429 the client throws it immediately (no retry loop) and propagates it unwrapped.
- Auto-submit handler in analyze/page.tsx now guards Sentry with instanceof RateLimitError.
- Server adds Retry-After: 3600 header so clients get a machine-readable retry hint.

## Test plan

- [ ] npm test passes (4 new rate-limit branch tests in __tests__/contribute.test.ts)
- [ ] npx tsc --noEmit clean
- [ ] Verify no new JAVASCRIPT-NEXTJS-66 events after deploy

## Acceptance criteria

- [x] contributeNights throws RateLimitError (not generic Error) on 429
- [x] RateLimitError carries retryAfterMs from Retry-After header
- [x] analyze/page.tsx auto-submit skips captureException for RateLimitError
- [x] Server responds with Retry-After: 3600 on 429
- [x] Unit tests cover the rate-limit branch