### PR TITLE
fix: improve AI insights error observability and user messaging

### DIFF
--- a/__tests__/ai-insights-client-error-handling.test.ts
+++ b/__tests__/ai-insights-client-error-handling.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for client-side AI insights error handling (AIR-1538).
+ *
+ * Verifies that:
+ * - Failed fetch (network) errors are captured to Sentry with distinguishable context
+ * - Error message for network failures does not blame user connectivity
+ * - Timeout errors produce an appropriate user message
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockCaptureException = vi.fn();
+vi.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  captureMessage: vi.fn(),
+}));
+
+// Minimal NightResult shape matching what the client needs
+function makeNight() {
+  return {
+    date: new Date('2026-03-12'),
+    dateStr: '2026-03-12',
+    durationHours: 7,
+    sessionCount: 1,
+    settings: { cpapMode: 'APAP', minPressure: 6, maxPressure: 14, epr: 3, rampTime: 0, settingsSource: 'str_edf' },
+    glasgow: { overall: 3.5, skew: 0, spike: 0, flatTop: 0, topHeavy: 0, multiPeak: 0, noPause: 0, inspirRate: 0, multiBreath: 0, variableAmp: 0 },
+    wat: { flScore: 40, regularityScore: 1, periodicityIndex: 0.05 },
+    ned: {
+      breathCount: 400, nedMean: 25, nedMedian: 24, nedP95: 60, nedClearFLPct: 40,
+      nedBorderlinePct: 25, fiMean: 0.8, fiFL85Pct: 30, tpeakMean: 0.38, mShapePct: 10,
+      reraIndex: 2, reraCount: 3, h1NedMean: 22, h2NedMean: 28, combinedFLPct: 30,
+      breaths: [], reras: [],
+    },
+    oximetry: null,
+    machineSummary: undefined,
+    settingsFingerprint: undefined,
+  };
+}
+
+describe('AI Insights Client Error Handling (AIR-1538)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.stubGlobal('fetch', undefined);
+  });
+
+  it('captures Failed-to-fetch to Sentry with network_fetch_failed tag (standard mode)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    const { fetchAIInsights } = await import('@/lib/ai-insights-client');
+    await expect(fetchAIInsights([makeNight() as never], 0, null)).rejects.toThrow(
+      'The AI analysis service is temporarily unavailable. Please try again.'
+    );
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(TypeError),
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ error_type: 'network_fetch_failed', mode: 'standard' }),
+      })
+    );
+  });
+
+  it('captures Failed-to-fetch to Sentry with network_fetch_failed tag (deep mode)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    const { fetchDeepAIInsights } = await import('@/lib/ai-insights-client');
+    await expect(fetchDeepAIInsights([makeNight() as never], 0, null)).rejects.toThrow(
+      'The AI analysis service is temporarily unavailable. Please try again.'
+    );
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(TypeError),
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({ error_type: 'network_fetch_failed', mode: 'deep' }),
+      })
+    );
+  });
+
+  it('does not capture to Sentry for external AbortError (unmount)', async () => {
+    const externalController = new AbortController();
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+      externalController.abort();
+      return Promise.reject(new DOMException('Aborted', 'AbortError'));
+    }));
+
+    const { fetchAIInsights } = await import('@/lib/ai-insights-client');
+    await expect(
+      fetchAIInsights([makeNight() as never], 0, null, externalController.signal)
+    ).rejects.toBeInstanceOf(DOMException);
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('returns server error message verbatim for non-ok responses', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'AI service is temporarily unavailable. Our team has been notified and is working on it.' }),
+    }));
+
+    const { fetchAIInsights } = await import('@/lib/ai-insights-client');
+    await expect(fetchAIInsights([makeNight() as never], 0, null)).rejects.toThrow(
+      'AI service is temporarily unavailable. Our team has been notified and is working on it.'
+    );
+  });
+});

