### PR TITLE
fix(waveforms): retry transient storage errors, suppress Sentry noise for 5xx

### DIFF
--- a/__tests__/waveform-api-route.test.ts
+++ b/__tests__/waveform-api-route.test.ts
@@ -237,4 +237,66 @@ describe('contribute-waveforms API route', () => {
     const response = await POST(request as never);
     expect(response.status).toBe(400);
   });
+
+  it('retries on transient storage errors and succeeds on 2nd attempt', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    // First attempt fails with Bad Gateway, second succeeds
+    mockUpload
+      .mockResolvedValueOnce({ error: { message: 'Bad Gateway' } })
+      .mockResolvedValueOnce({ error: null });
+
+    const request = makeRequest();
+    const response = await POST(request as never);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(mockUpload).toHaveBeenCalledTimes(2);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 503 after exhausting all retries on transient errors', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    // All 3 attempts fail with Bad Gateway
+    mockUpload.mockResolvedValue({ error: { message: 'Bad Gateway' } });
+
+    const request = makeRequest();
+    const response = await POST(request as never);
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.error).toBe('Storage temporarily unavailable.');
+    expect(mockUpload).toHaveBeenCalledTimes(3);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('does not retry on non-transient storage errors', async () => {
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    mockUpload.mockResolvedValue({ error: { message: 'Permission denied' } });
+
+    const request = makeRequest();
+    const response = await POST(request as never);
+
+    expect(response.status).toBe(500);
+    // Should only try once — no retry on non-transient error
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it('tags Sentry with transient=true for Bad Gateway errors', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    const { POST } = await import('@/app/api/contribute-waveforms/route');
+
+    mockUpload.mockResolvedValue({ error: { message: 'Bad Gateway' } });
+
+    const request = makeRequest();
+    await POST(request as never);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Bad Gateway' }),
+      expect.objectContaining({ tags: expect.objectContaining({ transient: 'true' }) })
+    );
+  });
 });

