### PR TITLE
feat: PostHog feature flag + tier window hit event

### DIFF
--- a/__tests__/orchestrator-tier-trace-gate.test.ts
+++ b/__tests__/orchestrator-tier-trace-gate.test.ts
@@ -105,6 +105,44 @@ describe('filterNightsToTierWindow — oximetry/breath trace pruning for persist
     });
   });
 
+  describe('overrideWindowDays (PostHog experiment)', () => {
+    it('community: overrideWindowDays=30 includes nights between 14 and 30 days ago', () => {
+      // 20 nights ending today (2026-05-11). Default 14-day window would include 15 nights.
+      // With override=30 all 20 nights should be included (max span is 20 days).
+      const nights = makeNights(20, new Date('2026-05-11'));
+      const result14 = filterNightsToTierWindow(nights, 'community', now);
+      const result30 = filterNightsToTierWindow(nights, 'community', now, 30);
+      expect(result14).toHaveLength(15);
+      expect(result30).toHaveLength(20);
+    });
+
+    it('community: overrideWindowDays=7 restricts to 7-day window', () => {
+      const nights = makeNights(20, new Date('2026-05-11'));
+      const result = filterNightsToTierWindow(nights, 'community', now, 7);
+      // Cutoff = 2026-05-04. Nights from 2026-05-04 to 2026-05-11 = 8 nights.
+      expect(result).toHaveLength(8);
+      expect(result[0]!.dateStr).toBe('2026-05-11');
+      expect(result[result.length - 1]!.dateStr).toBe('2026-05-04');
+    });
+
+    it('overrideWindowDays is ignored for non-community tiers', () => {
+      const nights = makeNights(10, new Date('2026-05-11'));
+      // Champion always returns all nights regardless of override
+      const resultChampion = filterNightsToTierWindow(nights, 'champion', now, 5);
+      expect(resultChampion).toHaveLength(10);
+      // Supporter uses its own 90-day window, not the override
+      const resultSupporter = filterNightsToTierWindow(nights, 'supporter', now, 5);
+      expect(resultSupporter).toHaveLength(10);
+    });
+
+    it('community: overrideWindowDays=undefined falls back to default 14-day window', () => {
+      const nights = makeNights(20, new Date('2026-05-11'));
+      const withUndefined = filterNightsToTierWindow(nights, 'community', now, undefined);
+      const withoutOverride = filterNightsToTierWindow(nights, 'community', now);
+      expect(withUndefined).toHaveLength(withoutOverride.length);
+    });
+  });
+
   describe('edge cases', () => {
     it('handles empty input for any tier', () => {
       expect(filterNightsToTierWindow([], 'community', now)).toHaveLength(0);

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -307,7 +307,7 @@ function AnalyzePageInner() {
           const resolvedWindowDays = overrideWindowDaysRef.current ?? getAnalysisWindowDays('community');
           capturePostHog('tier_window_hit', {
             cohort: String(overrideWindowDaysRef.current ?? 'control'),
-            nights_total: newState.nights.length + (newState.nightsCappedCount ?? 0),
+            nights_total: newState.nights.length,
             nights_capped: newState.nightsCappedCount ?? 0,
             tier_window_days: resolvedWindowDays,
             is_free_user: true,
@@ -315,8 +315,9 @@ function AnalyzePageInner() {
           // Set cap_encountered_at on first encounter only
           const capKey = 'airwaylab_cap_first_encounter';
           if (!localStorage.getItem(capKey)) {
-            localStorage.setItem(capKey, new Date().toISOString());
-            setPostHogPersonProps({ cap_encountered_at: new Date().toISOString() });
+            const encounteredAt = new Date().toISOString();
+            localStorage.setItem(capKey, encounteredAt);
+            setPostHogPersonProps({ cap_encountered_at: encounteredAt });
           }
         }
 

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -42,7 +42,8 @@ import { orchestrator } from '@/lib/analysis-orchestrator';
 import { SAMPLE_NIGHTS, SAMPLE_THERAPY_CHANGE_DATE } from '@/lib/sample-data';
 import type { AnalysisState, NightResult } from '@/lib/types';
 import { loadPersistedResults, clearPersistedNights } from '@/lib/persistence';
-import { events } from '@/lib/analytics';
+import { events, capturePostHog, setPostHogPersonProps } from '@/lib/analytics';
+import { useTierHistoryWindowDays } from '@/hooks/use-tier-history-window-days';
 import { contributeNights, trackContributedDates } from '@/lib/contribute';
 import { contributeWaveformsBackground } from '@/lib/contribute-waveforms';
 import { contributeOximetryTraceBackground } from '@/lib/contribute-oximetry-trace';
@@ -137,6 +138,9 @@ function AnalyzePageInner() {
   useEffect(() => { userRef.current = user; }, [user]);
   const tierRef = useRef(tier);
   useEffect(() => { tierRef.current = tier; }, [tier]);
+  const overrideWindowDays = useTierHistoryWindowDays();
+  const overrideWindowDaysRef = useRef(overrideWindowDays);
+  useEffect(() => { overrideWindowDaysRef.current = overrideWindowDays; }, [overrideWindowDays]);
   const [bannerActivated, setBannerActivated] = useState(false);
   const hasTriggeredAutoUpload = useRef(false);
   const thresholdModalRef = useRef<ThresholdSettingsModalHandle>(null);
@@ -297,6 +301,25 @@ function AnalyzePageInner() {
       // Persist results when analysis completes
       if (newState.status === 'complete' && newState.nights.length > 0) {
         events.analysisComplete(newState.nights.length);
+
+        // PostHog experiment: fire tier_window_hit when community cap excludes nights
+        if ((newState.nightsCappedCount ?? 0) > 0 && tierRef.current === 'community') {
+          const resolvedWindowDays = overrideWindowDaysRef.current ?? getAnalysisWindowDays('community');
+          capturePostHog('tier_window_hit', {
+            cohort: String(overrideWindowDaysRef.current ?? 'control'),
+            nights_total: newState.nights.length + (newState.nightsCappedCount ?? 0),
+            nights_capped: newState.nightsCappedCount ?? 0,
+            tier_window_days: resolvedWindowDays,
+            is_free_user: true,
+          });
+          // Set cap_encountered_at on first encounter only
+          const capKey = 'airwaylab_cap_first_encounter';
+          if (!localStorage.getItem(capKey)) {
+            localStorage.setItem(capKey, new Date().toISOString());
+            setPostHogPersonProps({ cap_encountered_at: new Date().toISOString() });
+          }
+        }
+
         // Orchestrator already calls persistResults internally — don't double-persist.
         // The persistenceWarning from the orchestrator state will surface any issues.
         setPersistedData(null);
@@ -381,7 +404,7 @@ function AnalyzePageInner() {
       if (lifetimeNights > 0) {
         events.returningUserUpload(lifetimeNights);
       }
-      orchestrator.analyze(sdFiles, oxFiles.length > 0 ? oxFiles : undefined, deviceType, bmcSerial, tierRef.current);
+      orchestrator.analyze(sdFiles, oxFiles.length > 0 ? oxFiles : undefined, deviceType, bmcSerial, tierRef.current, overrideWindowDaysRef.current);
     },
     [lifetimeNights]
   );

--- a/docs/experiments/tier-history-window.md
+++ b/docs/experiments/tier-history-window.md
@@ -1,0 +1,67 @@
+# Experiment: Community Tier History Window
+
+## Overview
+
+Tests whether expanding the community tier's history window beyond the default increases
+retention and upgrade conversion among free users who hit the cap.
+
+## Flag
+
+**Name:** `tier_history_window_days`  
+**Type:** String (number as string, e.g. `"7"`, `"14"`, `"30"`)  
+**Created:** 2026-05-15  
+**Status:** Not yet active (100% control)
+
+## Variants
+
+| Variant | Value | Description |
+|---------|-------|-------------|
+| control | *(flag absent / null)* | Default — uses `getAnalysisWindowDays('community')` (currently 14 days) |
+| 7d | `"7"` | Restrict to 7-day window (regression baseline) |
+| 30d | `"30"` | Expand to 30-day window |
+
+## Code Implementation
+
+- **`lib/analysis-orchestrator.ts`** — `filterNightsToTierWindow` accepts `overrideWindowDays?: number`; used only when `tier === 'community'`
+- **`hooks/use-tier-history-window-days.ts`** — reads `tier_history_window_days` flag via `posthog.getFeatureFlag()`; returns `undefined` on fallback (caller uses default)
+- **`app/analyze/page.tsx`** — passes resolved days to `orchestrator.analyze()`; fires `tier_window_hit` event after analysis
+
+## Events & Properties
+
+### `tier_window_hit`
+Fired when a community user's analysis results are capped by the tier window.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `cohort` | string | Flag variant value or `"control"` |
+| `nights_total` | number | Total nights before window filter |
+| `nights_capped` | number | Nights excluded by the window |
+| `tier_window_days` | number | Effective window in days |
+| `is_free_user` | boolean | Always `true` (community tier only) |
+
+### `cap_encountered_at` (person property)
+ISO timestamp of first cap encounter. Written once per device (guarded by
+`airwaylab_cap_first_encounter` localStorage key).
+
+## Metrics
+
+**Primary:** 7-day upgrade rate for users who triggered `tier_window_hit`  
+**Secondary:** Session retention (return visits within 14 days), nights analysed per session
+
+## Expected Effect
+
+Hypothesis: users on a 30-day window see more historical context, reducing friction and
+increasing the perceived value of the premium tier, leading to higher upgrade conversion.
+
+## Launch Checklist
+
+- [ ] Flag created in PostHog dashboard with variants `7`, `14`, `30`
+- [ ] Start with 100% control; validate `tier_window_hit` event appearing in PostHog
+- [ ] Roll out to 10% traffic in each variant for 2 weeks minimum
+- [ ] Read date: 2026-06-15 (4 weeks minimum for statistical significance)
+- [ ] Minimum detectable effect: 2pp lift in 7-day upgrade rate
+
+## MDR Note
+
+Event payloads contain only metadata (counts, flags, cohort labels). No raw sleep data,
+no dates, no personally identifiable health information is transmitted.

--- a/hooks/use-tier-history-window-days.ts
+++ b/hooks/use-tier-history-window-days.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { usePostHog } from 'posthog-js/react';
+
+/**
+ * Reads the PostHog feature flag `tier_history_window_days` and returns the
+ * resolved number of days for the community tier history window.
+ *
+ * Returns `undefined` when PostHog is unavailable or the flag is unset —
+ * callers should fall back to the hardcoded default from `getAnalysisWindowDays`.
+ */
+export function useTierHistoryWindowDays(): number | undefined {
+  const posthog = usePostHog();
+  if (!posthog) return undefined;
+
+  const flag = posthog.getFeatureFlag('tier_history_window_days');
+
+  if (typeof flag === 'string') {
+    const n = parseInt(flag, 10);
+    if (!isNaN(n) && n > 0) return n;
+  }
+  if (typeof flag === 'number' && flag > 0) return flag;
+
+  return undefined;
+}

--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -51,6 +51,7 @@ class AnalysisOrchestrator {
   private persistTimer: ReturnType<typeof setTimeout> | null = null;
   private boundBeforeUnload: (() => void) | null = null;
   private currentTier: Tier = 'community';
+  private currentOverrideWindowDays?: number;
 
   /** Diagnostic info from settings extraction failure (null when extraction succeeded). */
   settingsDiagnostic: WorkerSettingsDiagnostic | null = null;
@@ -79,9 +80,11 @@ class AnalysisOrchestrator {
     oximetryFiles?: FileList | File[],
     deviceType?: string,
     bmcSerial?: string,
-    tier: Tier = 'community'
+    tier: Tier = 'community',
+    overrideWindowDays?: number
   ): Promise<NightResult[]> {
     this.currentTier = tier;
+    this.currentOverrideWindowDays = overrideWindowDays;
     this.terminate();
     const sdArr = Array.from(sdFiles);
     this.setState({
@@ -279,7 +282,7 @@ class AnalysisOrchestrator {
       }
 
       // ── Authoritative save of final results (tier-gated window) ──
-      const nightsToSave = filterNightsToTierWindow(merged, tier);
+      const nightsToSave = filterNightsToTierWindow(merged, tier, Date.now(), this.currentOverrideWindowDays);
       const persistResult = persistResults(nightsToSave, therapyChangeDate);
       persistOximetryTraces(merged);
       persistBreathData(merged);
@@ -290,6 +293,7 @@ class AnalysisOrchestrator {
       this.setState({
         status: 'complete',
         nights: merged,
+        nightsCappedCount: merged.length - nightsToSave.length,
         therapyChangeDate,
         warning,
         persistenceWarning: persistResult.reason ?? null,
@@ -580,13 +584,14 @@ class AnalysisOrchestrator {
 
       // Persist updated results (tier-gated window)
       const therapyChangeDate = detectTherapyChange(merged);
-      const nightsToSave = filterNightsToTierWindow(merged, tier);
+      const nightsToSave = filterNightsToTierWindow(merged, tier, Date.now(), this.currentOverrideWindowDays);
       const persistResult = persistResults(nightsToSave, therapyChangeDate);
       persistOximetryTraces(merged);
 
       this.setState({
         status: 'complete',
         nights: merged,
+        nightsCappedCount: merged.length - nightsToSave.length,
         therapyChangeDate,
         warning,
         persistenceWarning: persistResult.reason ?? null,
@@ -710,7 +715,7 @@ class AnalysisOrchestrator {
     if (this.persistTimer) clearTimeout(this.persistTimer);
     this.persistTimer = setTimeout(() => {
       if (this.incrementalNights.length > 0) {
-        const nights = filterNightsToTierWindow(this.incrementalNights, this.currentTier);
+        const nights = filterNightsToTierWindow(this.incrementalNights, this.currentTier, Date.now(), this.currentOverrideWindowDays);
         persistNightsIncremental(nights);
       }
     }, 2000);
@@ -730,7 +735,7 @@ class AnalysisOrchestrator {
     this.boundBeforeUnload = () => {
       if (this.incrementalNights.length > 0) {
         try {
-          const nights = filterNightsToTierWindow(this.incrementalNights, this.currentTier);
+          const nights = filterNightsToTierWindow(this.incrementalNights, this.currentTier, Date.now(), this.currentOverrideWindowDays);
           persistNightsIncremental(nights);
         } catch {
           // Best effort — page is closing
@@ -770,8 +775,15 @@ class AnalysisOrchestrator {
  * Champions get all nights; supporters get 90 days; community gets 14 days.
  * `now` is injectable for deterministic testing.
  */
-export function filterNightsToTierWindow(nights: NightResult[], tier: Tier, now = Date.now()): NightResult[] {
-  const windowDays = getAnalysisWindowDays(tier);
+export function filterNightsToTierWindow(
+  nights: NightResult[],
+  tier: Tier,
+  now = Date.now(),
+  overrideWindowDays?: number
+): NightResult[] {
+  const windowDays = (tier === 'community' && overrideWindowDays != null)
+    ? overrideWindowDays
+    : getAnalysisWindowDays(tier);
   if (windowDays === Infinity) return nights;
   const cutoff = now - windowDays * 24 * 60 * 60 * 1000;
   return nights.filter((n) => new Date(n.dateStr).getTime() >= cutoff);

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -34,6 +34,15 @@ export function capturePostHog(
   }).catch(() => { /* analytics failure is non-critical — never block user flow */ });
 }
 
+export function setPostHogPersonProps(props: Record<string, string | number | boolean>) {
+  if (typeof window === 'undefined') return;
+  import('posthog-js').then(({ default: posthog }) => {
+    if (posthog.__loaded) {
+      posthog.setPersonProperties(props);
+    }
+  }).catch(() => { /* analytics failure is non-critical */ });
+}
+
 // ── Existing events ──────────────────────────────────────────
 export const events = {
   /** User uploaded SD card files */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -598,6 +598,8 @@ export interface AnalysisState {
   persistenceWarning: string | null;
   /** Accumulated non-fatal warnings from analysis (e.g. truncated EDF files) */
   warnings: string[];
+  /** Nights excluded by the tier history window (community cap). Populated after analysis completes. */
+  nightsCappedCount?: number;
 }
 
 export interface WorkerAnalyzeMessage {


### PR DESCRIPTION
## Summary

- Adds `overrideWindowDays` parameter to `filterNightsToTierWindow` — when PostHog flag `tier_history_window_days` is set for a community user, it overrides the default 14-day window
- New `hooks/use-tier-history-window-days.ts` hook reads the flag and returns `undefined` on fallback (caller uses hardcoded default)
- Fires `tier_window_hit` PostHog event when community cap excludes nights; sets `cap_encountered_at` person property on first encounter (guarded by localStorage key)
- `AnalysisState` gains `nightsCappedCount?: number` so the page can compare total vs saved nights
- `setPostHogPersonProps` helper added to `lib/analytics.ts`
- 4 new unit tests for `overrideWindowDays` behaviour across all tiers
- `docs/experiments/tier-history-window.md` experiment launch checklist

Closes AIR-1582

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] E2e tests pass locally (for UI changes)
- [x] Bundle size impact checked (no new dependencies)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [x] Self-review: no regressions, loading/error/empty states handled
- [x] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)