### PR TITLE
fix: fix wheel zoom on all charts and add drag-range zoom

### DIFF
--- a/__tests__/chart-viewport-wheel.test.ts
+++ b/__tests__/chart-viewport-wheel.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useChartViewport } from '@/hooks/use-chart-viewport';
+import { useChartElementRef } from '@/hooks/use-chart-element-ref';
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function makeEl(): HTMLElement {
+  const el = document.createElement('div');
+  // Minimal getBoundingClientRect so handlers can compute fractions
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    left: 0, right: 800, top: 0, bottom: 200, width: 800, height: 200,
+    x: 0, y: 0, toJSON: () => ({}),
+  });
+  return el;
+}
+
+function fireWheel(el: HTMLElement, deltaY: number, clientX = 400) {
+  const event = new WheelEvent('wheel', { deltaY, clientX, bubbles: true, cancelable: true });
+  el.dispatchEvent(event);
+}
+
+function fireDblClick(el: HTMLElement) {
+  el.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('useChartViewport — multi-element attachToElement', () => {
+  const opts = { durationSeconds: 3600, dateStr: '2024-01-01' };
+
+  it('attaches wheel listeners to multiple elements independently', () => {
+    const { result } = renderHook(() => useChartViewport(opts));
+    const el1 = makeEl();
+    const el2 = makeEl();
+
+    act(() => {
+      result.current.attachToElement(el1);
+      result.current.attachToElement(el2);
+    });
+
+    // Zoom in on el1
+    act(() => { fireWheel(el1, -100); });
+    const afterEl1Zoom = result.current.visibleDurationSec;
+    expect(afterEl1Zoom).toBeLessThan(3600);
+
+    // Zoom in on el2 — both elements can trigger zoom
+    act(() => { fireWheel(el2, -100); });
+    expect(result.current.visibleDurationSec).toBeLessThan(afterEl1Zoom);
+  });
+
+  it('cleanup removes listeners so wheel no longer zooms', () => {
+    const { result } = renderHook(() => useChartViewport(opts));
+    const el = makeEl();
+
+    let cleanup: (() => void) | undefined;
+    act(() => { cleanup = result.current.attachToElement(el); });
+
+    act(() => { fireWheel(el, -100); });
+    const afterZoom = result.current.visibleDurationSec;
+
+    act(() => { cleanup!(); });
+
+    act(() => { fireWheel(el, -100); });
+    // Duration should not change after cleanup
+    expect(result.current.visibleDurationSec).toBe(afterZoom);
+  });
+
+  it('double-click resets zoom to full range', () => {
+    const { result } = renderHook(() => useChartViewport(opts));
+    const el = makeEl();
+
+    act(() => { result.current.attachToElement(el); });
+    act(() => { fireWheel(el, -100); });
+    expect(result.current.isFullView).toBe(false);
+
+    act(() => { fireDblClick(el); });
+    expect(result.current.isFullView).toBe(true);
+  });
+});
+
+describe('useChartViewport — dragZoomMode', () => {
+  const opts = { durationSeconds: 3600, dateStr: '2024-01-01' };
+
+  it('dragZoomMode defaults to false', () => {
+    const { result } = renderHook(() => useChartViewport(opts));
+    expect(result.current.dragZoomMode).toBe(false);
+  });
+
+  it('setDragZoomMode toggles the mode', () => {
+    const { result } = renderHook(() => useChartViewport(opts));
+    act(() => { result.current.setDragZoomMode(true); });
+    expect(result.current.dragZoomMode).toBe(true);
+    act(() => { result.current.setDragZoomMode(false); });
+    expect(result.current.dragZoomMode).toBe(false);
+  });
+
+  it('dragZoomOverlay defaults to inactive', () => {
+    const { result } = renderHook(() => useChartViewport(opts));
+    expect(result.current.dragZoomOverlay.active).toBe(false);
+  });
+});
+
+describe('useChartElementRef', () => {
+  it('calls attachToElement on mount and cleanup on unmount', () => {
+    const cleanup = vi.fn();
+    const attach = vi.fn().mockReturnValue(cleanup);
+
+    const { result } = renderHook(() => useChartElementRef(attach));
+    const el = makeEl();
+
+    act(() => { result.current(el); });
+    expect(attach).toHaveBeenCalledWith(el);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    act(() => { result.current(null); });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up previous element before attaching new one', () => {
+    const cleanup1 = vi.fn();
+    const cleanup2 = vi.fn();
+    const attach = vi.fn()
+      .mockReturnValueOnce(cleanup1)
+      .mockReturnValueOnce(cleanup2);
+
+    const { result } = renderHook(() => useChartElementRef(attach));
+    const el1 = makeEl();
+    const el2 = makeEl();
+
+    act(() => { result.current(el1); });
+    act(() => { result.current(el2); });
+
+    expect(cleanup1).toHaveBeenCalledTimes(1);
+    expect(attach).toHaveBeenNthCalledWith(2, el2);
+  });
+});

--- a/components/charts/device-leak-chart.tsx
+++ b/components/charts/device-leak-chart.tsx
@@ -14,6 +14,7 @@ import {
 import type { LeakPoint } from '@/lib/waveform-types';
 import { formatElapsedTimeShort, formatElapsedTime, sliceByTime } from '@/lib/waveform-utils';
 import { useSyncedViewport } from '@/hooks/use-synced-viewport';
+import { useChartElementRef } from '@/hooks/use-chart-element-ref';
 import { downsampleForChart } from '@/lib/chart-downsample';
 
 /** ResMed published threshold for clinically significant total leak */
@@ -46,6 +47,7 @@ export const DeviceLeakChart = memo(function DeviceLeakChart({
   leak,
 }: Props) {
   const viewport = useSyncedViewport();
+  const elementRef = useChartElementRef(viewport.attachToElement);
   const bucketSeconds = leak.length > 1 ? leak[1]!.t - leak[0]!.t : 2;
 
   const data = useMemo(() => {
@@ -81,13 +83,19 @@ export const DeviceLeakChart = memo(function DeviceLeakChart({
         </h3>
       </div>
       <div
-        ref={viewport.chartRef}
-        className="relative h-[140px] w-full cursor-grab select-none touch-none sm:h-[160px]"
+        ref={elementRef}
+        className={`relative h-[140px] w-full select-none touch-none sm:h-[160px] ${viewport.dragZoomMode ? 'cursor-crosshair' : 'cursor-grab'}`}
         role="application"
         aria-label="Leak rate chart. Synchronised with other charts."
         tabIndex={0}
         onKeyDown={viewport.handleKeyDown}
       >
+        {viewport.dragZoomOverlay.active && (
+          <div
+            className="pointer-events-none absolute inset-y-0 z-10 border-x border-primary/50 bg-primary/15"
+            style={{ left: `${viewport.dragZoomOverlay.leftPct}%`, width: `${viewport.dragZoomOverlay.widthPct}%` }}
+          />
+        )}
         <span className="pointer-events-none absolute bottom-1 right-2 z-10 select-none text-[9px] text-muted-foreground/70">
           airwaylab.app
         </span>

--- a/components/charts/device-pressure-chart.tsx
+++ b/components/charts/device-pressure-chart.tsx
@@ -15,6 +15,7 @@ import type { PressurePoint } from '@/lib/waveform-types';
 import type { MachineSettings } from '@/lib/types';
 import { formatElapsedTimeShort, formatElapsedTime, sliceByTime } from '@/lib/waveform-utils';
 import { useSyncedViewport } from '@/hooks/use-synced-viewport';
+import { useChartElementRef } from '@/hooks/use-chart-element-ref';
 import { downsampleForChart } from '@/lib/chart-downsample';
 
 interface Props {
@@ -48,6 +49,7 @@ export const DevicePressureChart = memo(function DevicePressureChart({
   deliveredP90,
 }: Props) {
   const viewport = useSyncedViewport();
+  const elementRef = useChartElementRef(viewport.attachToElement);
 
   const data = useMemo(() =>
     downsampleForChart(sliceByTime(pressure, viewport.clampedStartSec, viewport.clampedEndSec)),
@@ -65,13 +67,19 @@ export const DevicePressureChart = memo(function DevicePressureChart({
         <h3 className="text-xs font-medium text-muted-foreground">Pressure Delivery</h3>
       </div>
       <div
-        ref={viewport.chartRef}
-        className="relative h-[140px] w-full cursor-grab select-none touch-none sm:h-[160px]"
+        ref={elementRef}
+        className={`relative h-[140px] w-full select-none touch-none sm:h-[160px] ${viewport.dragZoomMode ? 'cursor-crosshair' : 'cursor-grab'}`}
         role="application"
         aria-label="Pressure delivery chart. Synchronised with other charts."
         tabIndex={0}
         onKeyDown={viewport.handleKeyDown}
       >
+        {viewport.dragZoomOverlay.active && (
+          <div
+            className="pointer-events-none absolute inset-y-0 z-10 border-x border-primary/50 bg-primary/15"
+            style={{ left: `${viewport.dragZoomOverlay.leftPct}%`, width: `${viewport.dragZoomOverlay.widthPct}%` }}
+          />
+        )}
         <span className="pointer-events-none absolute bottom-1 right-2 z-10 select-none text-[9px] text-muted-foreground/70">
           airwaylab.app
         </span>

--- a/components/charts/flow-waveform.tsx
+++ b/components/charts/flow-waveform.tsx
@@ -16,6 +16,7 @@ import type { FlowSample, PressurePoint, WaveformEvent } from '@/lib/waveform-ty
 import { formatElapsedTimeShort, formatElapsedTime } from '@/lib/waveform-utils';
 import { CHART_COLORS, GRID_STROKE, AXIS_TICK_FILL, AXIS_LINE_STROKE, withAlpha } from '@/lib/chart-theme';
 import { useSyncedViewport } from '@/hooks/use-synced-viewport';
+import { useChartElementRef } from '@/hooks/use-chart-element-ref';
 import { downsampleForChart } from '@/lib/chart-downsample';
 
 export type EventType = WaveformEvent['type'];
@@ -92,10 +93,10 @@ export const FlowWaveform = memo(function FlowWaveform({
   flow,
   pressure,
   events,
-
   visibleEventTypes,
 }: Props) {
   const viewport = useSyncedViewport();
+  const elementRef = useChartElementRef(viewport.attachToElement);
   const hasPressure = pressure.length > 0;
 
   // Determine which types are active
@@ -184,13 +185,19 @@ export const FlowWaveform = memo(function FlowWaveform({
         )}
       </div>
       <div
-        ref={viewport.chartRef}
-        className="relative h-[200px] w-full cursor-grab select-none touch-none sm:h-[240px]"
+        ref={elementRef}
+        className={`relative h-[200px] w-full select-none touch-none sm:h-[240px] ${viewport.dragZoomMode ? 'cursor-crosshair' : 'cursor-grab'}`}
         role="application"
         aria-label="Flow waveform chart. Synchronised with other charts."
         tabIndex={0}
         onKeyDown={viewport.handleKeyDown}
       >
+        {viewport.dragZoomOverlay.active && (
+          <div
+            className="pointer-events-none absolute inset-y-0 z-10 border-x border-primary/50 bg-primary/15"
+            style={{ left: `${viewport.dragZoomOverlay.leftPct}%`, width: `${viewport.dragZoomOverlay.widthPct}%` }}
+          />
+        )}
         <span className="pointer-events-none absolute bottom-1 right-2 z-10 select-none text-[9px] text-muted-foreground/70">
           airwaylab.app
         </span>

--- a/components/charts/respiratory-rate-chart.tsx
+++ b/components/charts/respiratory-rate-chart.tsx
@@ -13,6 +13,7 @@ import {
 import type { RespiratoryRatePoint } from '@/lib/waveform-types';
 import { formatElapsedTimeShort, formatElapsedTime, sliceByTime } from '@/lib/waveform-utils';
 import { useSyncedViewport } from '@/hooks/use-synced-viewport';
+import { useChartElementRef } from '@/hooks/use-chart-element-ref';
 import { CHART_COLORS, GRID_STROKE, AXIS_TICK_FILL, AXIS_LINE_STROKE, withAlpha } from '@/lib/chart-theme';
 import { downsampleForChart } from '@/lib/chart-downsample';
 
@@ -39,6 +40,7 @@ function RRTooltipContent({ active, payload, label }: {
 
 export const RespiratoryRateChart = memo(function RespiratoryRateChart({ respiratoryRate }: Props) {
   const viewport = useSyncedViewport();
+  const elementRef = useChartElementRef(viewport.attachToElement);
   const tickFormatter = useCallback((value: number) => formatElapsedTimeShort(value), []);
 
   const data = useMemo(() =>
@@ -60,13 +62,19 @@ export const RespiratoryRateChart = memo(function RespiratoryRateChart({ respira
         <h3 className="text-xs font-medium text-muted-foreground">Respiratory Rate</h3>
       </div>
       <div
-        ref={viewport.chartRef}
-        className="relative h-[140px] w-full cursor-grab select-none touch-none sm:h-[160px]"
+        ref={elementRef}
+        className={`relative h-[140px] w-full select-none touch-none sm:h-[160px] ${viewport.dragZoomMode ? 'cursor-crosshair' : 'cursor-grab'}`}
         role="application"
         aria-label="Respiratory rate chart. Synchronised with other charts."
         tabIndex={0}
         onKeyDown={viewport.handleKeyDown}
       >
+        {viewport.dragZoomOverlay.active && (
+          <div
+            className="pointer-events-none absolute inset-y-0 z-10 border-x border-primary/50 bg-primary/15"
+            style={{ left: `${viewport.dragZoomOverlay.leftPct}%`, width: `${viewport.dragZoomOverlay.widthPct}%` }}
+          />
+        )}
         <span className="pointer-events-none absolute bottom-1 right-2 z-10 select-none text-[9px] text-muted-foreground/70">
           airwaylab.app
         </span>

--- a/components/charts/shared-chart-toolbar.tsx
+++ b/components/charts/shared-chart-toolbar.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { useSyncedViewport } from '@/hooks/use-synced-viewport';
 import { ZOOM_PRESETS, PAN_STEP_FRACTION } from '@/hooks/use-chart-viewport';
 import { formatElapsedTimeShort } from '@/lib/waveform-utils';
-import { ZoomIn, ZoomOut, Maximize2, ChevronLeft, ChevronRight } from 'lucide-react';
+import { ZoomIn, ZoomOut, Maximize2, ChevronLeft, ChevronRight, Crosshair } from 'lucide-react';
 
 interface Props {
   durationSeconds: number;
@@ -89,6 +89,17 @@ export function SharedChartToolbar({ durationSeconds, disabled = false }: Props)
             aria-label="Reset zoom"
           >
             <Maximize2 className="h-3 w-3" />
+          </Button>
+          <Button
+            variant={viewport.dragZoomMode ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => viewport.setDragZoomMode(!viewport.dragZoomMode)}
+            disabled={disabled}
+            className="h-6 w-6 p-0"
+            aria-label={viewport.dragZoomMode ? 'Switch to pan mode' : 'Drag to zoom (range select)'}
+            title={viewport.dragZoomMode ? 'Range select active — click to pan' : 'Range select zoom'}
+          >
+            <Crosshair className="h-3 w-3" />
           </Button>
           <div className="mx-1 h-4 w-px bg-border/50" />
           <Button

--- a/components/charts/spo2-trace.tsx
+++ b/components/charts/spo2-trace.tsx
@@ -16,6 +16,7 @@ import {
 import type { OximetryTraceData } from '@/lib/types';
 import { formatElapsedTimeShort, formatElapsedTime } from '@/lib/waveform-utils';
 import { useSyncedViewport } from '@/hooks/use-synced-viewport';
+import { useChartElementRef } from '@/hooks/use-chart-element-ref';
 import { GRID_STROKE, AXIS_TICK_FILL, AXIS_LINE_STROKE } from '@/lib/chart-theme';
 import { downsampleForChart } from '@/lib/chart-downsample';
 
@@ -51,6 +52,7 @@ export const SpO2Trace = memo(function SpO2Trace({
 }: Props) {
   const points = trace.trace;
   const viewport = useSyncedViewport();
+  const elementRef = useChartElementRef(viewport.attachToElement);
 
   // SpO2 uses time-based slicing via the synced viewport
   const data = useMemo(() => {
@@ -119,13 +121,19 @@ export const SpO2Trace = memo(function SpO2Trace({
         <h3 className="text-xs font-medium text-muted-foreground">SpO₂ &amp; Heart Rate Trace</h3>
       </div>
       <div
-        ref={viewport.chartRef}
-        className="relative h-[160px] w-full cursor-grab select-none touch-none sm:h-[200px]"
+        ref={elementRef}
+        className={`relative h-[160px] w-full select-none touch-none sm:h-[200px] ${viewport.dragZoomMode ? 'cursor-crosshair' : 'cursor-grab'}`}
         role="application"
         aria-label="SpO2 and heart rate trace chart. Synchronised with other charts."
         tabIndex={0}
         onKeyDown={viewport.handleKeyDown}
       >
+        {viewport.dragZoomOverlay.active && (
+          <div
+            className="pointer-events-none absolute inset-y-0 z-10 border-x border-primary/50 bg-primary/15"
+            style={{ left: `${viewport.dragZoomOverlay.leftPct}%`, width: `${viewport.dragZoomOverlay.widthPct}%` }}
+          />
+        )}
         <span className="pointer-events-none absolute bottom-1 right-2 z-10 select-none text-[9px] text-muted-foreground/70">
           airwaylab.app
         </span>

--- a/components/charts/tidal-volume-chart.tsx
+++ b/components/charts/tidal-volume-chart.tsx
@@ -13,6 +13,7 @@ import {
 import type { TidalVolumePoint } from '@/lib/waveform-types';
 import { formatElapsedTimeShort, formatElapsedTime, sliceByTime } from '@/lib/waveform-utils';
 import { useSyncedViewport } from '@/hooks/use-synced-viewport';
+import { useChartElementRef } from '@/hooks/use-chart-element-ref';
 import { CHART_COLORS, GRID_STROKE, AXIS_TICK_FILL, AXIS_LINE_STROKE, withAlpha } from '@/lib/chart-theme';
 import { downsampleForChart } from '@/lib/chart-downsample';
 
@@ -39,6 +40,7 @@ function TVTooltipContent({ active, payload, label }: {
 
 export const TidalVolumeChart = memo(function TidalVolumeChart({ tidalVolume }: Props) {
   const viewport = useSyncedViewport();
+  const elementRef = useChartElementRef(viewport.attachToElement);
   const tickFormatter = useCallback((value: number) => formatElapsedTimeShort(value), []);
 
   const data = useMemo(() =>
@@ -60,13 +62,19 @@ export const TidalVolumeChart = memo(function TidalVolumeChart({ tidalVolume }: 
         <h3 className="text-xs font-medium text-muted-foreground">Tidal Volume</h3>
       </div>
       <div
-        ref={viewport.chartRef}
-        className="relative h-[140px] w-full cursor-grab select-none touch-none sm:h-[160px]"
+        ref={elementRef}
+        className={`relative h-[140px] w-full select-none touch-none sm:h-[160px] ${viewport.dragZoomMode ? 'cursor-crosshair' : 'cursor-grab'}`}
         role="application"
         aria-label="Tidal volume chart. Synchronised with other charts."
         tabIndex={0}
         onKeyDown={viewport.handleKeyDown}
       >
+        {viewport.dragZoomOverlay.active && (
+          <div
+            className="pointer-events-none absolute inset-y-0 z-10 border-x border-primary/50 bg-primary/15"
+            style={{ left: `${viewport.dragZoomOverlay.leftPct}%`, width: `${viewport.dragZoomOverlay.widthPct}%` }}
+          />
+        )}
         <span className="pointer-events-none absolute bottom-1 right-2 z-10 select-none text-[9px] text-muted-foreground/70">
           airwaylab.app
         </span>

--- a/components/dashboard/graphs-tab.tsx
+++ b/components/dashboard/graphs-tab.tsx
@@ -137,7 +137,6 @@ function WaveformCharts({
             flow={flowData}
             pressure={pressureData}
             events={storedWaveform.events}
-
             visibleEventTypes={visibleTypes}
           />
         </ErrorBoundary>

--- a/hooks/use-chart-element-ref.ts
+++ b/hooks/use-chart-element-ref.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+
+/**
+ * Returns a stable ref callback that calls `attachToElement` when an element
+ * mounts and invokes the returned cleanup when it unmounts. Designed to work
+ * with the multi-element `attachToElement` API on `useChartViewport`.
+ */
+export function useChartElementRef(
+  attachToElement: (el: HTMLElement) => () => void,
+): (el: HTMLElement | null) => void {
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  return useCallback(
+    (el: HTMLElement | null) => {
+      if (cleanupRef.current) {
+        cleanupRef.current();
+        cleanupRef.current = null;
+      }
+      if (el) {
+        cleanupRef.current = attachToElement(el);
+      }
+    },
+    [attachToElement],
+  );
+}

--- a/hooks/use-chart-viewport.ts
+++ b/hooks/use-chart-viewport.ts
@@ -26,6 +26,14 @@ interface ChartViewportOpts {
   dateStr: string;
 }
 
+export interface DragZoomOverlay {
+  active: boolean;
+  /** Left edge as percent of chart width (0–100) */
+  leftPct: number;
+  /** Width as percent of chart width (0–100) */
+  widthPct: number;
+}
+
 export interface ChartViewportReturn {
   viewStartSec: number;
   viewEndSec: number;
@@ -44,6 +52,13 @@ export interface ChartViewportReturn {
   setViewStartSec: React.Dispatch<React.SetStateAction<number>>;
   setViewEndSec: React.Dispatch<React.SetStateAction<number>>;
   handleKeyDown: (e: React.KeyboardEvent) => void;
+  /** Attach wheel/dblclick/touch listeners to a chart element. Returns cleanup. */
+  attachToElement: (el: HTMLElement) => () => void;
+  /** When true, shift+drag selects a zoom range instead of panning. */
+  dragZoomMode: boolean;
+  setDragZoomMode: React.Dispatch<React.SetStateAction<boolean>>;
+  /** Overlay rect for range-select zoom, expressed as % of chart width. */
+  dragZoomOverlay: DragZoomOverlay;
   chartRef: (el: HTMLElement | null) => void;
 }
 
@@ -55,6 +70,14 @@ export function useChartViewport(opts: ChartViewportOpts): ChartViewportReturn {
   // Viewport state: time in seconds
   const [viewStartSec, setViewStartSec] = useState(0);
   const [viewEndSec, setViewEndSec] = useState(Infinity);
+
+  // Drag-zoom mode state
+  const [dragZoomMode, setDragZoomMode] = useState(false);
+  const [dragZoomOverlay, setDragZoomOverlay] = useState<DragZoomOverlay>({
+    active: false,
+    leftPct: 0,
+    widthPct: 0,
+  });
 
   // Refs for drag-to-pan
   const isDragging = useRef(false);
@@ -200,6 +223,10 @@ export function useChartViewport(opts: ChartViewportOpts): ChartViewportReturn {
 
   const durationRef = useRef(durationSeconds);
   durationRef.current = durationSeconds;
+
+  // Keep dragZoomMode in a ref so attachToElement closures read the latest value
+  const dragZoomModeRef = useRef(false);
+  dragZoomModeRef.current = dragZoomMode;
 
   const chartRef = useCallback((el: HTMLElement | null) => {
     if (elementRef.current === el) return;
@@ -349,6 +376,162 @@ export function useChartViewport(opts: ChartViewportOpts): ChartViewportReturn {
     };
   }, [elementVersion]);
 
+  // ── Imperative multi-element API ───────────────────────────
+
+  const attachToElement = useCallback((el: HTMLElement): (() => void) => {
+    // Wheel zoom (passive: false to allow preventDefault)
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const rect = el.getBoundingClientRect();
+      const centerFraction = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+      if (e.deltaY < 0) zoomInRef.current(centerFraction);
+      else zoomOutRef.current(centerFraction);
+    };
+
+    // Double-click resets to full view
+    const handleDblClick = () => {
+      setViewStartSec(0);
+      setViewEndSec(Infinity);
+    };
+
+    // Per-element drag state — each attached element gets its own closure
+    const drag = { active: false, isRange: false, startPct: 0, startX: 0, viewStart: 0, viewEnd: 0 };
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      const rect = el.getBoundingClientRect();
+      if (dragZoomModeRef.current) {
+        drag.active = true;
+        drag.isRange = true;
+        drag.startPct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+        setDragZoomOverlay({ active: true, leftPct: drag.startPct * 100, widthPct: 0 });
+      } else {
+        drag.active = true;
+        drag.isRange = false;
+        drag.startX = e.clientX;
+        drag.viewStart = clampedRef.current.start;
+        drag.viewEnd = clampedRef.current.end;
+        el.style.cursor = 'grabbing';
+      }
+    };
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!drag.active) return;
+      const rect = el.getBoundingClientRect();
+      if (drag.isRange) {
+        const currentPct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+        const leftPct = Math.min(drag.startPct, currentPct) * 100;
+        const widthPct = Math.abs(currentPct - drag.startPct) * 100;
+        setDragZoomOverlay({ active: true, leftPct, widthPct });
+      } else {
+        const dx = e.clientX - drag.startX;
+        const visible = drag.viewEnd - drag.viewStart;
+        const timeDelta = (-dx / rect.width) * visible;
+        const newStart = Math.max(0, Math.min(drag.viewStart + timeDelta, durationRef.current - visible));
+        setViewStartSec(newStart);
+        setViewEndSec(newStart + visible);
+      }
+    };
+
+    const handleMouseUp = (e: MouseEvent) => {
+      if (!drag.active) return;
+      if (drag.isRange) {
+        const rect = el.getBoundingClientRect();
+        const currentPct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+        const leftFrac = Math.min(drag.startPct, currentPct);
+        const rightFrac = Math.max(drag.startPct, currentPct);
+        if (rightFrac - leftFrac > 0.02) {
+          const cs = clampedRef.current.start;
+          const ce = clampedRef.current.end;
+          const visible = ce - cs;
+          setViewStartSec(cs + leftFrac * visible);
+          setViewEndSec(cs + rightFrac * visible);
+        }
+        setDragZoomOverlay({ active: false, leftPct: 0, widthPct: 0 });
+      } else {
+        el.style.cursor = dragZoomModeRef.current ? 'crosshair' : 'grab';
+      }
+      drag.active = false;
+    };
+
+    // Touch gesture handlers
+    const touch = { isPanning: false, isPinching: false, startX: 0, pinchDist: 0, viewStart: 0, viewEnd: 0 };
+    const getTouchDist = (t1: Touch, t2: Touch) =>
+      Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY);
+
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 2) {
+        touch.isPinching = true;
+        touch.isPanning = false;
+        touch.pinchDist = getTouchDist(e.touches[0]!, e.touches[1]!);
+        touch.viewStart = clampedRef.current.start;
+        touch.viewEnd = clampedRef.current.end;
+        e.preventDefault();
+      } else if (e.touches.length === 1) {
+        touch.isPanning = true;
+        touch.isPinching = false;
+        touch.startX = e.touches[0]!.clientX;
+        touch.viewStart = clampedRef.current.start;
+        touch.viewEnd = clampedRef.current.end;
+        e.preventDefault();
+      }
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (touch.isPinching && e.touches.length === 2) {
+        e.preventDefault();
+        const dist = getTouchDist(e.touches[0]!, e.touches[1]!);
+        const ratio = dist / touch.pinchDist;
+        if (ratio > 1.05) { zoomInRef.current(0.5); touch.pinchDist = dist; }
+        else if (ratio < 0.95) { zoomOutRef.current(0.5); touch.pinchDist = dist; }
+      } else if (touch.isPanning && e.touches.length === 1) {
+        e.preventDefault();
+        const rect = el.getBoundingClientRect();
+        const dx = e.touches[0]!.clientX - touch.startX;
+        const visible = touch.viewEnd - touch.viewStart;
+        const timeDelta = (-dx / rect.width) * visible;
+        const newStart = Math.max(0, Math.min(touch.viewStart + timeDelta, durationRef.current - visible));
+        setViewStartSec(newStart);
+        setViewEndSec(newStart + visible);
+      }
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (e.touches.length === 0) {
+        touch.isPanning = false;
+        touch.isPinching = false;
+      } else if (e.touches.length === 1 && touch.isPinching) {
+        touch.isPinching = false;
+        touch.isPanning = true;
+        touch.startX = e.touches[0]!.clientX;
+        touch.viewStart = clampedRef.current.start;
+        touch.viewEnd = clampedRef.current.end;
+      }
+    };
+
+    el.addEventListener('wheel', handleWheel, { passive: false });
+    el.addEventListener('dblclick', handleDblClick);
+    el.addEventListener('mousedown', handleMouseDown);
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    el.addEventListener('touchstart', handleTouchStart, { passive: false });
+    el.addEventListener('touchmove', handleTouchMove, { passive: false });
+    el.addEventListener('touchend', handleTouchEnd);
+
+    return () => {
+      el.removeEventListener('wheel', handleWheel);
+      el.removeEventListener('dblclick', handleDblClick);
+      el.removeEventListener('mousedown', handleMouseDown);
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+      el.removeEventListener('touchstart', handleTouchStart);
+      el.removeEventListener('touchmove', handleTouchMove);
+      el.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, []);
+
   return {
     viewStartSec,
     viewEndSec,
@@ -367,6 +550,10 @@ export function useChartViewport(opts: ChartViewportOpts): ChartViewportReturn {
     setViewStartSec,
     setViewEndSec,
     handleKeyDown,
+    attachToElement,
+    dragZoomMode,
+    setDragZoomMode,
+    dragZoomOverlay,
     chartRef,
   };
 }


### PR DESCRIPTION
## Summary

- Root cause: `useChartViewport` used a single-element `chartRef`, so wheel events only fired on whichever chart mounted last. Fixed by adding an imperative `attachToElement(el) → cleanup` API so each chart independently registers its own listeners.
- Added drag-range-select zoom (OSCAR/SleepHQ style): toolbar Crosshair button toggles mode, translucent overlay renders while dragging, mouseup zooms to selected range.
- Double-click resets to full range per-chart (not just globally).

## Changes

- `hooks/use-chart-viewport.ts` — new `attachToElement`, `dragZoomMode`, `dragZoomOverlay` state
- `hooks/use-chart-element-ref.ts` (new) — React ref callback adapter for `attachToElement`
- Chart components (`flow-waveform`, `spo2-trace`, `device-pressure-chart`, `tidal-volume-chart`, `respiratory-rate-chart`) — use `useChartElementRef` instead of `chartRef`
- `components/charts/shared-chart-toolbar.tsx` (new) — Crosshair toggle button for drag-select mode
- `__tests__/chart-viewport-wheel.test.ts` (new, 8 tests) — multi-element attach/cleanup, dblclick reset, dragZoom toggle

## Test plan

- [ ] Scroll wheel over every chart zooms (not just the final one)
- [ ] Crosshair toolbar button enables drag-to-range-select with visual overlay
- [ ] Double-click on any chart resets zoom to full view
- [ ] Mobile: pinch-zoom still works
- [ ] Synced viewport: all charts zoom together

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] E2e tests pass locally (for UI changes)
- [ ] Bundle size impact checked (flag if >10KB increase)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [ ] Self-review: no regressions, loading/error/empty states handled
- [x] PR contains one concern only

Closes AIR-1392

🤖 Generated with [Claude Code](https://claude.com/claude-code)