### PR TITLE
fix: use maybeSingle() for profiles query (AIR-1486)

### DIFF
--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -58,12 +58,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const fetchProfile = useCallback(async (userId: string) => {
     if (!supabase) return;
 
-    // M1: Handle query errors instead of swallowing them
     const { data: profileData, error: profileError } = await supabase
       .from('profiles')
       .select('id, email, display_name, tier, stripe_customer_id, show_on_supporters, walkthrough_completed, email_opt_in, discord_id, discord_username')
       .eq('id', userId)
-      .single();
+      .maybeSingle();
 
     if (profileError) {
       // "Lock was stolen" is transient Supabase SSR lock contention -- suppress
@@ -78,25 +77,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    // M2: Safe field mapping instead of unsafe cast
-    if (profileData) {
-      const validTiers: Tier[] = ['community', 'supporter', 'champion'];
-      const profileTier = validTiers.includes(profileData.tier) ? profileData.tier : 'community';
-      setProfile({
-        id: profileData.id,
-        email: profileData.email,
-        display_name: profileData.display_name,
-        tier: profileTier,
-        stripe_customer_id: profileData.stripe_customer_id,
-        show_on_supporters: profileData.show_on_supporters,
-        walkthrough_completed: profileData.walkthrough_completed ?? false,
-        email_opt_in: profileData.email_opt_in ?? false,
-        discord_id: profileData.discord_id ?? null,
-        discord_username: profileData.discord_username ?? null,
+    if (!profileData) {
+      // Profile row missing — auth trigger may not have fired for this user
+      console.error('[auth-context] No profile row found for user:', userId);
+      Sentry.captureMessage('Profile row missing for authenticated user', {
+        level: 'warning',
+        tags: { context: 'auth-profile-fetch' },
       });
+      return;
     }
 
-    // M1: Use maybeSingle() — .single() errors when 0 rows
+    const validTiers: Tier[] = ['community', 'supporter', 'champion'];
+    const profileTier = validTiers.includes(profileData.tier) ? profileData.tier : 'community';
+    setProfile({
+      id: profileData.id,
+      email: profileData.email,
+      display_name: profileData.display_name,
+      tier: profileTier,
+      stripe_customer_id: profileData.stripe_customer_id,
+      show_on_supporters: profileData.show_on_supporters,
+      walkthrough_completed: profileData.walkthrough_completed ?? false,
+      email_opt_in: profileData.email_opt_in ?? false,
+      discord_id: profileData.discord_id ?? null,
+      discord_username: profileData.discord_username ?? null,
+    });
     const { data: subData, error: subError } = await supabase
       .from('subscriptions')
       .select('id, stripe_subscription_id, stripe_price_id, status, tier, current_period_end, cancel_at_period_end')


### PR DESCRIPTION
## Summary

- Replaces `.single()` with `.maybeSingle()` on the `profiles` table query in `lib/auth/auth-context.tsx`
- Adds an explicit Sentry warning when no profile row exists for an authenticated user (auth trigger may not have fired)
- Removes the now-redundant `if (profileData)` guard since we return early on null

## Root Cause

`profiles.id` is the primary key (FK to `auth.users`), so duplicate rows are impossible. The `.single()` call was throwing `Cannot coerce the result to a single JSON object` (Sentry NEXTJS-62) for users whose profile creation trigger did not fire, resulting in 0 rows. `.single()` throws on both 0 and >1 rows; `.maybeSingle()` returns `null` on 0 rows without throwing.

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [x] PR contains one concern only
- [x] No health data affected — auth context only
