### PR TITLE
fix(device-diagnostic): dedup unsupported_device Discord alerts per model 24h TTL (AIR-1459)

### DIFF
--- a/__tests__/device-diagnostic-dedup.test.ts
+++ b/__tests__/device-diagnostic-dedup.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/discord-webhook', () => ({
+  sendAlert: vi.fn().mockResolvedValue(true),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+}))
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseAdmin: vi.fn().mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    }),
+  }),
+}))
+
+vi.mock('@/lib/csrf', () => ({
+  validateOrigin: vi.fn().mockReturnValue(true),
+}))
+
+vi.mock('@/lib/rate-limit', () => {
+  const isLimited = vi.fn().mockResolvedValue(false)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function RateLimiter(this: any) { this.isLimited = isLimited }
+  return { RateLimiter, getRateLimitKey: vi.fn().mockReturnValue('test-ip') }
+})
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}))
+
+import { POST } from '@/app/api/device-diagnostic/route'
+import { __resetForTests } from '@/app/api/device-diagnostic/_dedup'
+import { sendAlert } from '@/lib/discord-webhook'
+
+const mockSendAlert = sendAlert as ReturnType<typeof vi.fn>
+
+function makeRequest(deviceModel: string, hasStrFile = false): NextRequest {
+  return new NextRequest('http://localhost/api/device-diagnostic', {
+    method: 'POST',
+    body: JSON.stringify({
+      deviceModel,
+      signalLabels: ['Flow'],
+      identificationText: null,
+      hasStrFile,
+    }),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('device-diagnostic dedup', () => {
+  beforeEach(() => {
+    __resetForTests()
+    mockSendAlert.mockClear()
+  })
+
+  it('fires 1 alert for 10 calls with the same device model', async () => {
+    for (let i = 0; i < 10; i++) {
+      await POST(makeRequest('ResMed-AirSense10'))
+    }
+    expect(mockSendAlert).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires 2 alerts for two distinct device models (5 calls each)', async () => {
+    for (let i = 0; i < 5; i++) {
+      await POST(makeRequest('ResMed-AirSense10'))
+    }
+    for (let i = 0; i < 5; i++) {
+      await POST(makeRequest('Philips-DreamStation'))
+    }
+    expect(mockSendAlert).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-fires alert for same model after 24h TTL elapses', async () => {
+    let fakeNow = Date.now()
+    vi.spyOn(Date, 'now').mockImplementation(() => fakeNow)
+
+    await POST(makeRequest('ResMed-AirSense10'))
+    expect(mockSendAlert).toHaveBeenCalledTimes(1)
+
+    // Still within 24h — no second alert
+    await POST(makeRequest('ResMed-AirSense10'))
+    expect(mockSendAlert).toHaveBeenCalledTimes(1)
+
+    // Advance past 24h window
+    fakeNow += 24 * 60 * 60 * 1000 + 1
+
+    await POST(makeRequest('ResMed-AirSense10'))
+    expect(mockSendAlert).toHaveBeenCalledTimes(2)
+
+    vi.restoreAllMocks()
+  })
+
+  it('writes device_diagnostics row on every request regardless of dedup state', async () => {
+    const { getSupabaseAdmin } = await import('@/lib/supabase/server')
+    const insertSpy = vi.fn().mockResolvedValue({ error: null })
+    ;(getSupabaseAdmin as ReturnType<typeof vi.fn>).mockReturnValue({
+      from: vi.fn().mockReturnValue({ insert: insertSpy }),
+    })
+
+    const callCount = 10
+    for (let i = 0; i < callCount; i++) {
+      await POST(makeRequest('ResMed-AirSense10'))
+    }
+
+    expect(insertSpy).toHaveBeenCalledTimes(callCount)
+  })
+})

--- a/app/api/device-diagnostic/_dedup.ts
+++ b/app/api/device-diagnostic/_dedup.ts
@@ -1,0 +1,10 @@
+export const DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000
+
+export const deviceModelLastAlertTs = new Map<string, number>()
+export const deviceModelHitCount = new Map<string, number>()
+
+/** Exported only for unit tests — do not call in production code. */
+export function __resetForTests(): void {
+  deviceModelLastAlertTs.clear()
+  deviceModelHitCount.clear()
+}

--- a/app/api/device-diagnostic/route.ts
+++ b/app/api/device-diagnostic/route.ts
@@ -5,6 +5,7 @@ import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import { sendAlert, formatUserSignalEmbed } from '@/lib/discord-webhook';
+import { DEDUP_WINDOW_MS, deviceModelLastAlertTs, deviceModelHitCount } from './_dedup';
 
 const limiter = new RateLimiter({ windowMs: 3_600_000, max: 5 });
 
@@ -59,12 +60,21 @@ export async function POST(request: NextRequest) {
       if (error) {
         console.error('[device-diagnostic] Supabase error:', error.message);
         Sentry.captureException(error, { tags: { route: 'device-diagnostic' } });
-      } else {
-        void sendAlert('user-signals', '', [formatUserSignalEmbed({
-          type: 'unsupported_device',
-          message: `Settings extraction failed - model: ${deviceModel}, hasStr: ${hasStrFile}`,
-        })]);
       }
+    }
+
+    const now = Date.now();
+    const lastAlert = deviceModelLastAlertTs.get(deviceModel) ?? 0;
+    const hitCount = (deviceModelHitCount.get(deviceModel) ?? 0) + 1;
+    deviceModelHitCount.set(deviceModel, hitCount);
+
+    if (now - lastAlert > DEDUP_WINDOW_MS) {
+      deviceModelLastAlertTs.set(deviceModel, now);
+      deviceModelHitCount.set(deviceModel, 0);
+      void sendAlert('user-signals', '', [formatUserSignalEmbed({
+        type: 'unsupported_device',
+        message: `Settings extraction failed — model: ${deviceModel}, hasStr: ${hasStrFile} (${hitCount} hit${hitCount !== 1 ? 's' : ''} in last 24h)`,
+      })]);
     }
 
     return NextResponse.json({ ok: true });


### PR DESCRIPTION
## Summary

Fixes Discord alert flood from PR #736 regression (AIR-1459).

PR #736 added a `sendAlert` call on every `device_diagnostics` insert — no dedup, no throttle. With multiple unsupported-device users, this fans out to ops channel flood.

**Changes:**
- `app/api/device-diagnostic/_dedup.ts` — module-level Maps (`deviceModelLastAlertTs`, `deviceModelHitCount`) with 24h TTL, `__resetForTests` export for unit test isolation
- `app/api/device-diagnostic/route.ts` — replaced bare `sendAlert` with dedup-wrapped logic; DB insert still fires unconditionally on every request
- `__tests__/device-diagnostic-dedup.test.ts` — 4 test cases: same-model dedup (10→1 alert), multi-model (2 models→2 alerts), TTL expiry re-fire, DB insert fires on all calls

**Behaviour:**
- First occurrence of a model: fires immediately
- Subsequent occurrences within 24h: suppressed, counter incremented
- After 24h: fires again with `(N hits in last 24h)` suffix in message
- `device_diagnostics` row: written unconditionally (data capture is dedup-blind)

## Test plan

- [ ] `npm test` passes (all 4 new dedup cases)
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Post-merge: verify Discord ops channel returns to baseline volume
- [ ] Post-merge: confirm `device_diagnostics` row written for every upload

## Related

- Closes AIR-1459
- Child of AIR-1436/AIR-1437 (trigger gap fix shipped via #736)
- Sub-dependency of AIR-1426 (device-expansion roadmap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)