### PR TITLE
fix: lift bulk arrays out of NIGHT_RESULT postMessage to prevent OOM

### DIFF
--- a/__tests__/worker-oom-fix.test.ts
+++ b/__tests__/worker-oom-fix.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { NightResult, NEDResults, Breath, OximetryTraceData } from '@/lib/types';
+import type { NightResult, NEDResults, Breath, OximetryTraceData, WorkerNightResult } from '@/lib/types';
 
 // Mirror of the stripNightBulkData function from workers/analysis-worker.ts
 // (not exported from worker — duplicated here for testing, must stay in sync)
@@ -8,6 +8,19 @@ function stripNightBulkData(night: NightResult): NightResult {
     ...night,
     ned: { ...night.ned, breaths: [] },
     oximetryTrace: null,
+    csl: night.csl ? { ...night.csl, episodes: [] } : null,
+  };
+}
+
+// Mirrors the NIGHT_RESULT construction in the worker (both ResMed and BMC paths)
+function buildNightResultMsg(night: NightResult, i: number, total: number): WorkerNightResult {
+  return {
+    type: 'NIGHT_RESULT',
+    night: stripNightBulkData(night),
+    nightIndex: i,
+    totalNights: total,
+    breaths: night.ned.breaths,
+    oximetryTrace: night.oximetryTrace,
   };
 }
 
@@ -154,5 +167,62 @@ describe('stripNightBulkData — worker RESULTS payload size reduction', () => {
       expect(night.ned.breaths ?? []).toHaveLength(0);
       expect(night.oximetryTrace).toBeNull();
     }
+  });
+});
+
+describe('WorkerNightResult NIGHT_RESULT message — bulk data lifted to top-level', () => {
+  it('msg.night has no breaths; msg.breaths carries the per-breath array', () => {
+    const night = makeNight('2026-01-01', true);
+    const originalBreaths = night.ned.breaths!;
+
+    const msg = buildNightResultMsg(night, 0, 1);
+
+    expect(msg.night.ned.breaths).toHaveLength(0);
+    expect(msg.breaths).toBe(originalBreaths); // same reference — no copy
+    expect(msg.breaths).toHaveLength(500);
+  });
+
+  it('msg.night has no oximetryTrace; msg.oximetryTrace carries the trace', () => {
+    const night = makeNight('2026-01-01', true);
+    const originalTrace = night.oximetryTrace!;
+
+    const msg = buildNightResultMsg(night, 0, 1);
+
+    expect(msg.night.oximetryTrace).toBeNull();
+    expect(msg.oximetryTrace).toBe(originalTrace);
+    expect(msg.oximetryTrace?.trace).toHaveLength(100);
+  });
+
+  it('msg.breaths is empty when night has no breaths', () => {
+    const night = makeNight('2026-01-02', false);
+    const msg = buildNightResultMsg(night, 0, 1);
+
+    expect(msg.breaths ?? []).toHaveLength(0);
+    expect(msg.oximetryTrace).toBeNull();
+  });
+
+  it('msg.night preserves all scalar fields after stripping', () => {
+    const night = makeNight('2026-01-01', true);
+    const msg = buildNightResultMsg(night, 0, 1);
+
+    expect(msg.night.dateStr).toBe('2026-01-01');
+    expect(msg.night.durationHours).toBe(7.5);
+    expect(msg.night.ned.breathCount).toBe(500);
+    expect(msg.night.ned.nedMean).toBe(22.5);
+    expect(msg.nightIndex).toBe(0);
+    expect(msg.totalNights).toBe(1);
+  });
+
+  it('orchestrator can read IDB data from top-level fields instead of night object', () => {
+    const night = makeNight('2026-01-01', true);
+    const msg = buildNightResultMsg(night, 0, 1);
+
+    // Simulate orchestrator IDB write conditions (from analysis-orchestrator.ts)
+    const breathsForIdb = msg.breaths;
+    const traceForIdb = msg.oximetryTrace;
+
+    expect(breathsForIdb).toBeDefined();
+    expect(breathsForIdb!.length).toBeGreaterThan(0);
+    expect(traceForIdb).not.toBeNull();
   });
 });

