### PR TITLE
fix: partial device support detection gap (AirSense 11 ID + AirCurve 10 BiPAP signals + Discord alert)

### DIFF
--- a/__tests__/night-grouper.test.ts
+++ b/__tests__/night-grouper.test.ts
@@ -470,4 +470,43 @@ describe('findIdentificationFile', () => {
     ];
     expect(findIdentificationFile(files)).toBeNull();
   });
+
+  it('finds CurrentSettings.json in SETTINGS/ path (AirSense 11)', () => {
+    const files = [
+      { name: 'BRP.edf', path: 'DATALOG/20260315/BRP.edf' },
+      { name: 'CurrentSettings.json', path: 'SETTINGS/CurrentSettings.json' },
+    ];
+    expect(findIdentificationFile(files)).toEqual({
+      name: 'CurrentSettings.json',
+      path: 'SETTINGS/CurrentSettings.json',
+    });
+  });
+
+  it('does not match CurrentSettings.json outside a settings/ path', () => {
+    const files = [
+      { name: 'CurrentSettings.json', path: 'DATALOG/CurrentSettings.json' },
+    ];
+    expect(findIdentificationFile(files)).toBeNull();
+  });
+
+  it('is case-insensitive for currentsettings.json filename and settings/ path', () => {
+    const files = [
+      { name: 'currentsettings.json', path: 'Settings/currentsettings.json' },
+    ];
+    expect(findIdentificationFile(files)).toEqual({
+      name: 'currentsettings.json',
+      path: 'Settings/currentsettings.json',
+    });
+  });
+
+  it('prefers identification.tgt over currentsettings.json when both present', () => {
+    const files = [
+      { name: 'Identification.tgt', path: '/a/Identification.tgt' },
+      { name: 'CurrentSettings.json', path: 'SETTINGS/CurrentSettings.json' },
+    ];
+    expect(findIdentificationFile(files)).toEqual({
+      name: 'Identification.tgt',
+      path: '/a/Identification.tgt',
+    });
+  });
 });

--- a/__tests__/settings-extractor.test.ts
+++ b/__tests__/settings-extractor.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from 'vitest';
-import { parseIdentification, getSettingsForDate, sensitivityLabel } from '@/lib/parsers/settings-extractor';
+import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { resolve } from 'path';
+import { readFileSync } from 'fs';
+
+vi.mock('@/lib/parsers/edf-parser', async () => {
+  const actual = await vi.importActual('@/lib/parsers/edf-parser');
+  return { ...(actual as object), parseSTR: vi.fn() };
+});
+
+import { parseSTR } from '@/lib/parsers/edf-parser';
+import { extractSettings, getSTRSignalLabels, isAirSense11, parseIdentification, getSettingsForDate, sensitivityLabel } from '@/lib/parsers/settings-extractor';
 import type { MachineSettings } from '@/lib/types';
 
 describe('parseIdentification', () => {
@@ -194,6 +203,92 @@ describe('parseIdentification — AirCurve 11 nested JSON', () => {
   });
 });
 
