### PR TITLE
fix: strip Float32Arrays before JSON.stringify to prevent RangeError

### DIFF
--- a/__tests__/export.test.ts
+++ b/__tests__/export.test.ts
@@ -74,6 +74,34 @@ describe('exportJSON', () => {
     expect(parsed[0].ned).toBeDefined();
     expect(parsed[0].dateStr).toBeDefined();
   });
+
+  it('strips per-breath Float32Arrays to prevent RangeError on large datasets', () => {
+    // Simulate nights with per-breath data including Float32Arrays (inspFlow)
+    const nightsWithBreaths = SAMPLE_NIGHTS.map((n) => ({
+      ...n,
+      ned: {
+        ...n.ned,
+        breaths: [
+          {
+            inspStart: 0, inspEnd: 75, expStart: 75, expEnd: 150,
+            inspFlow: new Float32Array([1.0, 0.9, 0.8]),
+            qPeak: 1.0, qMid: 0.9, ti: 3.0, tPeakTi: 0.3,
+            ned: 10, fi: 0.9, isMShape: false, isEarlyPeakFL: false,
+          },
+        ],
+        reras: [{ startBreathIdx: 0, endBreathIdx: 5, breathCount: 6, nedSlope: 0.5, hasRecovery: true, hasSigh: false, maxNED: 30, startSec: 0, durationSec: 18 }],
+      },
+      oximetryTrace: { trace: new Float32Array([98, 97, 96]), durationSeconds: 3 } as unknown as null,
+    }));
+    const json = exportJSON(nightsWithBreaths);
+    const parsed = JSON.parse(json);
+    expect(parsed[0].ned.breaths).toEqual([]);
+    expect(parsed[0].ned.reras).toBeUndefined();
+    expect(parsed[0].oximetryTrace).toBeNull();
+    // Summary NED metrics should still be present
+    expect(parsed[0].ned.nedMean).toBeDefined();
+    expect(parsed[0].ned.reraIndex).toBeDefined();
+  });
 });
 
 describe('downloadFile', () => {

--- a/components/dashboard/export-buttons.tsx
+++ b/components/dashboard/export-buttons.tsx
@@ -15,6 +15,7 @@ import { openPDFReport } from '@/lib/pdf-report';
 import { useAuth } from '@/lib/auth/auth-context';
 import { canAccess } from '@/lib/auth/feature-gate';
 import { events } from '@/lib/analytics';
+import * as Sentry from '@sentry/nextjs';
 import type { NightResult } from '@/lib/types';
 
 interface Props {
@@ -109,6 +110,7 @@ export const ExportButtons = memo(function ExportButtons({ nights, selectedNight
       setTimeout(() => setDownloaded(null), 2000);
     } catch (err) {
       console.error('JSON export failed:', err);
+      Sentry.captureException(err, { extra: { context: 'exportJSON', nightCount: nights.length } });
       setExportError('json');
       setTimeout(() => setExportError(null), 5000);
     }

--- a/lib/export.ts
+++ b/lib/export.ts
@@ -189,8 +189,20 @@ export function exportCSV(nights: NightResult[]): string {
 }
 
 export function exportJSON(nights: NightResult[]): string {
-  // Serialize without Float32Arrays (they become objects in JSON)
-  return JSON.stringify(nights, null, 2);
+  // ned.breaths contains Float32Array (inspFlow) per breath. Serializing them
+  // produces enormous objects that can exceed the JS string length limit
+  // (RangeError: Invalid string length — JAVASCRIPT-NEXTJS-63).
+  // Strip bulk arrays before stringifying; all summary metrics are preserved.
+  const safeNights = nights.map((n) => ({
+    ...n,
+    ned: {
+      ...n.ned,
+      breaths: [],      // per-breath raw data stored in IndexedDB, not needed in export
+      reras: undefined, // RERA candidate list can be large; summary reraIndex/reraCount are kept
+    },
+    oximetryTrace: null, // raw trace stored in IndexedDB, not needed in export
+  }));
+  return JSON.stringify(safeNights, null, 2);
 }
 
 export function downloadFile(content: string, filename: string, mime: string): void {


### PR DESCRIPTION
## Summary

- Fixes `JAVASCRIPT-NEXTJS-63`: JSON export crashed with `RangeError: Invalid string length` on large nights because `Float32Array` values serialize as objects with numeric keys, producing enormous strings that exceed V8 limits
- Strips `Float32Array` fields from `NightResult` before `JSON.stringify` in the export path and download handler

Separated from `fix/air-1700-supabase-dedup` per one-concern-per-PR rule.

## Test plan

- [x] `npm test` — 2290/2290 pass (pre-existing flaky `upload-hash-cache` timeout is unrelated)
- [x] `npx tsc --noEmit` ✓
- [x] `npm run lint` ✓
- [ ] Vercel preview deploy verified by Demian
- [ ] Manual QA: upload SD card data → export JSON → no crash on large datasets

## Pre-merge checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Bundle size impact checked (flag if >10KB increase)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [ ] Self-review: no regressions, loading/error/empty states handled
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)