### PR TITLE
fix(e2e): update stale demo CTA text assertions after PR #777 copy change

### DIFF
--- a/__tests__/first-run-onboarding.test.tsx
+++ b/__tests__/first-run-onboarding.test.tsx
@@ -117,7 +117,7 @@ describe('FirstRunWelcome', () => {
   it('renders FileUpload and demo CTA on non-iOS', () => {
     render(<FirstRunWelcome onLoadDemo={vi.fn()} onFilesSelected={vi.fn()} />);
     expect(screen.getByTestId('file-upload')).toBeDefined();
-    expect(screen.getByRole('button', { name: /Load 7-night sample dataset/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /Load 7-night sample dataset — no file needed/i })).toBeDefined();
   });
 
   it('renders MobileEmailCapture and demo CTA on iOS', async () => {
@@ -131,7 +131,7 @@ describe('FirstRunWelcome', () => {
   it('fires onLoadDemo callback when demo button clicked', async () => {
     const onLoadDemo = vi.fn();
     render(<FirstRunWelcome onLoadDemo={onLoadDemo} onFilesSelected={vi.fn()} />);
-    fireEvent.click(screen.getByRole('button', { name: /Load 7-night sample dataset/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Load 7-night sample dataset — no file needed/i }));
     expect(onLoadDemo).toHaveBeenCalledOnce();
   });
 

--- a/e2e/demo-flow.spec.ts
+++ b/e2e/demo-flow.spec.ts
@@ -30,11 +30,11 @@ test.describe('Demo Mode Flow', () => {
     await expect(page.getByText('Upload Your Data')).toBeVisible();
   });
 
-  // ── Demo loads via "Try sample data" button ─────────────────
-  test('"Try sample data" button loads demo', async ({ page }) => {
+  // ── Demo loads via demo CTA button ──────────────────────────
+  test('demo CTA button loads demo', async ({ page }) => {
     await page.goto('/analyze');
 
-    await page.getByText('Try sample data').click();
+    await page.getByText('See a demo analysis — no file needed →').click();
 
     // Wait for dashboard tabs
     await expect(

--- a/e2e/export-and-errors.spec.ts
+++ b/e2e/export-and-errors.spec.ts
@@ -79,7 +79,7 @@ test.describe('Mobile Viewport', () => {
     await page.goto('/analyze');
 
     await expect(page.getByText('Choose your SD card folder')).toBeVisible();
-    await expect(page.getByText('Try sample data')).toBeVisible();
+    await expect(page.getByText('See a demo analysis — no file needed →')).toBeVisible();
     await expect(page.locator('input[type="file"][webkitdirectory]')).toBeAttached();
   });
 });

--- a/e2e/free-user-flow.spec.ts
+++ b/e2e/free-user-flow.spec.ts
@@ -39,7 +39,7 @@ test.describe('Free User Flow', () => {
     // File input should be present
     await expect(page.locator('input[type="file"][webkitdirectory]')).toBeAttached();
     // Demo button should be available
-    await expect(page.getByText('Try sample data')).toBeVisible();
+    await expect(page.getByText('See a demo analysis — no file needed →')).toBeVisible();
   });
 
   // ── Analysis complete banner ─────────────────────────────────
@@ -158,7 +158,7 @@ test.describe('Free User Flow', () => {
 
     // Upload form should reappear
     await expect(page.locator('input[type="file"][webkitdirectory]')).toBeAttached({ timeout: 5_000 });
-    await expect(page.getByText('Try sample data')).toBeVisible();
+    await expect(page.getByText('See a demo analysis — no file needed →')).toBeVisible();
   });
 
   // ── No sign-in required for core analysis ───────────────────

--- a/e2e/returning-user.spec.ts
+++ b/e2e/returning-user.spec.ts
@@ -25,7 +25,7 @@ test.describe('Returning User Flow', () => {
     });
 
     // Load demo to quickly get to dashboard
-    await page.getByText('Try sample data').click();
+    await page.getByText('See a demo analysis — no file needed →').click();
 
     await expect(
       page.locator('[data-slot="tabs-trigger"]').filter({ hasText: /overview/i })
@@ -49,7 +49,7 @@ test.describe('Returning User Flow', () => {
     await page.reload();
 
     // Load demo
-    await page.getByText('Try sample data').click();
+    await page.getByText('See a demo analysis — no file needed →').click();
 
     await expect(
       page.locator('[data-slot="tabs-trigger"]').filter({ hasText: /overview/i })
@@ -103,7 +103,7 @@ test.describe('Returning User Flow', () => {
     await page.reload();
 
     // Load demo to get to dashboard
-    await page.getByText('Try sample data').click();
+    await page.getByText('See a demo analysis — no file needed →').click();
 
     await expect(
       page.locator('[data-slot="tabs-trigger"]').filter({ hasText: /overview/i })
@@ -121,7 +121,7 @@ test.describe('Returning User Flow', () => {
     // resource pressure on CI. The test goal is verifying the New → re-upload
     // flow, not the analysis itself (covered by upload-and-analyze.spec.ts).
     await page.goto('/analyze');
-    await page.getByText('Try sample data').click();
+    await page.getByText('See a demo analysis — no file needed →').click();
     await expect(
       page.locator('[data-slot="tabs-trigger"]').filter({ hasText: /overview/i })
     ).toBeVisible({ timeout: 30_000 });

--- a/e2e/session-persistence.spec.ts
+++ b/e2e/session-persistence.spec.ts
@@ -81,7 +81,7 @@ test.describe('Session Persistence', () => {
 
     // Upload form should reappear
     await expect(page.locator('input[type="file"][webkitdirectory]')).toBeAttached({ timeout: 5_000 });
-    await expect(page.getByText('Try sample data')).toBeVisible();
+    await expect(page.getByText('See a demo analysis — no file needed →')).toBeVisible();
   });
 
   // ── Lifetime night counter persists ─────────────────────────


### PR DESCRIPTION
## Problem

PR #777 renamed the demo CTA button text from `Try sample data` to `See a demo analysis — no file needed →` and updated the aria-label from `Load 7-night sample dataset` to `Load 7-night sample dataset — no file needed`, but did not update any of the test files that reference the old strings.

This is the same class of bug that caused the 7 E2E failures in AIR-940.

## Stale assertions fixed (11 total across 5 files)

| File | Changes |
|---|---|
| `e2e/returning-user.spec.ts` | 4 `getByText("Try sample data")` clicks |
| `e2e/session-persistence.spec.ts` | 1 `getByText("Try sample data")` visibility check |
| `e2e/export-and-errors.spec.ts` | 1 `getByText("Try sample data")` visibility check |
| `e2e/demo-flow.spec.ts` | comment, test title, and 1 click call |
| `__tests__/first-run-onboarding.test.tsx` | 2 `/Load 7-night sample dataset/i` aria-label lookups |

## Verification

- All 145 unit test files pass (2284 tests)
- Unit test `first-run-onboarding.test.tsx` passes with updated aria-label
- E2E fixes follow the same pattern used in PR #769 (AIR-940 E2E fix)

Generated with Claude Code