### PR TITLE
fix: graceful error message for file read failure on upload

### DIFF
--- a/__tests__/analysis-orchestrator-worker-error.test.ts
+++ b/__tests__/analysis-orchestrator-worker-error.test.ts
@@ -551,4 +551,75 @@ describe('analysis-orchestrator worker error handling', () => {
       vi.unstubAllGlobals();
     });
   });
+
+  // ── analyze — NotReadableError during file read ───────────────────────────
+
+  describe('analyze — NotReadableError during file read', () => {
+    it('sets error state with user-friendly message when arrayBuffer() throws NotReadableError', async () => {
+      // Stub Worker so it never gets called — the error is thrown before the worker
+      vi.stubGlobal('Worker', makeThrowingWorkerCtor(new Error('should not reach worker')));
+
+      const { orchestrator } = await import('@/lib/analysis-orchestrator');
+
+      const notReadable = new DOMException('The requested file could not be read', 'NotReadableError');
+      const mockFile = {
+        name: 'BRP.edf',
+        size: 100 * 1024,
+        webkitRelativePath: 'DATALOG/20240101/BRP.edf',
+        arrayBuffer: () => Promise.reject(notReadable),
+        text: () => Promise.reject(notReadable),
+        lastModified: Date.now(),
+        type: '',
+        slice: () => new Blob(),
+        stream: () => { throw new Error('not implemented'); },
+      } as unknown as File;
+
+      try {
+        await orchestrator.analyze([mockFile]);
+      } catch {
+        // analyze re-throws; we inspect state below
+      }
+
+      const state = orchestrator.getState();
+      expect(state.status).toBe('error');
+      expect(state.error).toBe(
+        'File could not be read — please re-select your SD card files and try again'
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    it('still calls Sentry.captureException for NotReadableError', async () => {
+      vi.stubGlobal('Worker', makeThrowingWorkerCtor(new Error('should not reach worker')));
+
+      const { orchestrator } = await import('@/lib/analysis-orchestrator');
+      const Sentry = await import('@sentry/nextjs');
+
+      const notReadable = new DOMException('The requested file could not be read', 'NotReadableError');
+      const mockFile = {
+        name: 'BRP.edf',
+        size: 100 * 1024,
+        webkitRelativePath: 'DATALOG/20240101/BRP.edf',
+        arrayBuffer: () => Promise.reject(notReadable),
+        text: () => Promise.reject(notReadable),
+        lastModified: Date.now(),
+        type: '',
+        slice: () => new Blob(),
+        stream: () => { throw new Error('not implemented'); },
+      } as unknown as File;
+
+      try {
+        await orchestrator.analyze([mockFile]);
+      } catch {
+        // expected
+      }
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        notReadable,
+        expect.objectContaining({ extra: expect.objectContaining({ context: 'analysis-worker' }) })
+      );
+
+      vi.unstubAllGlobals();
+    });
+  });
 });

--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -311,7 +311,10 @@ class AnalysisOrchestrator {
         }
       }
       this.clearIncrementalState();
-      const error = err instanceof Error ? err.message : String(err);
+      let error = err instanceof Error ? err.message : String(err);
+      if (err instanceof DOMException && err.name === 'NotReadableError') {
+        error = 'File could not be read — please re-select your SD card files and try again';
+      }
       Sentry.captureException(err, { extra: { context: 'analysis-worker' } });
       this.setState({ status: 'error', error });
       throw err;


### PR DESCRIPTION
## Summary

- Maps `NotReadableError` (Sentry JAVASCRIPT-NEXTJS-2K, 3 events, 2 users) to a user-friendly message in the main analysis orchestrator
- Error state now shows: "File could not be read — please re-select your SD card files and try again"
- Sentry still captures the original `DOMException` for monitoring continuity
- Satisfies `airwaylab/no-silent-catch` — error is logged to Sentry and set in UI state

## Root cause

`readFileList()` in `lib/analysis-orchestrator.ts` calls `file.arrayBuffer()` which can throw `NotReadableError` when the browser revokes file handle access (e.g. SD card removed, brief navigation away, large card parse delay). The catch block passed the raw error message through without mapping it.

The waveform orchestrator already had equivalent handling; this brings the main analysis path to parity.

## Test plan

- [ ] All existing tests pass (`npx vitest run`)
- [ ] 2 new tests in `__tests__/analysis-orchestrator-worker-error.test.ts`:
  - `sets error state with user-friendly message when arrayBuffer() throws NotReadableError`
  - `still calls Sentry.captureException for NotReadableError`
- [ ] Vercel preview deploy verified by Demian
- [ ] Manual QA: error message appears correctly on file read failure

## Pre-merge checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [ ] Self-review: no regressions, loading/error/empty states handled
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)