+// ── extractSettings — AirCurve 10 VAuto fixes (AIR-1437) ──────────────────
+
+const mockParseSTR = parseSTR as ReturnType<typeof vi.fn>;
+
+function makeSignal(label: string, values: number[]) {
+  return { label, physicalValues: values, digitalValues: values };
+}
+
+function makeSTRResult(signals: ReturnType<typeof makeSignal>[]) {
+  return { header: {}, signals, startDateTime: new Date('2026-01-11T00:00:00Z') };
+}
+
+describe('extractSettings — AirCurve 10 VAuto', () => {
+  afterEach(() => {
+    mockParseSTR.mockReset();
+  });
+
+  it('maps mode 8 to VAuto for AirCurve 10 VAuto', () => {
+    mockParseSTR.mockReturnValue(makeSTRResult([
+      makeSignal('TgtIPAP.50', [15]),
+      makeSignal('TgtEPAP.50', [8]),
+      makeSignal('Mode', [8]),
+      makeSignal('Date', [0]),
+    ]));
+    const result = extractSettings(new ArrayBuffer(0), 'AirCurve 10 VAuto');
+    const dates = Object.keys(result);
+    expect(dates.length).toBeGreaterThan(0);
+    expect(result[dates[0]!]!.papMode).toBe('VAuto');
+  });
+
+  it('maps mode 8 to VAuto for AirCurve 11 VAuto', () => {
+    mockParseSTR.mockReturnValue(makeSTRResult([
+      makeSignal('TgtIPAP.50', [15]),
+      makeSignal('TgtEPAP.50', [8]),
+      makeSignal('Mode', [8]),
+      makeSignal('Date', [0]),
+    ]));
+    const result = extractSettings(new ArrayBuffer(0), 'AirCurve 11 VAuto');
+    const dates = Object.keys(result);
+    expect(dates.length).toBeGreaterThan(0);
+    expect(result[dates[0]!]!.papMode).toBe('VAuto');
+  });
+
+  it('maps mode 8 to iVAPS for AirCurve 10 ST-A (not VAuto)', () => {
+    mockParseSTR.mockReturnValue(makeSTRResult([
+      makeSignal('TgtIPAP.50', [15]),
+      makeSignal('TgtEPAP.50', [8]),
+      makeSignal('Mode', [8]),
+      makeSignal('Date', [0]),
+    ]));
+    // AirCurve 10 ST-A: mode 8 = iVAPS (not VAuto)
+    const result10 = extractSettings(new ArrayBuffer(0), 'AirCurve 10 ST-A');
+    const dates10 = Object.keys(result10);
+    expect(dates10.length).toBeGreaterThan(0);
+    expect(result10[dates10[0]!]!.papMode).toBe('iVAPS');
+  });
+
+  it('uses S.VA.Trigger exact-match over substring-matched S.S.Trigger for AirCurve 10', () => {
+    mockParseSTR.mockReturnValue(makeSTRResult([
+      makeSignal('TgtIPAP.50', [15]),
+      makeSignal('TgtEPAP.50', [8]),
+      makeSignal('Mode', [5]),
+      makeSignal('Date', [0]),
+      makeSignal('S.VA.Trigger', [3]),  // value 3 on 0-4 scale = 'high'
+      makeSignal('S.S.Trigger', [1]),   // substring match would give 'low'
+      makeSignal('S.VA.Cycle', [2]),
+    ]));
+    const result = extractSettings(new ArrayBuffer(0), 'AirCurve 10 VAuto');
+    const dates = Object.keys(result);
+    expect(dates.length).toBeGreaterThan(0);
+    expect(result[dates[0]!]!.trigger).toBe('high');
+  });
+
+  it('returns empty map when IPAP signal is missing (condition for SETTINGS_DIAGNOSTIC in worker)', () => {
+    mockParseSTR.mockReturnValue(makeSTRResult([
+      // TgtIPAP.50 intentionally absent
+      makeSignal('TgtEPAP.50', [8]),
+      makeSignal('Mode', [8]),
+      makeSignal('Date', [0]),
+    ]));
+    const result = extractSettings(new ArrayBuffer(0), 'AirCurve 10 VAuto');
+    // Empty result causes the worker to fire SETTINGS_DIAGNOSTIC with signal label list
+    expect(Object.keys(result).length).toBe(0);
+  });
+});
+
 describe('sensitivityLabel — AirCurve 11 scale', () => {
   it('maps old scale (0-4) correctly by default', () => {
     expect(sensitivityLabel(0)).toBe('very low');
@@ -224,5 +319,241 @@ describe('sensitivityLabel — AirCurve 11 scale', () => {
   it('returns raw number for unmapped values', () => {
     expect(sensitivityLabel(7)).toBe('7');
     expect(sensitivityLabel(0, true)).toBe('0');
+  });
+});
+
+// ── AirSense 11 — device detection and settings extraction ───────────────────
+
+describe('isAirSense11 — device detection helper', () => {
+  it('returns true for "AirSense 11 AutoSet"', () => {
+    expect(isAirSense11('AirSense 11 AutoSet')).toBe(true);
+  });
+
+  it('returns true for "AirSense 11 Elite"', () => {
+    expect(isAirSense11('AirSense 11 Elite')).toBe(true);
+  });
+
+  it('returns true for underscore-separated "AirSense_11_AutoSet"', () => {
+    expect(isAirSense11('AirSense_11_AutoSet')).toBe(true);
+  });
+
+  it('returns true for compact "AirSense11"', () => {
+    expect(isAirSense11('AirSense11')).toBe(true);
+  });
+
+  it('returns false for AirSense 10', () => {
+    expect(isAirSense11('AirSense 10 AutoSet')).toBe(false);
+  });
+
+  it('returns false for AirCurve 11 (bilevel, not CPAP)', () => {
+    expect(isAirSense11('AirCurve 11 VAuto')).toBe(false);
+  });
+
+  it('returns false for AirMini', () => {
+    expect(isAirSense11('AirMini AutoSet')).toBe(false);
+  });
+});
+
+describe('parseIdentification — AirSense 11 model strings', () => {
+  it('parses "AirSense 11 AutoSet" from top-level ModelNumber', () => {
+    expect(parseIdentification(JSON.stringify({ ModelNumber: 'AirSense 11 AutoSet' }))).toBe('AirSense 11 AutoSet');
+  });
+
+  it('parses "AirSense_11_AutoSet" (underscore firmware variant)', () => {
+    expect(parseIdentification(JSON.stringify({ ModelNumber: 'AirSense_11_AutoSet' }))).toBe('AirSense_11_AutoSet');
+  });
+
+  it('parses AS11 from FlowGenerator nested JSON (same structure as AirCurve 11)', () => {
+    const json = JSON.stringify({
+      FlowGenerator: {
+        IdentificationProfiles: {
+          Product: {
+            ProductName: 'AirSense11AutoSet',
+            SerialNumber: '12345678',
+          },
+        },
+      },
+    });
+    expect(parseIdentification(json)).toBe('AirSense11AutoSet');
+  });
+
+  it('confirms AS11 model string does NOT match AirCurve 11 detection regex', () => {
+    const model = parseIdentification(JSON.stringify({ ModelNumber: 'AirSense 11 AutoSet' }));
+    // isAC11 logic: normalize whitespace, check for 'aircurve11'
+    const normalised = model.replace(/\s/g, '').toLowerCase();
+    expect(normalised.includes('aircurve11')).toBe(false);
+    // But it IS detected as AirSense 11
+    expect(isAirSense11(model)).toBe(true);
+  });
+});
+
+describe('extractSettings — AirSense 11 (mocked STR signals)', () => {
+  afterEach(() => {
+    mockParseSTR.mockReset();
+  });
+
+  it('extracts CPAP settings from AS11 STR using standard AirSense signal names', () => {
+    mockParseSTR.mockReturnValue(makeSTRResult([
+      makeSignal('S.C.Press', [10]),
+      makeSignal('S.EPR.Level', [2]),
+      makeSignal('S.EPR.EPREnable', [1]),
+      makeSignal('Mode', [0]),   // CPAP
+      makeSignal('Date', [0]),
+    ]));
+    const result = extractSettings(new ArrayBuffer(0), 'AirSense 11 AutoSet');
+    const dates = Object.keys(result);
+    expect(dates.length).toBeGreaterThan(0);
+    const s = result[dates[0]!]!;
+    expect(s.ipap).toBe(10);
+    expect(s.epap).toBe(8);   // 10 - EPR level 2
+    expect(s.papMode).toBe('CPAP');
+    expect(s.deviceModel).toBe('AirSense 11 AutoSet');
+  });
+
+  it('falls back to S.EPR.LevelS when S.EPR.Level is absent (some AS11 firmware)', () => {
+    mockParseSTR.mockReturnValue(makeSTRResult([
+      makeSignal('S.C.Press', [12]),
+      makeSignal('S.EPR.LevelS', [3]),  // firmware variant label
+      makeSignal('S.EPR.EPREnable', [1]),
+      makeSignal('Mode', [2]),   // AutoSet
+      makeSignal('Date', [0]),
+    ]));
+    const result = extractSettings(new ArrayBuffer(0), 'AirSense 11 AutoSet');
+    const dates = Object.keys(result);
+    expect(dates.length).toBeGreaterThan(0);
+    const s = result[dates[0]!]!;
+    expect(s.ipap).toBe(12);
+    expect(s.epap).toBe(9);   // 12 - EPR level 3
+    expect(s.papMode).toBe('AutoSet');
+  });
+
+  it('does NOT apply AirCurve 11 sensitivity scale (1-5) for AS11 trigger values', () => {
+    mockParseSTR.mockReturnValue(makeSTRResult([
+      makeSignal('S.C.Press', [10]),
+      makeSignal('S.EPR.Level', [0]),
+      makeSignal('S.EPR.EPREnable', [0]),
+      makeSignal('S.Trigger', [3]),
+      makeSignal('S.Cycle', [3]),
+      makeSignal('Mode', [0]),
+      makeSignal('Date', [0]),
+    ]));
+    const result = extractSettings(new ArrayBuffer(0), 'AirSense 11 AutoSet');
+    const s = result[Object.keys(result)[0]!]!;
+    // AS11 is not an AirCurve 11 — must use 0-4 scale: value 3 = 'high', not 'medium'
+    expect(s.trigger).toBe('high');
+    expect(s.cycle).toBe('high');
+  });
+});
+
+// ── extractSettings — AirCurve 10 VAuto integration (real STR.edf fixture) ──
+//
+// Signal labels found in __tests__/fixtures/sd-card/STR.edf (97 signals):
+// Date, MaskOn, MaskOff, MaskEvents, Duration, OnDuration, PatientHours, Mode,
+// S.RampEnable, S.RampTime, S.C.StartPress, S.C.Press, S.EPR.ClinEnable,
+// S.EPR.EPREnable, S.EPR.Level, S.EPR.EPRType, S.BL.StartPress, S.BL.IPAP,
+// S.BL.EPAP, S.EasyBreathe, S.VA.StartPress, S.VA.MaxIPAP, S.VA.MinEPAP,
+// S.VA.PS, S.RiseEnable, S.RiseTime, S.Cycle, S.Trigger, S.TiMax, S.TiMin,
+// S.SmartStart, S.PtAccess, S.ABFilter, S.LeakAlert, S.Mask, S.Tube,
+// S.ClimateControl, S.HumEnable, S.HumLevel, S.TempEnable, S.Temp,
+// HeatedTube, Humidifier, BlowPress.95, BlowPress.5, Flow.95, Flow.5,
+// BlowFlow.50, AmbHumidity.50, HumTemp.50, HTubeTemp.50, HTubePow.50,
+// HumPow.50, SpO2.50, SpO2.95, SpO2.Max, SpO2Thresh, SpontCyc%,
+// MaskPress.50, MaskPress.95, MaskPress.Max, TgtIPAP.50, TgtIPAP.95,
+// TgtIPAP.Max, TgtEPAP.50, TgtEPAP.95, TgtEPAP.Max, Leak.50, Leak.95,
+// Leak.70, Leak.Max, MinVent.50, MinVent.95, MinVent.Max, RespRate.50,
+// RespRate.95, RespRate.Max, TidVol.50, TidVol.95, TidVol.Max, IERatio.50,
+// IERatio.95, IERatio.Max, Ti.50, Ti.95, Ti.Max, AHI, HI, AI, OAI, CAI,
+// UAI, Fault.Device, Fault.Alarm, Fault.Humidifier, Fault.HeatedTube, Crc16
+//
+// Key firmware signal name differences from what prior code expected:
+//   S.HumLevel      (not S.Humid.Level / S.HumidLevel)
+//   S.Temp          (not S.TubeTemp / S.Tube.Temp)
+//   S.VA.StartPress (ramp start press for VAuto mode, not S.RampPress)
+
+describe('extractSettings — AirCurve 10 VAuto integration (real STR.edf)', () => {
+  beforeEach(async () => {
+    const { parseSTR: realParseSTR } = await vi.importActual<typeof import('@/lib/parsers/edf-parser')>('@/lib/parsers/edf-parser');
+    mockParseSTR.mockImplementation(realParseSTR as typeof parseSTR);
+  });
+
+  afterEach(() => {
+    mockParseSTR.mockReset();
+  });
+
+  function loadStrFixture(): ArrayBuffer {
+    const fixturePath = resolve(process.cwd(), '__tests__/fixtures/sd-card/STR.edf');
+    const nodeBuf = readFileSync(fixturePath);
+    return nodeBuf.buffer.slice(nodeBuf.byteOffset, nodeBuf.byteOffset + nodeBuf.byteLength) as ArrayBuffer;
+  }
+
+  it('getSTRSignalLabels enumerates 97 signals including TgtIPAP.50 and TgtEPAP.50', () => {
+    const ab = loadStrFixture();
+    const labels = getSTRSignalLabels(ab);
+    expect(labels).toHaveLength(97);
+    expect(labels).toContain('TgtIPAP.50');
+    expect(labels).toContain('TgtEPAP.50');
+    expect(labels).toContain('S.Trigger');
+    expect(labels).toContain('S.Cycle');
+    expect(labels).toContain('S.HumLevel');
+    expect(labels).toContain('S.Temp');
+    expect(labels).toContain('S.VA.StartPress');
+  });
+
+  it('extractSettings returns non-empty map with valid IPAP/EPAP for AirCurve 10 VAuto', () => {
+    const ab = loadStrFixture();
+    const result = extractSettings(ab, 'AirCurve_10_VAuto');
+    const dates = Object.keys(result).sort();
+    expect(dates.length).toBeGreaterThan(0);
+
+    // Fixture has valid therapy data from 2025-02-15 through 2026-03-10
+    const firstDate = dates[0]!;
+    const s = result[firstDate]!;
+    expect(s.ipap).toBeGreaterThan(0);
+    expect(s.epap).toBeGreaterThan(0);
+    expect(s.pressureSupport).toBeGreaterThanOrEqual(0);
+    expect(s.deviceModel).toBe('AirCurve_10_VAuto');
+  });
+
+  it('extracts correct IPAP=18 EPAP=10 for 2026-03-09 (last DATALOG night)', () => {
+    const ab = loadStrFixture();
+    const result = extractSettings(ab, 'AirCurve_10_VAuto');
+    const s = result['2026-03-09'];
+    expect(s).not.toBeUndefined();
+    expect(s!.ipap).toBe(18);
+    expect(s!.epap).toBe(10);
+    expect(s!.pressureSupport).toBe(8);
+  });
+
+  it('extracts non-N/A trigger and cycle from S.Trigger/S.Cycle signals', () => {
+    const ab = loadStrFixture();
+    const result = extractSettings(ab, 'AirCurve_10_VAuto');
+    const s = result['2026-03-09']!;
+    // S.Trigger = 3 → 'high', S.Cycle = 2 → 'medium' on 0-4 scale
+    expect(s.trigger).not.toBe('N/A');
+    expect(s.cycle).not.toBe('N/A');
+  });
+
+  it('extracts humidifierLevel from S.HumLevel signal (not S.Humid.Level)', () => {
+    const ab = loadStrFixture();
+    const result = extractSettings(ab, 'AirCurve_10_VAuto');
+    const s = result['2026-03-09']!;
+    // S.HumLevel = 4 in fixture
+    expect(s.humidifierLevel).toBe(4);
+  });
+
+  it('extracts tubeTempSetting from S.Temp signal (not S.TubeTemp)', () => {
+    const ab = loadStrFixture();
+    const result = extractSettings(ab, 'AirCurve_10_VAuto');
+    const s = result['2026-03-09']!;
+    // S.Temp = 25 in fixture
+    expect(s.tubeTempSetting).toBe(25);
+  });
+
+  it('extracts rampPressure from S.VA.StartPress signal (not S.RampPress)', () => {
+    const ab = loadStrFixture();
+    const result = extractSettings(ab, 'AirCurve_10_VAuto');
+    const s = result['2026-03-09']!;
+    // S.VA.StartPress = 4.0 in fixture
+    expect(s.rampPressure).toBe(4);
   });
 });

--- a/app/api/device-diagnostic/route.ts
+++ b/app/api/device-diagnostic/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
+import { sendAlert, formatUserSignalEmbed } from '@/lib/discord-webhook';
 
 const limiter = new RateLimiter({ windowMs: 3_600_000, max: 5 });
 
@@ -58,6 +59,11 @@ export async function POST(request: NextRequest) {
       if (error) {
         console.error('[device-diagnostic] Supabase error:', error.message);
         Sentry.captureException(error, { tags: { route: 'device-diagnostic' } });
+      } else {
+        void sendAlert('user-signals', '', [formatUserSignalEmbed({
+          type: 'unsupported_device',
+          message: `Settings extraction failed - model: ${deviceModel}, hasStr: ${hasStrFile}`,
+        })]);
       }
     }
 

--- a/lib/parsers/night-grouper.ts
+++ b/lib/parsers/night-grouper.ts
@@ -209,7 +209,10 @@ export function findIdentificationFile(
   return (
     files.find((f) => {
       const name = f.name.toLowerCase();
-      return name === 'identification.tgt' || name === 'identification.json';
+      const path = f.path.toLowerCase();
+      return name === 'identification.tgt'
+        || name === 'identification.json'
+        || (name === 'currentsettings.json' && path.includes('settings/'));
     }) ?? null
   );
 }

--- a/lib/parsers/settings-extractor.ts
+++ b/lib/parsers/settings-extractor.ts
@@ -57,9 +57,12 @@ const TYPED_SIGNAL_LABELS = new Set([
   'S.RiseTime', 'S.Trigger', 'S.Cycle', 'S.EasyBreathe',
   'S.EPR.Level', 'S.EPR.EPREnable', 'S.C.Press',
   'S.VA.Trigger', 'S.VA.Cycle', // AirCurve 11 VAuto-specific signals
-  'S.RampEnable', 'S.RampTime', 'S.RampPress',
-  'S.Humid.Level', 'S.HumidLevel', 'S.ClimateControl', 'S.Humid.Status',
-  'S.TubeTemp', 'S.Tube.Temp', 'S.Mask', 'S.SmartStart',
+  'S.RampEnable', 'S.RampTime',
+  'S.RampPress', 'S.VA.StartPress', 'S.C.StartPress', // ramp start pressure variants
+  'S.Humid.Level', 'S.HumidLevel', 'S.HumLevel', // humidity level variants (firmware varies)
+  'S.ClimateControl', 'S.Humid.Status',
+  'S.TubeTemp', 'S.Tube.Temp', 'S.Temp', // tube temp variants (firmware varies)
+  'S.Mask', 'S.SmartStart',
   'S.TiMax', 'S.TiMin',
 ]);
 
@@ -77,6 +80,13 @@ export function extractSettings(strBuffer: ArrayBuffer, deviceModel: string): Da
   console.error(`[settings] STR.edf signals (${allLabels.length}): ${allLabels.join(', ')}`);
 
   const isAC11 = deviceModel.replace(/\s/g, '').toLowerCase().includes('aircurve11');
+  // AirCurve devices (10 and 11) share VAuto signal names; used for S.VA.* signal selection
+  const isAirCurveDevice = deviceModel.replace(/\s/g, '').toLowerCase().includes('aircurve');
+  // VAuto devices use mode 8 for VAuto; AirCurve 10 ST-A uses mode 8 for iVAPS (different firmware)
+  const isVAutoDevice = deviceModel.replace(/\s/g, '').toLowerCase().includes('vauto');
+  // AirSense 11 — CPAP/APAP device. Uses same STR signal names as AirSense 10 per firmware audit.
+  // Tracked separately for diagnostics and future AS11-specific handling.
+  const isAS11 = /airsense[\s_]?11/i.test(deviceModel);
 
   const findSignal = (substring: string) =>
     signals.find((s) => s.label.includes(substring));
@@ -91,27 +101,41 @@ export function extractSettings(strBuffer: ArrayBuffer, deviceModel: string): Da
   const modeSignal = findSignal('Mode');
   const dateSignal = findSignal('Date');
   const riseTimeSignal = findSignal('S.RiseTime');
-  // AirCurve 11 VAuto uses S.VA.Trigger/S.VA.Cycle signals.
+  // AirCurve devices (10+11) use S.VA.Trigger/S.VA.Cycle for VAuto mode.
   // findSignal('S.Trigger') would match S.S.Trigger (Spont mode) via substring,
-  // so prefer S.VA.* exact matches for AirCurve 11 devices, falling back to generic.
-  const triggerSignal = isAC11
+  // so prefer S.VA.* exact matches for any AirCurve device, falling back to generic.
+  const triggerSignal = isAirCurveDevice
     ? (findSignalExact('S.VA.Trigger') ?? findSignal('S.Trigger'))
     : findSignal('S.Trigger');
-  const cycleSignal = isAC11
+  const cycleSignal = isAirCurveDevice
     ? (findSignalExact('S.VA.Cycle') ?? findSignal('S.Cycle'))
     : findSignal('S.Cycle');
   const easyBreatheSignal = findSignal('S.EasyBreathe');
-  const eprLevelSignal = findSignal('S.EPR.Level');
+  // S.EPR.LevelS is an alternate label seen in some AirSense 11 firmware versions
+  const eprLevelSignal = findSignalExact('S.EPR.Level') ?? findSignalExact('S.EPR.LevelS');
   const eprEnableSignal = findSignal('S.EPR.EPREnable');
   const cpapPressSignal = findSignal('S.C.Press');
 
   // Comfort/environment signals
   const rampEnableSignal = findSignal('S.RampEnable');
   const rampTimeSignal = findSignal('S.RampTime');
-  const rampPressSignal = findSignal('S.RampPress');
-  const humidLevelSignal = findSignal('S.Humid.Level') ?? findSignal('S.HumidLevel');
+  // AirCurve 10 uses S.VA.StartPress; AirSense CPAP uses S.C.StartPress; legacy uses S.RampPress
+  const rampPressSignal =
+    findSignal('S.RampPress') ??
+    findSignalExact('S.VA.StartPress') ??
+    findSignalExact('S.C.StartPress');
+  // Humidity signal name varies by firmware: S.Humid.Level → S.HumidLevel → S.HumLevel
+  const humidLevelSignal =
+    findSignal('S.Humid.Level') ??
+    findSignal('S.HumidLevel') ??
+    findSignalExact('S.HumLevel');
   const climateControlSignal = findSignal('S.ClimateControl') ?? findSignal('S.Humid.Status');
-  const tubeTempSignal = findSignal('S.TubeTemp') ?? findSignal('S.Tube.Temp');
+  // Tube temp signal name varies by firmware: S.TubeTemp → S.Tube.Temp → S.Temp
+  // Use exact match for S.Temp to avoid matching S.TempEnable via substring
+  const tubeTempSignal =
+    findSignalExact('S.TubeTemp') ??
+    findSignalExact('S.Tube.Temp') ??
+    findSignalExact('S.Temp');
   const maskSignal = findSignal('S.Mask');
   const smartStartSignal = findSignal('S.SmartStart');
   const tiMaxSignal = findSignal('S.TiMax');
@@ -128,7 +152,12 @@ export function extractSettings(strBuffer: ArrayBuffer, deviceModel: string): Da
   const isAirCurve = !!(targetIPAP && targetEPAP);
   const isAirSense = !!(cpapPressSignal && eprLevelSignal && eprEnableSignal && !targetIPAP);
 
-  if (!isAirCurve && !isAirSense) return dailySettings;
+  if (!isAirCurve && !isAirSense) {
+    if (isAS11) {
+      console.error(`[settings] AirSense 11 detected but device type could not be determined from STR signals. Expected S.C.Press + S.EPR.Level + S.EPR.EPREnable. Found: ${allLabels.join(', ')}`);
+    }
+    return dailySettings;
+  }
 
   const dates = dateSignal.physicalValues;
 
@@ -206,9 +235,10 @@ export function extractSettings(strBuffer: ArrayBuffer, deviceModel: string): Da
       }
     }
 
-    // AirCurve 11 uses mode 8 for VAuto, not iVAPS
+    // VAuto devices (AC10 VAuto and AC11) use mode 8 for VAuto, not iVAPS.
+    // AirCurve 10 ST-A uses mode 8 for iVAPS and must NOT be remapped.
     let papMode = MODE_MAP[modeNum] ?? `Mode ${modeNum}`;
-    if (isAC11 && modeNum === 8) {
+    if (isVAutoDevice && modeNum === 8) {
       papMode = 'VAuto';
     }
 
@@ -238,6 +268,14 @@ export function extractSettings(strBuffer: ArrayBuffer, deviceModel: string): Da
   }
 
   return dailySettings;
+}
+
+/**
+ * Returns true when the device model string identifies an AirSense 11 device.
+ * Exported for unit testing device-detection logic without requiring EDF fixture data.
+ */
+export function isAirSense11(deviceModel: string): boolean {
+  return /airsense[\s_]?11/i.test(deviceModel);
 }
 
 /**

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -158,10 +158,8 @@ async function processFiles(
       } catch {
         // Machine summary extraction failed — continue without summary
       }
-      // Capture signal labels for diagnostics when extraction returns empty
-      if (Object.keys(dailySettings).length === 0) {
-        strSignalLabels = getSTRSignalLabels(strFile.buffer);
-      }
+      // Always capture signal labels — needed for both empty-settings and AirCurve partial-support diagnostics
+      strSignalLabels = getSTRSignalLabels(strFile.buffer);
     }
   }
 
@@ -175,6 +173,23 @@ async function processFiles(
       hasStrFile: !!strFileInfo,
     };
     self.postMessage(diag);
+  }
+
+  // Post diagnostic when AirCurve 10 STR has settings but is missing expected BiPAP signals
+  if (Object.keys(dailySettings).length > 0 && deviceModel.toLowerCase().includes('aircurve')) {
+    const expectedBiPAP = ['PS_Min', 'PS_Max', 'SpMode', 'Spont'];
+    const anyMissing = expectedBiPAP.some(
+      (s) => !strSignalLabels.some((l) => l.toLowerCase().includes(s.toLowerCase()))
+    );
+    if (anyMissing) {
+      self.postMessage({
+        type: 'SETTINGS_DIAGNOSTIC',
+        deviceModel,
+        signalLabels: strSignalLabels,
+        identificationText: identificationText ? identificationText.slice(0, 2000) : null,
+        hasStrFile: !!strFileInfo,
+      } satisfies WorkerSettingsDiagnostic);
+    }
   }
 
   postProgress(1, brpFiles.length + 2, 'Parsing EDF files...');


### PR DESCRIPTION
## Summary

- **Part 1** (`lib/parsers/night-grouper.ts`): `findIdentificationFile` now matches `SETTINGS/CurrentSettings.json` so AirSense 11 uploads return a real device model instead of `Unknown`
- **Part 2** (`app/api/device-diagnostic/route.ts`): Discord `#user-signals` alert fires after each successful Supabase insert, giving ops real-time pings on unsupported devices
- **Part 3** (`workers/analysis-worker.ts`): STR signal labels are captured unconditionally (not just on empty-settings path), and a second `SETTINGS_DIAGNOSTIC` fires when an AirCurve device has settings but is missing expected BiPAP signals (`PS_Min`, `PS_Max`, `SpMode`, `Spont`)
- **Tests** (`__tests__/night-grouper.test.ts`): 4 new cases covering AirSense 11 `CurrentSettings.json` path detection

Closes AIR-1439. Follow-up to AIR-1436 investigation and AIR-1437 AirCurve 10 extraction fixes (both commits on this branch).

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes (upload-hash-cache timeout is pre-existing on main)
- [ ] `npm run build` passes
- [ ] Upload AirSense 11 SD card — device model shows non-Unknown value
- [ ] Upload AirCurve 10 SD card with missing BiPAP signals — SETTINGS_DIAGNOSTIC fires and appears in Discord #user-signals

## Pre-merge checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Bundle size impact checked (flag if >10KB increase)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [ ] Self-review: no regressions, loading/error/empty states handled
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)