### PR TITLE
fix(persistence): catch RangeError in trySerialise + worker progress yield (AIR-1433, AIR-1432)

### DIFF
--- a/__tests__/persistence.test.ts
+++ b/__tests__/persistence.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { persistResults, loadPersistedResults, clearPersistedResults, clearPersistedNights } from '@/lib/persistence';
 import { SAMPLE_NIGHTS } from '@/lib/sample-data';
 
@@ -147,6 +147,54 @@ describe('persistence', () => {
       const saved = storage.get('airwaylab_results');
       const parsed = JSON.parse(saved!);
       expect(parsed.nights[0].csl).toBeNull();
+    });
+
+    describe('RangeError handling (AIR-1433)', () => {
+      afterEach(() => { vi.restoreAllMocks(); });
+
+      it('does not throw when JSON.stringify raises RangeError (V8 string-length overflow)', () => {
+        // RangeError: Invalid string length fires inside JSON.stringify before any size guard runs.
+        // The outer persistResults catch must handle it gracefully rather than crashing the page.
+        vi.spyOn(JSON, 'stringify').mockImplementation(() => {
+          throw new RangeError('Invalid string length');
+        });
+
+        let result: ReturnType<typeof persistResults>;
+        expect(() => { result = persistResults(SAMPLE_NIGHTS, null); }).not.toThrow();
+        expect(result!.saved).toBe(false);
+        expect(result!.nightsSaved).toBe(0);
+        expect(result!.nightsDropped).toBe(SAMPLE_NIGHTS.length);
+      });
+
+      it('falls back to binary-search subset when JSON.stringify throws RangeError for large payloads only (AIR-1433 regression)', () => {
+        // Root cause of AIR-1433: trySerialise propagates RangeError instead of returning null,
+        // which breaks out of the binary search and causes a total save failure even when a
+        // smaller subset of nights would have fitted.
+        // After the fix (try-catch inside trySerialise), binary search converges to 1 night.
+        if (SAMPLE_NIGHTS.length < 2) return;
+
+        const originalStringify = JSON.stringify;
+        vi.spyOn(JSON, 'stringify').mockImplementation((...args: Parameters<typeof JSON.stringify>) => {
+          const first = args[0];
+          if (
+            first !== null &&
+            typeof first === 'object' &&
+            'nights' in (first as object) &&
+            Array.isArray((first as { nights: unknown }).nights) &&
+            (first as { nights: unknown[] }).nights.length >= 2
+          ) {
+            throw new RangeError('Invalid string length');
+          }
+          return originalStringify(...args);
+        });
+
+        const result = persistResults(SAMPLE_NIGHTS, null);
+
+        // Fixed behaviour: binary search saves the largest subset that serialises (1 night here).
+        expect(result.saved).toBe(true);
+        expect(result.nightsSaved).toBe(1);
+        expect(result.nightsDropped).toBe(SAMPLE_NIGHTS.length - 1);
+      });
     });
 
     it('reports size diagnostics in Sentry on total failure', () => {

--- a/lib/persistence.ts
+++ b/lib/persistence.ts
@@ -62,7 +62,16 @@ function trySerialise(
     savedAt: Date.now(),
     engineVersion: ENGINE_VERSION,
   };
-  const json = JSON.stringify(data);
+
+  let json: string;
+  try {
+    json = JSON.stringify(data);
+  } catch {
+    // JSON.stringify can throw RangeError: Invalid string length when the payload approaches
+    // V8's ~512MB string-length cap. Return null so the caller's binary-search can retry
+    // with a smaller slice rather than propagating the exception to persistResults' catch.
+    return null;
+  }
 
   if (json.length * 2 <= MAX_STORAGE_BYTES) {
     return { json, nightCount: nights.length };

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -392,7 +392,8 @@ async function processFiles(
   const oximetryByDate = new Map<string, ReturnType<typeof parseOximetryCSV>>();
   const sa2Files = filterSA2Files(fileList);
   if (sa2Files.length > 0) {
-    for (const sa2Info of sa2Files) {
+    for (let idx = 0; idx < sa2Files.length; idx++) {
+      const sa2Info = sa2Files[idx]!;
       const fileData = files.find((f) => f.path === sa2Info.path);
       if (!fileData) continue;
       try {
@@ -414,6 +415,10 @@ async function processFiles(
       } catch (err) {
         const filename = sa2Info.path.split('/').pop() || sa2Info.path;
         console.error(`[sa2] Failed to parse ${filename}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      if ((idx + 1) % PARSE_BATCH_SIZE === 0) {
+        postProgress(1, brpFiles.length + 2, `Parsing SA2 files (${idx + 1}/${sa2Files.length})...`);
+        await yieldControl();
       }
     }
   }


### PR DESCRIPTION
## Summary

- **AIR-1433**: `trySerialise` now wraps `JSON.stringify` in try-catch. `RangeError: Invalid string length` is caught and returns `null` so the binary-search fallback in `persistResults` can save a partial subset of nights rather than failing completely.
- **AIR-1432**: SA2 oximetry parse loop now yields via batched progress to prevent idle-timer false positives during heavy parse.
- Regression test (commit `93c745e`) confirms the binary-search behaviour for AIR-1433.

## Test plan

- [ ] `npx vitest run __tests__/persistence.test.ts` — 24 tests pass (including 2 new AIR-1433 regression tests)
- [ ] `npx vitest run __tests__/worker-idle-timeout.test.ts` — 6 tests pass
- [ ] Full suite: 2186 tests, 138 files — all passing (verified by pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)