### PR TITLE
feat: add cloud sync for analysis results (POST /api/nights/sync)

### DIFF
--- a/__tests__/nights-sync-route.test.ts
+++ b/__tests__/nights-sync-route.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+// ── Mocks ──────────────────────────────────────────────────────
+
+const mockValidateOrigin = vi.fn(() => true);
+vi.mock('@/lib/csrf', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  validateOrigin: (...args: any[]) => mockValidateOrigin(...(args as [])),
+}));
+
+const mockIsLimited = vi.fn(() => Promise.resolve(false));
+vi.mock('@/lib/rate-limit', () => ({
+  getRateLimitKey: vi.fn(() => '127.0.0.1'),
+  RateLimiter: class {
+    isLimited() { return mockIsLimited(); }
+  },
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+const mockUpsert = vi.fn(() => Promise.resolve({ error: null }));
+const mockFrom = vi.fn((_table: string) => ({ upsert: mockUpsert }));
+const mockGetUser = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseServer: vi.fn(() =>
+    Promise.resolve({ auth: { getUser: () => mockGetUser() } })
+  ),
+  getSupabaseServiceRole: vi.fn(() => ({ from: (table: string) => mockFrom(table) })),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function makeNight(dateStr = '2024-01-15') {
+  return {
+    dateStr,
+    durationHours: 7.5,
+    sessionCount: 1,
+    settings: { papMode: 'CPAP', epap: 8 },
+    glasgow: { overall: 3.2, skew: 0.4 },
+    wat: { flScore: 22, regularityScore: 1.1, periodicityIndex: 0.05 },
+    ned: { nedMean: 12, fiMean: 0.8, breathCount: 400 },
+    oximetry: null,
+  };
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return {
+    headers: { get: () => null },
+    json: () => Promise.resolve(body),
+  } as unknown as NextRequest;
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('POST /api/nights/sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidateOrigin.mockReturnValue(true);
+    mockIsLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-uuid-1234' } }, error: null });
+    mockUpsert.mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({ upsert: mockUpsert });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('No session') });
+
+    const { POST } = await import('@/app/api/nights/sync/route');
+    const res = await POST(makeRequest({ nights: [makeNight()] }));
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when origin invalid', async () => {
+    mockValidateOrigin.mockReturnValue(false);
+
+    const { POST } = await import('@/app/api/nights/sync/route');
+    const res = await POST(makeRequest({ nights: [makeNight()] }));
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 429 when rate limited', async () => {
+    mockIsLimited.mockResolvedValue(true);
+
+    const { POST } = await import('@/app/api/nights/sync/route');
+    const res = await POST(makeRequest({ nights: [makeNight()] }));
+
+    expect(res.status).toBe(429);
+  });
+
+  it('returns 400 when nights array is empty', async () => {
+    const { POST } = await import('@/app/api/nights/sync/route');
+    const res = await POST(makeRequest({ nights: [] }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when more than 50 nights provided', async () => {
+    const nights = Array.from({ length: 51 }, (_, i) =>
+      makeNight(`2024-01-${String(i + 1).padStart(2, '0')}`)
+    );
+    const { POST } = await import('@/app/api/nights/sync/route');
+    const res = await POST(makeRequest({ nights }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('upserts with correct fields and returns synced count', async () => {
+    const night = makeNight('2024-03-10');
+    const { POST } = await import('@/app/api/nights/sync/route');
+    const res = await POST(makeRequest({ nights: [night] }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { synced: number; skipped: number };
+    expect(body.synced).toBe(1);
+    expect(body.skipped).toBe(0);
+
+    expect(mockFrom).toHaveBeenCalledWith('user_nights');
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-uuid-1234',
+        night_date: '2024-03-10',
+        analysis_data: expect.any(Object),
+      }),
+      { onConflict: 'user_id,night_date' }
+    );
+  });
+
+  it('strips bulk fields (breaths, reras) from ned before upsert', async () => {
+    const nightWithBulk = {
+      ...makeNight('2024-03-11'),
+      ned: { nedMean: 12, breathCount: 400, breaths: [1, 2, 3], reras: [{ start: 0 }] },
+    };
+
+    const { POST } = await import('@/app/api/nights/sync/route');
+    await POST(makeRequest({ nights: [nightWithBulk] }));
+
+    const calls = mockUpsert.mock.calls as unknown as Array<[{ analysis_data: { ned: Record<string, unknown> } }]>;
+    const storedNed = (calls[0]?.[0])?.analysis_data.ned;
+    expect(storedNed?.breaths).toBeUndefined();
+    expect(storedNed?.reras).toBeUndefined();
+    expect(storedNed?.nedMean).toBe(12);
+  });
+
+  it('counts skipped nights when upsert errors', async () => {
+    const supabaseError = { message: 'db error', code: '23505', details: '', hint: '' };
+    mockUpsert.mockResolvedValue({ error: supabaseError as unknown as null });
+
+    const nights = [makeNight('2024-03-12'), makeNight('2024-03-13')];
+    const { POST } = await import('@/app/api/nights/sync/route');
+    const res = await POST(makeRequest({ nights }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { synced: number; skipped: number };
+    expect(body.synced).toBe(0);
+    expect(body.skipped).toBe(2);
+  });
+});

--- a/__tests__/nights-sync.test.ts
+++ b/__tests__/nights-sync.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { syncAnalysisToCloud } from '@/lib/storage/nights-sync';
+import type { NightResult } from '@/lib/types';
+
+// ── Mock fetch ──────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function makeNight(dateStr: string): NightResult {
+  return {
+    dateStr,
+    durationHours: 7,
+    sessionCount: 1,
+    settings: { papMode: 'CPAP', epap: 8 } as NightResult['settings'],
+    glasgow: { overall: 3 } as NightResult['glasgow'],
+    wat: { flScore: 20, regularityScore: 1, periodicityIndex: 0.04 } as NightResult['wat'],
+    ned: {
+      nedMean: 10,
+      breathCount: 300,
+      breaths: [{ ned: 10 }] as unknown as NightResult['ned']['breaths'],
+      reras: [{ start: 0, end: 1 }] as unknown as NightResult['ned']['reras'],
+    } as NightResult['ned'],
+    oximetry: null,
+  } as unknown as NightResult;
+}
+
+function okResponse(synced: number, skipped = 0) {
+  return Promise.resolve(
+    new Response(JSON.stringify({ synced, skipped }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+}
+
+function errorResponse(status = 500) {
+  return Promise.resolve(new Response('{}', { status }));
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('syncAnalysisToCloud', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends a single batch for ≤50 nights', async () => {
+    mockFetch.mockReturnValueOnce(okResponse(5));
+
+    const nights = Array.from({ length: 5 }, (_, i) =>
+      makeNight(`2024-01-${String(i + 1).padStart(2, '0')}`)
+    );
+    const result = await syncAnalysisToCloud(nights);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ synced: 5, skipped: 0, failed: 0 });
+  });
+
+  it('sends two batches for 51 nights', async () => {
+    mockFetch
+      .mockReturnValueOnce(okResponse(50))
+      .mockReturnValueOnce(okResponse(1));
+
+    const nights = Array.from({ length: 51 }, (_, i) =>
+      makeNight(`2024-${String(Math.floor(i / 28) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`)
+    );
+    const result = await syncAnalysisToCloud(nights);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.synced).toBe(51);
+
+    // First batch has 50 nights
+    const firstCall = mockFetch.mock.calls[0]?.[1] as { body: string };
+    const firstBatch = JSON.parse(firstCall.body) as { nights: unknown[] };
+    expect(firstBatch.nights).toHaveLength(50);
+
+    // Second batch has 1 night
+    const secondCall = mockFetch.mock.calls[1]?.[1] as { body: string };
+    const secondBatch = JSON.parse(secondCall.body) as { nights: unknown[] };
+    expect(secondBatch.nights).toHaveLength(1);
+  });
+
+  it('strips bulk data (breaths, reras) before sending', async () => {
+    mockFetch.mockReturnValueOnce(okResponse(1));
+
+    await syncAnalysisToCloud([makeNight('2024-03-01')]);
+
+    const call = mockFetch.mock.calls[0]?.[1] as { body: string };
+    const payload = JSON.parse(call.body) as { nights: Array<{ ned: Record<string, unknown> }> };
+    const sentNed = payload.nights[0]?.ned;
+
+    expect(sentNed?.breaths).toBeUndefined();
+    expect(sentNed?.reras).toBeUndefined();
+    expect(sentNed?.nedMean).toBe(10);
+  });
+
+  it('strips oximetryTrace before sending', async () => {
+    mockFetch.mockReturnValueOnce(okResponse(1));
+
+    const nightWithTrace = {
+      ...makeNight('2024-03-01'),
+      oximetryTrace: new Float32Array([1, 2, 3]),
+    } as unknown as NightResult;
+
+    await syncAnalysisToCloud([nightWithTrace]);
+
+    const call = mockFetch.mock.calls[0]?.[1] as { body: string };
+    const payload = JSON.parse(call.body) as { nights: Array<Record<string, unknown>> };
+    expect(payload.nights[0]?.oximetryTrace).toBeUndefined();
+  });
+
+  it('marks failed count on HTTP error but does not throw', async () => {
+    mockFetch.mockReturnValueOnce(errorResponse(500));
+
+    const nights = [makeNight('2024-03-01'), makeNight('2024-03-02')];
+    const result = await syncAnalysisToCloud(nights);
+
+    expect(result.failed).toBe(2);
+    expect(result.synced).toBe(0);
+  });
+
+  it('marks failed count on network error but does not throw', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    const result = await syncAnalysisToCloud([makeNight('2024-03-01')]);
+
+    expect(result.failed).toBe(1);
+    expect(result.synced).toBe(0);
+  });
+
+  it('aggregates synced/skipped across multiple batches', async () => {
+    mockFetch
+      .mockReturnValueOnce(okResponse(48, 2))
+      .mockReturnValueOnce(okResponse(1));
+
+    const nights = Array.from({ length: 51 }, (_, i) =>
+      makeNight(`2024-${String(Math.floor(i / 28) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`)
+    );
+    const result = await syncAnalysisToCloud(nights);
+
+    expect(result.synced).toBe(49);
+    expect(result.skipped).toBe(2);
+    expect(result.failed).toBe(0);
+  });
+});

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -19,6 +19,7 @@ import { useAuth } from '@/lib/auth/auth-context';
 import { getAnalysisWindowDays } from '@/lib/auth/feature-gate';
 import { storeAnalysisData } from '@/lib/analysis-data-client';
 import { uploadOrchestrator } from '@/lib/storage/upload-orchestrator';
+import { syncAnalysisToCloud } from '@/lib/storage/nights-sync';
 import { DataContribution, type AutoSubmitStatus } from '@/components/dashboard/data-contribution';
 import { NightSelector } from '@/components/common/night-selector';
 import { ExportButtons } from '@/components/dashboard/export-buttons';
@@ -251,6 +252,14 @@ function AnalyzePageInner() {
 
     // Store aggregate analysis data
     storeAnalysisData(currentNights).catch(() => { /* logged in client */ });
+
+    // Sync full analysis results to cloud (non-fatal)
+    if (userRef.current) {
+      syncAnalysisToCloud(currentNights).catch(err => {
+        Sentry.captureException(err, { extra: { context: 'analysis_cloud_sync' } });
+        // Non-fatal: local results still available
+      });
+    }
   }, [user, isDemo, state.nights, persistedData?.nights]);
 
   // Show GitHub star prompt after 30s in demo mode (once per session)

--- a/app/api/nights/sync/route.ts
+++ b/app/api/nights/sync/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import * as Sentry from '@sentry/nextjs';
+import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server';
+import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
+import { validateOrigin } from '@/lib/csrf';
+
+// ~1000 nights/hour per user
+const rateLimiter = new RateLimiter({ windowMs: 3_600_000, max: 1000 });
+
+const MAX_NIGHTS_PER_BATCH = 50;
+
+// Permissive schema — bulk data stripped server-side as defence-in-depth
+const strippedNightResultSchema = z.object({
+  dateStr: z.string(),
+  durationHours: z.number(),
+  sessionCount: z.number(),
+  settings: z.record(z.string(), z.unknown()),
+  glasgow: z.record(z.string(), z.unknown()),
+  wat: z.record(z.string(), z.unknown()),
+  ned: z.record(z.string(), z.unknown()),
+  oximetry: z.record(z.string(), z.unknown()).nullable().optional(),
+  machineSummary: z.record(z.string(), z.unknown()).nullable().optional(),
+  settingsMetrics: z.unknown().optional(),
+}).passthrough();
+
+const bodySchema = z.object({
+  nights: z.array(strippedNightResultSchema).min(1).max(MAX_NIGHTS_PER_BATCH),
+});
+
+type StrippedNight = z.infer<typeof strippedNightResultSchema>;
+
+function stripBulkData(night: StrippedNight): StrippedNight {
+  const ned = { ...((night.ned ?? {}) as Record<string, unknown>) };
+  delete ned.breaths;
+  delete ned.reras;
+
+  return {
+    ...night,
+    ned,
+    // oximetryTrace lives at the top level in full NightResult
+    oximetryTrace: undefined,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    if (!validateOrigin(request)) {
+      return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
+    }
+
+    const ip = getRateLimitKey(request);
+    if (await rateLimiter.isLimited(ip)) {
+      console.error('[nights/sync] 429 rate limited', { ip });
+      return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+    }
+
+    const supabase = await getSupabaseServer();
+    if (!supabase) {
+      return NextResponse.json({ error: 'Auth not configured' }, { status: 503 });
+    }
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const raw = await request.json().catch(() => null);
+    const parsed = bodySchema.safeParse(raw);
+    if (!parsed.success) {
+      const firstError = parsed.error.issues[0]?.message ?? 'Invalid request data';
+      console.error('[nights/sync] 400 validation failed', { error: firstError });
+      return NextResponse.json({ error: firstError }, { status: 400 });
+    }
+
+    const serviceRole = getSupabaseServiceRole();
+    if (!serviceRole) {
+      return NextResponse.json({ error: 'Service not configured' }, { status: 503 });
+    }
+
+    // Strip bulk data server-side as defence-in-depth
+    const nights = parsed.data.nights.map(stripBulkData);
+
+    // Upsert each night — idempotent on (user_id, night_date)
+    let synced = 0;
+    let skipped = 0;
+
+    for (const night of nights) {
+      const nightDate = night.dateStr;
+      const { error } = await serviceRole
+        .from('user_nights')
+        .upsert(
+          { user_id: user.id, night_date: nightDate, analysis_data: night },
+          { onConflict: 'user_id,night_date' }
+        );
+
+      if (error) {
+        Sentry.captureException(error, {
+          tags: { route: 'nights/sync', step: 'upsert' },
+          extra: { nightDate, userId: user.id.slice(0, 8) },
+        });
+        skipped++;
+      } else {
+        synced++;
+      }
+    }
+
+    // Anonymised user ID in logs (first 8 chars of UUID)
+    const anonymisedId = user.id.slice(0, 8);
+    console.error('[nights/sync] sync complete', {
+      action: 'nights_sync',
+      user_id: anonymisedId,
+      count: nights.length,
+      synced,
+      skipped,
+    });
+
+    return NextResponse.json({ synced, skipped });
+  } catch (err) {
+    Sentry.captureException(err, { tags: { route: 'nights/sync' } });
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/lib/storage/nights-sync.ts
+++ b/lib/storage/nights-sync.ts
@@ -1,0 +1,54 @@
+import type { NightResult } from '@/lib/types';
+
+const BATCH_SIZE = 50;
+
+type SyncResult = { synced: number; skipped: number; failed: number };
+
+function stripBulkData(night: NightResult): Record<string, unknown> {
+  const { breaths: _breaths, reras: _reras, ...nedSummary } = night.ned;
+  const { oximetryTrace: _oximetryTrace, ...rest } = night as NightResult & { oximetryTrace?: unknown };
+  return {
+    ...rest,
+    ned: nedSummary,
+    oximetry: night.oximetry ?? null,
+  };
+}
+
+/**
+ * Syncs analysis results to the user's cloud account.
+ * Batches in chunks of 50, strips bulk data before sending.
+ * Non-fatal: failed batches increment `failed` but do not throw.
+ */
+export async function syncAnalysisToCloud(nights: NightResult[]): Promise<SyncResult> {
+  const result: SyncResult = { synced: 0, skipped: 0, failed: 0 };
+
+  const stripped = nights.map(stripBulkData);
+
+  for (let i = 0; i < stripped.length; i += BATCH_SIZE) {
+    const batch = stripped.slice(i, i + BATCH_SIZE);
+
+    try {
+      const res = await fetch('/api/nights/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ nights: batch }),
+      });
+
+      if (!res.ok) {
+        console.error('[nights-sync] batch failed', { status: res.status, batchStart: i });
+        result.failed += batch.length;
+        continue;
+      }
+
+      const data = (await res.json()) as { synced?: number; skipped?: number };
+      result.synced += data.synced ?? 0;
+      result.skipped += data.skipped ?? 0;
+    } catch (err) {
+      console.error('[nights-sync] batch error', { batchStart: i, err });
+      result.failed += batch.length;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/nights/sync` route: auth-guarded, Zod-validated, upserts stripped `NightResult[]` to `user_nights` (idempotent on `user_id,night_date`)
- Adds `lib/storage/nights-sync.ts`: client helper batching in chunks of 50, strips bulk arrays before send
- Adds fire-and-forget sync call in `app/analyze/page.tsx` after analysis completes (non-fatal, Sentry-captured)
- Tests: 15 tests covering auth guard, Zod validation, bulk-field stripping, batching, and failure tolerance

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [x] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)