### PR TITLE
fix(share): hide owner-only write UI in shared view

### DIFF
--- a/__tests__/overview-tab-shared-view.test.ts
+++ b/__tests__/overview-tab-shared-view.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression guard: SymptomRating and NightContextEditor must be hidden in
+ * shared view (isSharedView=true) in OverviewTab.
+ *
+ * Both components write to localStorage on the viewer's device, which has no
+ * relation to the owner's data. Hiding them prevents confusing silent writes.
+ * (fix/air-1820-owner-write-ui-share-view)
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..');
+const src = fs.readFileSync(
+  path.join(ROOT, 'components/dashboard/overview-tab.tsx'),
+  'utf-8'
+);
+
+const sharedSrc = fs.readFileSync(
+  path.join(ROOT, 'components/share/shared-view-client.tsx'),
+  'utf-8'
+);
+
+describe('OverviewTab — isSharedView prop (AIR-1820)', () => {
+  it('Props interface includes isSharedView?: boolean', () => {
+    expect(src).toContain('isSharedView?: boolean');
+  });
+
+  it('function signature destructures isSharedView with default false', () => {
+    expect(src).toContain('isSharedView = false');
+  });
+
+  it('SymptomRating is guarded by !isSharedView', () => {
+    const symptomIndex = src.indexOf('<SymptomRating');
+    expect(symptomIndex).toBeGreaterThan(-1);
+    // The guard must appear before the component in source order
+    const guardIndex = src.lastIndexOf('!isSharedView', symptomIndex);
+    expect(guardIndex).toBeGreaterThan(-1);
+    expect(guardIndex).toBeLessThan(symptomIndex);
+  });
+
+  it('NightContextEditor is guarded by !isSharedView', () => {
+    const editorIndex = src.indexOf('<NightContextEditor');
+    expect(editorIndex).toBeGreaterThan(-1);
+    const guardIndex = src.lastIndexOf('!isSharedView', editorIndex);
+    expect(guardIndex).toBeGreaterThan(-1);
+    expect(guardIndex).toBeLessThan(editorIndex);
+  });
+});
+
+describe('SharedViewClient — passes isSharedView to OverviewTab (AIR-1820)', () => {
+  it('shared-view-client passes isSharedView={true} to OverviewTab', () => {
+    // Locate the OverviewTab usage in shared-view-client and check for the prop
+    const overviewTabIndex = sharedSrc.indexOf('<OverviewTab');
+    expect(overviewTabIndex).toBeGreaterThan(-1);
+    const snippet = sharedSrc.slice(overviewTabIndex, overviewTabIndex + 300);
+    expect(snippet).toContain('isSharedView={true}');
+  });
+});

--- a/components/dashboard/overview-tab.tsx
+++ b/components/dashboard/overview-tab.tsx
@@ -55,6 +55,7 @@ interface Props {
   onAdjustThreshold?: (metricKey: string) => void;
   isDemo?: boolean;
   isNewUser?: boolean;
+  isSharedView?: boolean;
 }
 
 /** Compute simple mean of the last 7 nights for a given accessor. Returns undefined if <2 nights. */
@@ -66,7 +67,7 @@ function avg7(nights: NightResult[], accessor: (n: NightResult) => number | null
   return vals.reduce((a, b) => a + b, 0) / vals.length;
 }
 
-export function OverviewTab({ nights, selectedNight, previousNight, therapyChangeDate, onUploadOximetry, onReUpload, onOpenAuth, onAdjustThreshold, isDemo = false, isNewUser = false }: Props) {
+export function OverviewTab({ nights, selectedNight, previousNight, therapyChangeDate, onUploadOximetry, onReUpload, onOpenAuth, onAdjustThreshold, isDemo = false, isNewUser = false, isSharedView = false }: Props) {
   const THRESHOLDS = useThresholds();
   const n = selectedNight;
   const p = previousNight;
@@ -163,20 +164,24 @@ export function OverviewTab({ nights, selectedNight, previousNight, therapyChang
         );
       })()}
 
-      {/* Symptom Rating — how did you sleep? */}
-      <SymptomRating
-        night={n}
-        value={symptomRating}
-        onChange={handleSymptomRatingChange}
-        isContributeConsented={isContributeConsented}
-      />
+      {/* Symptom Rating — owner-only; hidden in shared view */}
+      {!isSharedView && (
+        <SymptomRating
+          night={n}
+          value={symptomRating}
+          onChange={handleSymptomRatingChange}
+          isContributeConsented={isContributeConsented}
+        />
+      )}
 
-      {/* Night Context — structured enum fields (caffeine, position, stress, etc.) */}
-      <NightContextEditor
-        night={n}
-        notes={nightNotes}
-        onNotesChange={handleNotesChange}
-      />
+      {/* Night Context — owner-only; hidden in shared view */}
+      {!isSharedView && (
+        <NightContextEditor
+          night={n}
+          notes={nightNotes}
+          onNotesChange={handleNotesChange}
+        />
+      )}
 
       {/* Start-here guidance for new users — positioned right below hero */}
       {isNewUser && (

--- a/components/share/shared-view-client.tsx
+++ b/components/share/shared-view-client.tsx
@@ -210,6 +210,7 @@ export function SharedViewClient({
                 previousNight={previousNight}
                 therapyChangeDate={null}
                 isDemo={false}
+                isSharedView={true}
               />
             </ErrorBoundary>
           </TabsContent>


### PR DESCRIPTION
## Summary

- Adds `isSharedView?: boolean` prop to `OverviewTab` (default `false`)
- Guards `SymptomRating` and `NightContextEditor` with `{!isSharedView && (...)}` — both are localStorage-backed owner-only components that serve no purpose and could silently write to a viewer's device
- `SharedViewClient` passes `isSharedView={true}` to `OverviewTab`
- Adds 5 static regression tests in `__tests__/overview-tab-shared-view.test.ts`

## Test plan

- [x] `npx vitest run __tests__/overview-tab-shared-view.test.ts` — 5/5 pass
- [x] Normal dashboard (`/analyze`): both components still render (`isSharedView` defaults to `false`)
- [x] Shared view (`/shared/[id]`): `SymptomRating` and `NightContextEditor` do not render

Closes AIR-1820

🤖 Generated with [Claude Code](https://claude.com/claude-code)