--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -586,6 +586,7 @@ export async function POST(request: NextRequest) {
     if (err instanceof Anthropic.RateLimitError) {
       Sentry.captureException(err, {
         tags: { route: 'ai-insights', error_type: 'rate_limit' },
+        extra: { anthropicStatus: err.status },
         level: 'warning',
       });
       console.error('[ai-insights] Rate limit exceeded after retries');
@@ -598,6 +599,7 @@ export async function POST(request: NextRequest) {
     if (err instanceof Anthropic.AuthenticationError || err instanceof Anthropic.PermissionDeniedError) {
       Sentry.captureException(err, {
         tags: { route: 'ai-insights', error_type: 'auth' },
+        extra: { anthropicStatus: err.status },
         level: 'error',
       });
       console.error('[ai-insights] Auth/permission error:', err instanceof Anthropic.AuthenticationError ? 'authentication' : 'permission');
@@ -635,6 +637,7 @@ export async function POST(request: NextRequest) {
     if (err instanceof Anthropic.NotFoundError) {
       Sentry.captureException(err, {
         tags: { route: 'ai-insights', error_type: 'not_found' },
+        extra: { anthropicStatus: err.status },
         level: 'error',
       });
       console.error('[ai-insights] Model not found');
@@ -648,6 +651,7 @@ export async function POST(request: NextRequest) {
       const isBillingError = err.message?.includes('credit balance');
       Sentry.captureException(err, {
         tags: { route: 'ai-insights', error_type: isBillingError ? 'billing' : 'bad_request' },
+        extra: { anthropicStatus: err.status },
         level: isBillingError ? 'fatal' : 'error',
       });
       if (isBillingError) {
@@ -668,6 +672,7 @@ export async function POST(request: NextRequest) {
     if (err instanceof Anthropic.InternalServerError) {
       Sentry.captureException(err, {
         tags: { route: 'ai-insights', error_type: 'server_error' },
+        extra: { anthropicStatus: err.status },
         level: 'warning',
       });
       console.error('[ai-insights] Anthropic internal server error');

--- a/lib/ai-insights-client.ts
+++ b/lib/ai-insights-client.ts
@@ -213,7 +213,11 @@ export async function fetchAIInsights(
     }
     if (err instanceof TypeError && err.message === 'Failed to fetch') {
       console.error('[ai-insights] Network error (standard mode)');
-      throw new Error('Could not reach the AI service. Check your internet connection and try again.');
+      Sentry.captureException(err, {
+        level: 'warning',
+        tags: { error_type: 'network_fetch_failed', mode: 'standard', route: 'ai-insights' },
+      });
+      throw new Error('The AI analysis service is temporarily unavailable. Please try again.');
     }
     throw err;
   } finally {
@@ -302,7 +306,11 @@ export async function fetchDeepAIInsights(
     }
     if (err instanceof TypeError && err.message === 'Failed to fetch') {
       console.error('[ai-insights] Network error (deep mode)');
-      throw new Error('Could not reach the AI service. Check your internet connection and try again.');
+      Sentry.captureException(err, {
+        level: 'warning',
+        tags: { error_type: 'network_fetch_failed', mode: 'deep', route: 'ai-insights' },
+      });
+      throw new Error('The AI analysis service is temporarily unavailable. Please try again.');
     }
     throw err;
   } finally {


### PR DESCRIPTION
## Summary

Addresses JAVASCRIPT-NEXTJS-54: users seeing "Could not reach the AI service. Check your internet connection and try again." on /analyze.

- Add Sentry capture for TypeError('Failed to fetch') in lib/ai-insights-client.ts (standard and deep modes) with error_type:network_fetch_failed tag — these events were previously untagged, making client vs server failures indistinguishable
- Improve error message: "The AI analysis service is temporarily unavailable. Please try again." — the Failed to fetch path fires for server-side unreachability too, so blaming the user's connection was misleading
- Add anthropicStatus to Sentry extra for all Anthropic SDK errors that carry an HTTP status code (auth, rate_limit, bad_request, not_found, server_error) — allows distinguishing 529 overloaded from 500 internal server error
- New test file __tests__/ai-insights-client-error-handling.test.ts covering Sentry capture, message copy, and external AbortError passthrough

## Test plan

- [ ] npx vitest run __tests__/ai-insights-client-error-handling.test.ts __tests__/ai-insights-error-handling.test.ts — 13 tests, all pass
- [ ] TypeScript clean
- [ ] After deploy: verify network_fetch_failed tag appears in Sentry for any future occurrences; no further events from the 3 affected users

Generated with Claude Code