--- a/__tests__/waveform-contribution-integration.test.ts
+++ b/__tests__/waveform-contribution-integration.test.ts
@@ -372,6 +372,61 @@ describe('contributeWaveformsBackground — integration', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('does not report to Sentry on transient server errors (5xx)', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    fetchSpy.mockResolvedValue({ ok: false, status: 503, text: async () => 'Storage temporarily unavailable.' });
+
+    const nights = [makeNight('2025-01-15')];
+    const files = [makeBRPFile('2025-01-15')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    // sessionFailedDates should be set (cooldown applied)
+    expect(_sessionFailedDates.has('2025-01-15')).toBe(true);
+    // Sentry captureMessage should NOT be called for transient 5xx errors
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not report to Sentry on network errors (undefined status)', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    fetchSpy.mockRejectedValue(new Error('Network error'));
+
+    const nights = [makeNight('2025-01-15')];
+    const files = [makeBRPFile('2025-01-15')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    // sessionFailedDates should be set (cooldown applied)
+    expect(_sessionFailedDates.has('2025-01-15')).toBe(true);
+    // Sentry captureMessage should NOT be called for network errors
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('does report to Sentry on permanent client errors (4xx except 429)', async () => {
+    const Sentry = await import('@sentry/nextjs');
+    const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
+
+    fetchSpy.mockResolvedValue({ ok: false, status: 400, text: async () => 'Bad request.' });
+
+    const nights = [makeNight('2025-01-15')];
+    const files = [makeBRPFile('2025-01-15')];
+
+    await contributeWaveformsBackground(nights, files, 'test-id');
+
+    // Sentry captureMessage SHOULD be called for permanent 4xx errors
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Waveform upload failed'),
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ status: '400' }),
+      })
+    );
+  });
+
   it('skips failed dates within the same session even when localStorage is unavailable', async () => {
     const { contributeWaveformsBackground } = await import('@/lib/contribute-waveforms');
 

--- a/app/api/contribute-waveforms/route.ts
+++ b/app/api/contribute-waveforms/route.ts
@@ -24,6 +24,10 @@ const WaveformMetadataSchema = z.object({
 const limiter = new RateLimiter({ windowMs: 3_600_000, max: 20 });
 const MAX_BODY_BYTES = 5 * 1024 * 1024; // 5 MB
 
+function isTransientStorageError(message: string): boolean {
+  return /bad gateway|gateway timeout|service unavailable|502|503|504/i.test(message);
+}
+
 export async function POST(request: NextRequest) {
   if (!validateOrigin(request)) {
     return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
@@ -110,23 +114,38 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Server configuration error.' }, { status: 500 });
     }
 
-    // Upload to Supabase Storage
+    // Upload to Supabase Storage — retry up to 2 extra times on transient errors
     const storagePath = `${contributionId}/${nightDate}.flow${isCompressed ? '.gz' : '.bin'}`;
-    const { error: storageError } = await supabase.storage
-      .from('research-waveforms')
-      .upload(storagePath, Buffer.from(body), {
-        contentType: 'application/octet-stream',
-        upsert: false,
-      });
+    let storageError: { message?: string } | null = null;
+    const STORAGE_MAX_ATTEMPTS = 3;
+    for (let attempt = 0; attempt < STORAGE_MAX_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        await new Promise<void>(r => setTimeout(r, 500 * attempt));
+      }
+      const { error } = await supabase.storage
+        .from('research-waveforms')
+        .upload(storagePath, Buffer.from(body), {
+          contentType: 'application/octet-stream',
+          upsert: false,
+        });
+      storageError = error;
+      if (!storageError) break;
+      if (storageError.message?.includes('already exists') || storageError.message?.includes('Duplicate')) break;
+      if (!isTransientStorageError(storageError.message ?? '')) break;
+    }
 
     if (storageError) {
       // Duplicate upload — treat as success (idempotent)
       if (storageError.message?.includes('already exists') || storageError.message?.includes('Duplicate')) {
         return NextResponse.json({ ok: true, duplicate: true });
       }
+      const transient = isTransientStorageError(storageError.message ?? '');
       console.error('[contribute-waveforms] Storage error:', storageError.message);
-      Sentry.captureException(storageError, { tags: { route: 'contribute-waveforms' } });
-      return NextResponse.json({ error: 'Storage error.' }, { status: 500 });
+      Sentry.captureException(storageError, { tags: { route: 'contribute-waveforms', transient: String(transient) } });
+      return NextResponse.json(
+        { error: transient ? 'Storage temporarily unavailable.' : 'Storage error.' },
+        { status: transient ? 503 : 500 }
+      );
     }
 
     // Insert metadata row

--- a/lib/contribute-waveforms.ts
+++ b/lib/contribute-waveforms.ts
@@ -410,18 +410,19 @@ export async function contributeWaveformsBackground(
         // Update in-memory guard first — survives even if localStorage write fails below
         sessionFailedDates.add(night.dateStr);
         trackFailedWaveformDate(night.dateStr);
-        // Rate-limited (429) is expected behavior -- log locally only, never to Sentry.
-        // Actual failures (4xx/5xx) are reported to Sentry as warnings.
+        // Rate-limited (429) and transient server errors (5xx, network) are expected —
+        // log locally only. Server already retries 3 times before returning 5xx.
+        // Only permanent client/validation errors (4xx except 429) go to Sentry.
         if (result.status === 429) {
-          console.warn(
-            `Waveform upload rate-limited for ${night.dateStr} (429)`
-          );
+          console.warn(`[contribute-waveforms] Upload rate-limited for ${night.dateStr} (429)`);
+        } else if (result.status === undefined || result.status >= 500) {
+          console.warn(`[contribute-waveforms] Transient upload failure for ${night.dateStr} (${result.status ?? 'network error'})`);
         } else {
           Sentry.captureMessage(
             `Waveform upload failed for ${night.dateStr}`,
             {
               level: 'warning',
-              tags: { feature: 'waveform-contribution', status: String(result.status ?? 'unknown') },
+              tags: { feature: 'waveform-contribution', status: String(result.status) },
               extra: { detail: result.detail },
             }
           );


### PR DESCRIPTION
## Summary

Fixes JAVASCRIPT-NEXTJS-11 — 791 Sentry events from transient Supabase Storage Bad Gateway errors being treated as permanent waveform upload failures.

**Root cause:** Supabase Storage occasionally returns Bad Gateway (502). The server passed this as a 500 to the client, which then fired a Sentry `captureMessage` and added the night to the 24h failure cooldown. JAVASCRIPT-NEXTJS-1D (StorageApiError: Bad Gateway) shares an exact timestamp with the waveform failure events, confirming the correlation.

**Why AIR-690's fix was insufficient:** That fix added session-level dedup to reduce event frequency, but didn't address the underlying cause. Storage transients continued generating one Sentry event per user per day per failed night.

**Changes:**
- `app/api/contribute-waveforms/route.ts`: 3-attempt retry loop (500ms/1000ms back-off) for Bad Gateway, Gateway Timeout, and Service Unavailable errors. Permanent errors still fail fast. Persistent transient failures now return 503 (was 500).
- `lib/contribute-waveforms.ts`: 5xx and network errors (undefined status) are treated like 429 — suppressed from Sentry, logged locally. Sentry alerts reserved for permanent 4xx failures.
- Tests: 7 new tests covering retry-and-succeed, 503 exhaustion, non-transient fast-fail, Sentry suppression for 5xx/network, and Sentry fire for 4xx.

## Test plan

- [ ] Full pipeline passes (lint, typecheck, test, build) — verified locally
- [ ] Vercel preview deploy verified by Demian
- [ ] Manual QA: upload SD card data, confirm waveform contribution completes without Sentry events
- [ ] Monitor Sentry: JAVASCRIPT-NEXTJS-11 event count stops growing after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)