### PR TITLE
fix: filter 0-byte uploads + suppress false re-upload warning for cloud-sync users

### DIFF
--- a/__tests__/upload-orchestrator.test.ts
+++ b/__tests__/upload-orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isTransientServerError, getPartialFailureLevel } from '@/lib/storage/upload-orchestrator';
+import { isTransientServerError, getPartialFailureLevel, filterUploadableFiles } from '@/lib/storage/upload-orchestrator';
 
 describe('isTransientServerError', () => {
   it('identifies 502 Bad Gateway as transient', () => {
@@ -92,5 +92,51 @@ describe('getPartialFailureLevel', () => {
   it('returns error when uploaded === 0 and failed === 0', () => {
     // Edge case: no files processed at all
     expect(getPartialFailureLevel(0, 0)).toBe('error');
+  });
+});
+
+describe('filterUploadableFiles', () => {
+  it('excludes files with size === 0 from uploadable list', () => {
+    const empty = new File([], 'CSL.edf');
+    const real = new File(['data'], 'STR.edf');
+    const { uploadable, emptyCount } = filterUploadableFiles([empty, real]);
+    expect(uploadable).toHaveLength(1);
+    expect(uploadable[0]).toBe(real);
+    expect(emptyCount).toBe(1);
+  });
+
+  it('returns all files when none are empty', () => {
+    const f1 = new File(['a'], 'DATALOG.edf');
+    const f2 = new File(['b'], 'STR.edf');
+    const { uploadable, emptyCount } = filterUploadableFiles([f1, f2]);
+    expect(uploadable).toHaveLength(2);
+    expect(emptyCount).toBe(0);
+  });
+
+  it('returns empty uploadable list when all files are 0-byte', () => {
+    const e1 = new File([], 'CSL.edf');
+    const e2 = new File([], 'STR.edf');
+    const { uploadable, emptyCount } = filterUploadableFiles([e1, e2]);
+    expect(uploadable).toHaveLength(0);
+    expect(emptyCount).toBe(2);
+  });
+
+  it('returns empty lists for empty input', () => {
+    const { uploadable, emptyCount } = filterUploadableFiles([]);
+    expect(uploadable).toHaveLength(0);
+    expect(emptyCount).toBe(0);
+  });
+
+  it('counts multiple empty files accurately', () => {
+    const files = [
+      new File([], 'a.edf'),
+      new File(['x'], 'b.edf'),
+      new File([], 'c.edf'),
+      new File(['y'], 'd.edf'),
+      new File([], 'e.edf'),
+    ];
+    const { uploadable, emptyCount } = filterUploadableFiles(files);
+    expect(uploadable).toHaveLength(2);
+    expect(emptyCount).toBe(3);
   });
 });

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -890,16 +890,20 @@ function AnalyzePageInner() {
               <div className="flex flex-1 flex-wrap items-center justify-between gap-2">
                 <p className="text-sm text-muted-foreground">
                   <span className="font-medium text-foreground">Storage limit reached</span>
-                  {' '}&mdash; {persistenceWarning}
+                  {' '}&mdash; {hasCloudSyncConsent()
+                    ? `Viewing your ${nights.length} most recent night${nights.length !== 1 ? 's' : ''}. All your data is safely backed up.`
+                    : persistenceWarning}
                 </p>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 shrink-0 text-xs text-amber-600 hover:bg-amber-500/10 hover:text-amber-700"
-                  onClick={handleClearLocalData}
-                >
-                  Clear saved data
-                </Button>
+                {!hasCloudSyncConsent() && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 shrink-0 text-xs text-amber-600 hover:bg-amber-500/10 hover:text-amber-700"
+                    onClick={handleClearLocalData}
+                  >
+                    Clear saved data
+                  </Button>
+                )}
               </div>
             </div>
           )}

--- a/lib/storage/upload-orchestrator.ts
+++ b/lib/storage/upload-orchestrator.ts
@@ -47,6 +47,16 @@ export function getPartialFailureLevel(uploaded: number, failed: number): 'error
   return 'warning';
 }
 
+/**
+ * Split files into uploadable (size > 0) and empty.
+ * 0-byte files are AirSense SD card placeholders (CSL.edf, sometimes STR.edf)
+ * that have no upload value and would fail presign validation.
+ */
+export function filterUploadableFiles(files: File[]): { uploadable: File[]; emptyCount: number } {
+  const uploadable = files.filter(f => f.size > 0);
+  return { uploadable, emptyCount: files.length - uploadable.length };
+}
+
 function getFilePath(file: File): string {
   return (file as unknown as { webkitRelativePath?: string }).webkitRelativePath || file.name;
 }
@@ -156,18 +166,22 @@ class UploadOrchestrator {
    * Upload files to cloud storage. Handles hashing, dedup, and upload.
    */
   async upload(files: File[]): Promise<UploadResult> {
-    if (files.length === 0) {
-      return { uploaded: 0, skipped: 0, failed: 0, errors: [] };
+    // Filter empty files before presigning — 0-byte SD card placeholder files (empty CSL.edf etc.) have no upload value
+    const nonEmptyFiles = files.filter(f => f.size > 0);
+    const emptyFileCount = files.length - nonEmptyFiles.length;
+
+    if (nonEmptyFiles.length === 0) {
+      return { uploaded: 0, skipped: emptyFileCount, failed: 0, errors: [] };
     }
 
     this.abortController = new AbortController();
     const signal = this.abortController.signal;
     this.guardPageExit();
 
-    const totalBytes = files.reduce((sum, f) => sum + f.size, 0);
+    const totalBytes = nonEmptyFiles.reduce((sum, f) => sum + f.size, 0);
     this.setState({
       status: 'hashing',
-      progress: { current: 0, total: files.length, bytesUploaded: 0, bytesTotal: totalBytes, stage: 'hashing', skippedExisting: 0 },
+      progress: { current: 0, total: nonEmptyFiles.length, bytesUploaded: 0, bytesTotal: totalBytes, stage: 'hashing', skippedExisting: 0 },
       result: null,
       error: null,
     });
@@ -181,7 +195,7 @@ class UploadOrchestrator {
       if (signal.aborted) throw new Error('Cancelled');
 
       // Step 1: Hash all files
-      const fileHashes = await this.hashFiles(files, signal);
+      const fileHashes = await this.hashFiles(nonEmptyFiles, signal);
       if (signal.aborted) throw new Error('Cancelled');
 
       // Step 2: Check which files already exist
@@ -190,12 +204,12 @@ class UploadOrchestrator {
         progress: { ...this.state.progress, stage: 'checking' },
       });
 
-      const existingHashes = await this.checkExisting(files, fileHashes, signal);
+      const existingHashes = await this.checkExisting(nonEmptyFiles, fileHashes, signal);
       if (signal.aborted) throw new Error('Cancelled');
 
       // Step 3: Upload new files
-      const toUpload = files.filter((_, i) => !existingHashes.has(fileHashes[i]!));
-      const skipped = files.length - toUpload.length;
+      const toUpload = nonEmptyFiles.filter((_, i) => !existingHashes.has(fileHashes[i]!));
+      const skipped = nonEmptyFiles.length - toUpload.length;
 
       this.setState({
         status: 'uploading',
@@ -209,12 +223,12 @@ class UploadOrchestrator {
         },
       });
 
-      const result = await this.uploadFiles(toUpload, fileHashes, files, signal);
-      result.skipped = skipped;
+      const result = await this.uploadFiles(toUpload, fileHashes, nonEmptyFiles, signal);
+      result.skipped = skipped + emptyFileCount;
 
       // Report systematic failures to Sentry
       if (result.failed > 0) {
-        this.reportFailures(result, files.length);
+        this.reportFailures(result, nonEmptyFiles.length);
       }
 
       this.releasePageExit();
@@ -233,11 +247,11 @@ class UploadOrchestrator {
         Sentry.captureMessage('cloud_upload_failed', {
           level: 'error',
           tags: { stage: this.state.status },
-          extra: { error, fileCount: files.length },
+          extra: { error, fileCount: nonEmptyFiles.length },
         });
       }
       this.setState({ status: 'error', error });
-      return { uploaded: 0, skipped: 0, failed: files.length, errors: [error] };
+      return { uploaded: 0, skipped: emptyFileCount, failed: nonEmptyFiles.length, errors: [error] };
     }
   }
 


### PR DESCRIPTION
## Summary

- **Fix 1 (upload-orchestrator):** Filter files with `size === 0` before presign. AirSense SD cards write 0-byte placeholder files (`CSL.edf`, sometimes `STR.edf`) that hit `.positive()` Zod validation and return `fileSize: Too small`. These now count as `skipped` instead of `failed`, eliminating the 12/42 upload errors Tim Hopper saw.
- **Fix 2 (analyze page):** Storage-limit banner now shows a cloud-backup reassurance for users with cloud sync enabled ("Viewing your N most recent nights. All your data is safely backed up.") instead of a false re-upload prompt. Non-cloud users still see the original message.
- Exports `filterUploadableFiles` helper; 5 new unit tests added.

## Test plan

- [ ] `npx tsc --noEmit` — clean (verified)
- [ ] `npm run lint` — clean (verified)
- [ ] `npm test` — 2284 tests pass across 145 files (verified)
- [ ] Manual: upload a folder containing a 0-byte `.edf` — file should appear in skipped count, not failed
- [ ] Manual: trigger storage-limit with cloud sync on — banner shows backup message, no re-upload prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)