### PR TITLE
test(persistence): pin loadPersistedResults savedAt return contract

### DIFF
--- a/__tests__/persistence.test.ts
+++ b/__tests__/persistence.test.ts
@@ -297,6 +297,15 @@ describe('persistence', () => {
       expect(result!.nights[0]!.date).toBeInstanceOf(Date);
     });
 
+    it('returns savedAt timestamp in the result (recent-restore bypass needs it)', () => {
+      const before = Date.now();
+      persistResults(SAMPLE_NIGHTS, null);
+      const after = Date.now();
+      const result = loadPersistedResults();
+      expect(result?.savedAt).toBeGreaterThanOrEqual(before);
+      expect(result?.savedAt).toBeLessThanOrEqual(after);
+    });
+
     it('restores sessionStartTime as a Date after round-trip through localStorage', () => {
       const startTime = new Date('2025-03-15T22:31:00Z');
       const nightWithStartTime = {


### PR DESCRIPTION
## Summary

- Adds a unit test asserting that `loadPersistedResults()` returns the `savedAt` timestamp in its result object
- This pins the return-type contract introduced in AIR-940 PR #769, where `persistedData.savedAt` drives the same-day restore bypass in the analyze page
- Without this test, a future refactor could silently drop `savedAt` from the return value and break session restoration for same-day reloads

## Test plan

- [x] 31/31 persistence tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)