### PR TITLE
fix: update AirSense 11 copy to full support (AIR-1443)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -41,7 +41,7 @@ const faqData = [
   {
     question: 'What PAP devices are supported?',
     answer:
-      "AirwayLab currently supports ResMed AirSense 10 and AirCurve 10 series machines (CPAP, AutoSet, VPAP, ASV). These machines store detailed flow waveform data in EDF format on the SD card. AirSense 11 / AirCurve 11: ResMed's newer generation machines use an updated EDF format with different signal names. AirwayLab may partially work with AirSense 11 data, but full support is in development and results are not yet validated. Philips Respironics and other manufacturers use different data formats and are not currently supported.",
+      "AirwayLab currently supports ResMed AirSense 10, AirSense 11 AutoSet, AirSense 11 Elite, and AirCurve 10 series machines. These machines store detailed flow waveform data in EDF format on the SD card. Philips Respironics and other manufacturers use different data formats and are not currently supported.",
   },
   {
     question: 'How do I get the data from my SD card?',
@@ -433,25 +433,12 @@ export default function AboutPage() {
         <div className="rounded-xl border border-border/50 bg-card/30 px-5">
           <FAQItem question="What PAP devices are supported?">
             <p className="mb-3">
-              AirwayLab currently supports <strong className="text-foreground">ResMed AirSense 10</strong> and{' '}
-              <strong className="text-foreground">AirCurve 10</strong> series machines (CPAP, AutoSet,
-              VPAP, ASV). These machines store detailed flow waveform data in EDF
-              format on the SD card.
+              AirwayLab currently supports <strong className="text-foreground">ResMed AirSense 10</strong>,{' '}
+              <strong className="text-foreground">AirSense 11 AutoSet</strong>,{' '}
+              <strong className="text-foreground">AirSense 11 Elite</strong>, and{' '}
+              <strong className="text-foreground">AirCurve 10</strong> series machines. These machines store detailed
+              flow waveform data in EDF format on the SD card.
             </p>
-            <div className="mb-3 flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2">
-              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
-              <p className="text-xs">
-                <strong className="text-foreground">AirSense 11 / AirCurve 11:</strong> ResMed&rsquo;s
-                newer generation machines use an updated EDF format with different
-                signal names. AirwayLab may partially work with AirSense 11 data,
-                but full support is in development and results are not yet validated.
-                If you have an AirSense 11, you&rsquo;re welcome to try &mdash; please{' '}
-                <a href="https://github.com/airwaylab-app/airwaylab/issues" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 text-foreground hover:text-primary">
-                  report any issues
-                </a>{' '}
-                to help us improve compatibility.
-              </p>
-            </div>
             <p>
               Philips Respironics and other manufacturers use different
               data formats and are not currently supported.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -167,7 +167,7 @@ const landingFaqData = [
   {
     question: 'What PAP machines does AirwayLab support?',
     answer:
-      'AirwayLab currently supports ResMed AirSense 10, AirCurve 10, and partially AirSense 11. These machines store detailed flow waveform data in EDF format on the SD card. Philips Respironics and other manufacturers use different data formats and are not currently supported.',
+      'AirwayLab supports ResMed AirSense 10, AirSense 11 AutoSet, AirSense 11 Elite, and AirCurve 10 series machines. These machines store detailed flow waveform data in EDF format on the SD card. Philips Respironics and other manufacturers use different data formats and are not currently supported.',
   },
   {
     question: 'Is my sleep data private?',

--- a/lib/device-guides.ts
+++ b/lib/device-guides.ts
@@ -82,7 +82,7 @@ export const DEVICE_GUIDES: DeviceGuide[] = [
     fullName: 'ResMed AirSense 11',
     manufacturer: 'ResMed',
     type: 'Auto',
-    supportLevel: 'partial',
+    supportLevel: 'full',
     sdCardLocation: 'Right side of the machine, behind a flip-open door (same position as AirSense 10)',
     sdCardType: 'Standard SD card. Note: some AirSense 11 models ship without an SD card — you may need to purchase one separately.',
     datalogPath: 'DATALOG folder on the SD card root',
@@ -99,30 +99,22 @@ export const DEVICE_GUIDES: DeviceGuide[] = [
       'Insert the SD card into your computer.',
       'Go to https://airwaylab.app/analyze and click "Upload Your SD Card."',
       'Select the SD card or DATALOG folder. AirwayLab detects the AirSense 11 format automatically.',
-      'Results may show partial data for some metrics. This is expected — see the note below.',
+      'Results show full flow limitation analysis including Glasgow Index, WAT, and NED scores.',
     ],
     tips: [
-      'AirSense 11 support is partial. The core engines (Glasgow Index, WAT, NED) work with AirSense 11 flow data, but some machine settings extraction may be incomplete due to changed signal names in STR.edf.',
-      'If you see "Unknown" for pressure settings in your results, this is an AirSense 11 compatibility limitation, not a data problem.',
-      'The AirSense 11 uses the same SD card slot and EDF format family as the AirSense 10, so the upload process is identical.',
-      'ResMed\'s myAir app works differently on AirSense 11 (cellular upload). The SD card data is more detailed than what myAir shows.',
+      'AirSense 11 AutoSet and AirSense 11 Elite are both fully supported for CPAP/APAP flow limitation analysis (Glasgow Index, WAT, NED).',
+      'Settings extraction (pressure, mode) works via the standard STR.edf signals.',
+      'The AirSense 11 uses the same SD card slot and DATALOG folder structure as the AirSense 10.',
+      "ResMed's myAir app uses cellular upload. The SD card data is more detailed than what myAir shows.",
     ],
     troubleshooting: [
       {
-        question: 'AirwayLab shows "partially supported device"',
-        answer: 'This is expected for AirSense 11. The flow waveform data is parsed correctly, but some metadata fields use different signal names than AirSense 10. Flow limitation analysis (Glasgow, WAT, NED) still works. Settings extraction may be incomplete.',
-      },
-      {
-        question: 'My AirSense 11 didn\'t come with an SD card',
-        answer: 'Some AirSense 11 models ship without a card. Buy any standard SD card (2GB or larger, FAT32 formatted), insert it, and the machine will start recording detailed data from the next session. Data is not retroactive — only nights after the card is inserted are recorded.',
-      },
-      {
-        question: 'Pressure settings show as "Unknown"',
-        answer: 'AirSense 11 uses different signal names in its settings file. AirwayLab may not extract all settings correctly. This doesn\'t affect the flow limitation analysis — only the settings display in the dashboard.',
+        question: "My AirSense 11 didn't come with an SD card",
+        answer: "Some AirSense 11 models ship without a card. Buy any standard SD card (2GB or larger, FAT32 formatted), insert it, and the machine will start recording detailed data from the next session. Data is not retroactive — only nights after the card is inserted are recorded.",
       },
     ],
     metaDescription:
-      'How to upload ResMed AirSense 11 data to AirwayLab. Partial support for flow limitation analysis. Free, browser-based guide with troubleshooting.',
+      'How to upload ResMed AirSense 11 AutoSet and Elite data to AirwayLab. Full support for CPAP/APAP flow limitation analysis. Free, browser-based guide.',
   },
   {
     slug: 'aircurve-10',


### PR DESCRIPTION
## Summary

- `lib/device-guides.ts`: `supportLevel: 'partial'` → `'full'`; tips, troubleshooting, metaDescription, and uploadSteps updated to remove all partial/in-development language; AirSense 11 AutoSet and Elite named explicitly
- `app/about/page.tsx`: amber AlertTriangle "in development / not yet validated" warning block removed from FAQ JSX; JSON-LD `faqData` constant also updated (was missed in original commit)
- `app/page.tsx`: homepage FAQ — "partially AirSense 11" replaced with "AirSense 11 AutoSet, AirSense 11 Elite"

Context: AIR-1442 — paying Supporter assumed AS11 was unsupported. AIR-1438 confirmed full support. Text-only, no-spec-tier change.

## Pre-merge checklist

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] No logic or protected module changes
- [x] No MDR language changes (device listing only)
- [x] One concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)