### PR TITLE
fix: correct SD card slot location in FAQ copy

### DIFF
--- a/app/blog/posts/how-to-download-resmed-cpap-data.tsx
+++ b/app/blog/posts/how-to-download-resmed-cpap-data.tsx
@@ -428,7 +428,7 @@ export default function HowToDownloadResMedCPAPData() {
               How do I download data from my ResMed AirSense 10?
             </p>
             <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-              Power off the machine, remove the SD card from the right side panel, insert it into
+              Power off the machine, remove the SD card from the left side, behind a small cover panel, insert it into
               your computer, and open the DATALOG folder. The .edf files inside contain your full
               therapy data. Analysis tools like OSCAR and AirwayLab can read these files directly.
             </p>


### PR DESCRIPTION
## Summary

- Fixes internal inconsistency in `how-to-download-resmed-cpap-data.tsx` FAQ section
- FAQ answer at line 431 referenced "right side panel" for the SD card slot; corrected to "left side, behind a small cover panel"
- Now consistent with step-by-step instructions at line 262 and `resmed-airsense-11-sd-card.tsx:87`

## Test plan

- [ ] Verify line 431 now reads "left side, behind a small cover panel"
- [ ] Check no other "right side panel" SD card references remain for AirSense 11

Fixes AIR-1749

🤖 Generated with [Claude Code](https://claude.com/claude-code)