--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -387,14 +387,17 @@ class AnalysisOrchestrator {
             break;
           case 'NIGHT_RESULT': {
             const night = msg.night;
-            if (night.ned.breaths && night.ned.breaths.length > 0) {
+            // Bulk arrays are in top-level msg fields (stripped from night to avoid postMessage OOM).
+            const breaths = msg.breaths;
+            const trace = msg.oximetryTrace;
+            if (breaths && breaths.length > 0) {
               pendingIdbWrites.push(
-                storeBreathData(night.dateStr, night.ned.breaths, DEFAULT_SAMPLING_RATE)
+                storeBreathData(night.dateStr, breaths, DEFAULT_SAMPLING_RATE)
               );
             }
-            if (night.oximetryTrace) {
+            if (trace) {
               pendingIdbWrites.push(
-                storeOximetryTrace(night.dateStr, night.oximetryTrace)
+                storeOximetryTrace(night.dateStr, trace)
               );
             }
             onNightComplete?.(night);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -635,9 +635,14 @@ export interface WorkerOximetryResult {
 
 export interface WorkerNightResult {
   type: 'NIGHT_RESULT';
+  /** NightResult with ned.breaths and oximetryTrace stripped — bulk arrays are in the sibling fields below */
   night: NightResult;
   nightIndex: number;
   totalNights: number;
+  /** Per-breath data for IDB storage — lifted out of night to keep postMessage payload small */
+  breaths?: Breath[];
+  /** Oximetry trace for IDB storage — lifted out of night to keep postMessage payload small */
+  oximetryTrace?: OximetryTraceData | null;
 }
 
 export interface WorkerError {

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -591,12 +591,17 @@ async function processFiles(
       pldSummary,
     });
 
-    // Emit incremental result so the orchestrator can persist progress
+    // Emit incremental result so the orchestrator can persist progress.
+    // Bulk arrays (ned.breaths, oximetryTrace) are lifted to top-level fields
+    // and stripped from night to keep the structured-clone payload small.
+    const latestNight = nights[nights.length - 1]!;
     const nightMsg: WorkerNightResult = {
       type: 'NIGHT_RESULT',
-      night: nights[nights.length - 1]!,
+      night: stripNightBulkData(latestNight),
       nightIndex: i,
       totalNights: nightGroups.length,
+      breaths: latestNight.ned.breaths,
+      oximetryTrace: latestNight.oximetryTrace,
     };
     self.postMessage(nightMsg);
   }
@@ -766,9 +771,11 @@ async function processBMCFiles(
 
     const nightMsg: WorkerNightResult = {
       type: 'NIGHT_RESULT',
-      night,
+      night: stripNightBulkData(night),
       nightIndex: i,
       totalNights: nightDates.length,
+      breaths: night.ned.breaths,
+      oximetryTrace: night.oximetryTrace,
     };
     self.postMessage(nightMsg);
   }


### PR DESCRIPTION
## Summary

- `NIGHT_RESULT` messages sent by the analysis worker included the full `NightResult` object with `ned.breaths` (per-breath array) and `oximetryTrace` embedded in `night` — for large SD cards these exceed the structured-clone memory limit, causing `DOMException: Data cannot be cloned, out of memory`
- Fix: extend `WorkerNightResult` type with top-level `breaths` and `oximetryTrace` fields; strip them from the `night` object before `postMessage`; update the orchestrator to read from those top-level fields for IDB writes
- Both ResMed and BMC processing paths are fixed

Sentry: JAVASCRIPT-NEXTJS-V (13 events, 3 users, first seen 2026-03-17)

## Changes

- `lib/types.ts` — added `breaths?` and `oximetryTrace?` to `WorkerNightResult`
- `workers/analysis-worker.ts` — apply `stripNightBulkData()` to `NIGHT_RESULT` night and lift bulk arrays to top-level (both ResMed and BMC paths)
- `lib/analysis-orchestrator.ts` — read `msg.breaths` / `msg.oximetryTrace` instead of `msg.night.ned.breaths` / `msg.night.oximetryTrace`
- `__tests__/worker-oom-fix.test.ts` — 5 new tests for the message structure + fixed `stripNightBulkData` mirror to include `csl.episodes`

## Test plan

- [ ] All tests pass (`npm test`)
- [ ] TypeScript clean (`npx tsc --noEmit`)
- [ ] Production build passes (`npm run build`)
- [ ] Upload large SD card (100+ nights) — no OOM, progress arrives per-night, waveform tab loads from IDB
- [ ] Upload small SD card — analysis completes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)