### PR TITLE
Copy: PDF legend "Needs attention" → "Above typical" (AIR-1386)

### DIFF
--- a/lib/pdf-report.ts
+++ b/lib/pdf-report.ts
@@ -229,7 +229,7 @@ export function openPDFReport(nights: NightResult[]): void {
       Generated ${now} &middot; ${nights.length} night${nights.length !== 1 ? 's' : ''} analysed
     </p>
     <p style="font-size:11px;color:#475569;margin-top:8px;">
-      Traffic lights: \u2705 Good &middot; \u26a0\ufe0f Moderate &middot; \ud83d\udd34 Needs attention
+      Traffic lights: \u2705 Good &middot; \u26a0\ufe0f Moderate &middot; \ud83d\udd34 Above typical
     </p>
   </div>
 


### PR DESCRIPTION
## Summary

Replaces the red traffic-light label in the PDF report legend from **"Needs attention"** (judgment-adjacent) to **"Above typical"** (directional, metric-focused).

- Single copy change in `lib/pdf-report.ts` (line 232)
- No behaviour, logic, or colour changes — label text only
- Consistent with MDR SHOULD rule #8: directional language over clinical judgment language

## Context

- Surfaced by Head of Compliance during the AIR-1384 pre-clear (Compliance PASS already obtained)
- Prerequisite for the PDF-to-community tier experiment (AIR-1381, target 2026-06-02)
- Related: AIR-1386, AIR-1384

## Pre-Merge Checklist

- [x] Full pipeline passes (tests: 1997/1997 pass)
- [x] Bundle size: none (text-only change)
- [x] One concern only: single label copy change
- [x] Standing Pre-Approval Authority (AIR-569 class #1): text-only with Compliance pre-clear

🤖 Generated with [Claude Code](https://claude.ai/claude-code)