### PR TITLE
fix(device-diagnostic): add 4s timeout guard to stop Sentry noise

### DIFF
--- a/__tests__/device-diagnostic-timeout.test.ts
+++ b/__tests__/device-diagnostic-timeout.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+vi.mock('@/lib/csrf', () => ({ validateOrigin: vi.fn(() => true) }));
+vi.mock('@/lib/rate-limit', () => ({
+  getRateLimitKey: vi.fn(() => '127.0.0.1'),
+  RateLimiter: class {
+    isLimited() { return Promise.resolve(false); }
+  },
+}));
+
+const mockCaptureException = vi.fn();
+const mockCaptureMessage = vi.fn();
+vi.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+}));
+
+const mockInsert = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseAdmin: vi.fn(() => ({
+    from: vi.fn(() => ({ insert: (...args: unknown[]) => mockInsert(...args) })),
+  })),
+}));
+
+vi.mock('@/lib/discord-webhook', () => ({
+  sendAlert: vi.fn(() => Promise.resolve()),
+  formatUserSignalEmbed: vi.fn(() => ({})),
+}));
+
+vi.mock('./_dedup', () => ({
+  DEDUP_WINDOW_MS: 86_400_000,
+  deviceModelLastAlertTs: new Map(),
+  deviceModelHitCount: new Map(),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function makeRequest() {
+  return new Request('http://localhost:3000/api/device-diagnostic', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', origin: 'http://localhost:3000' },
+    body: JSON.stringify({
+      deviceModel: 'Unknown CPAP v9',
+      signalLabels: ['Flow', 'Mask Pressure'],
+      identificationText: null,
+      hasStrFile: false,
+    }),
+  }) as unknown as NextRequest;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+describe('POST /api/device-diagnostic — timeout handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockCaptureException.mockClear();
+    mockCaptureMessage.mockClear();
+    mockInsert.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns 200 ok:true when insert succeeds normally', async () => {
+    mockInsert.mockResolvedValue({ error: null });
+
+    const { POST } = await import('@/app/api/device-diagnostic/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 ok:true when Supabase insert hangs past 4s timeout', async () => {
+    // Insert that never resolves — simulates a hung Supabase connection
+    mockInsert.mockImplementation(
+      () => new Promise<never>(() => { /* never resolves */ }),
+    );
+
+    const { POST } = await import('@/app/api/device-diagnostic/route');
+    const responsePromise = POST(makeRequest());
+
+    // Advance fake timers past the 4-second AbortController deadline
+    await vi.advanceTimersByTimeAsync(4_100);
+
+    const res = await responsePromise;
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('does NOT call Sentry.captureException on insert timeout', async () => {
+    mockInsert.mockImplementation(
+      () => new Promise<never>(() => { /* never resolves */ }),
+    );
+
+    const { POST } = await import('@/app/api/device-diagnostic/route');
+    const responsePromise = POST(makeRequest());
+    await vi.advanceTimersByTimeAsync(4_100);
+    await responsePromise;
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('still reports a real Supabase error (non-timeout) to Sentry', async () => {
+    const dbError = { message: 'connection refused', code: '08006' };
+    mockInsert.mockResolvedValue({ error: dbError });
+
+    const { POST } = await import('@/app/api/device-diagnostic/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(mockCaptureException).toHaveBeenCalledWith(dbError, expect.anything());
+  });
+});

--- a/app/api/device-diagnostic/route.ts
+++ b/app/api/device-diagnostic/route.ts
@@ -50,16 +50,39 @@ export async function POST(request: NextRequest) {
       });
     }
     if (supabase) {
-      const { error } = await supabase.from('device_diagnostics').insert({
-        device_model: deviceModel,
-        signal_labels: signalLabels,
-        identification_text: identificationText,
-        has_str_file: hasStrFile,
-      });
+      try {
+        let timeoutHandle: ReturnType<typeof setTimeout>;
+        const timeoutPromise = new Promise<never>(
+          (_, reject) =>
+            (timeoutHandle = setTimeout(
+              () =>
+                reject(
+                  Object.assign(new Error('Supabase insert timed out'), { name: 'AbortError' }),
+                ),
+              4_000,
+            )),
+        );
 
-      if (error) {
-        console.error('[device-diagnostic] Supabase error:', error.message);
-        Sentry.captureException(error, { tags: { route: 'device-diagnostic' } });
+        const { error } = await Promise.race([
+          supabase.from('device_diagnostics').insert({
+            device_model: deviceModel,
+            signal_labels: signalLabels,
+            identification_text: identificationText,
+            has_str_file: hasStrFile,
+          }),
+          timeoutPromise,
+        ]).finally(() => clearTimeout(timeoutHandle));
+
+        if (error) {
+          console.error('[device-diagnostic] Supabase error:', error.message);
+          Sentry.captureException(error, { tags: { route: 'device-diagnostic' } });
+        }
+      } catch (insertErr) {
+        if (insertErr instanceof Error && insertErr.name === 'AbortError') {
+          console.warn('[device-diagnostic] Supabase insert timed out — data dropped');
+        } else {
+          Sentry.captureException(insertErr, { tags: { route: 'device-diagnostic' } });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Supabase insert in `POST /api/device-diagnostic` had no timeout guard; when Supabase was slow the Next.js function deadline fired first, producing `TimeoutError` captured by Sentry (JAVASCRIPT-NEXTJS-56, 46 events as of 2026-05-14)
- AIR-1485 was closed as done but the fix was never committed/merged — confirmed by checking full git log
- Wraps the insert in `Promise.race` with a 4 s deadline; `AbortError` (timeout) is logged as `console.warn` and swallowed — this endpoint is fire-and-forget diagnostic data, not user-critical
- Real Supabase errors (non-timeout) still reach Sentry

## Test plan

- [ ] 4 new Vitest tests in `__tests__/device-diagnostic-timeout.test.ts` — all pass (timeout returns 200, Sentry NOT called on timeout, real errors still reach Sentry)
- [ ] Full test suite: 2204 tests across 139 files — all pass
- [ ] `npx tsc --noEmit` — clean

Closes AIR-1536. Resolves Sentry JAVASCRIPT-NEXTJS-56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)