### PR TITLE
feat(seo): add FAQPage JSON-LD to epworth-sleepiness-scale page

### DIFF
--- a/__tests__/upload-hash-cache.test.ts
+++ b/__tests__/upload-hash-cache.test.ts
@@ -71,7 +71,7 @@ describe('HashCache', () => {
     // Most recent entries should still be accessible
     const recent = cache.get('DATALOG/night3999/BRP.edf', 1024 + 3999, 1710000000000);
     expect(recent).toBe('a'.repeat(64));
-  }, 15000);
+  });
 
   it('ignores entries older than 30 days', () => {
     // Manually write an expired entry

--- a/lib/blog-posts.ts
+++ b/lib/blog-posts.ts
@@ -1234,6 +1234,37 @@ export const blogPosts: BlogPost[] = [
     tags: ['ESS', 'Fatigue', 'UARS', 'Research'],
     ogDescription:
       'The Epworth Sleepiness Scale conflates sleepiness and fatigue. If your main symptom is exhaustion rather than drowsiness, the ESS may miss your problem entirely.',
+    faqItems: [
+      {
+        question: 'What is a normal Epworth Sleepiness Scale score?',
+        answer:
+          'A score of 0–9 is in the normal range. A score of 10 or above is in the excessive sleepiness range. Your sleep physician can put your score in context with your other symptoms and test results.',
+      },
+      {
+        question: 'What does an ESS score of 10 mean?',
+        answer:
+          'A score of 10 sits at the boundary between normal and mild-to-moderate excessive sleepiness. It is one data point — not a diagnosis. Discuss with your sleep physician what it means alongside your other symptoms.',
+      },
+      {
+        question: 'What does an ESS score of 16 or above mean?',
+        answer:
+          'A score of 16–24 is in the severe excessive sleepiness range. This is a signal to discuss further evaluation with your sleep specialist or GP.',
+      },
+      {
+        question: 'Can I have sleep apnea with a low Epworth score?',
+        answer:
+          'Yes. A low ESS does not rule out sleep-disordered breathing. The ESS measures subjective sleepiness — but many people whose primary complaint is fatigue (rather than the urge to doze off) score low on the ESS even when their breathing data shows significant flow limitation or RERAs. A sleep study or objective data review gives a more complete picture.',
+      },
+      {
+        question: 'What is the difference between the ESS and STOP-BANG?',
+        answer:
+          'The ESS measures how sleepy you feel during the day. STOP-BANG assesses risk factors for obstructive sleep apnea (snoring, BMI, neck size, age, etc.). They measure different things and are often used together in a clinical assessment.',
+      },
+      {
+        question: 'How many questions does the Epworth Sleepiness Scale have?',
+        answer: 'The ESS has 8 questions. Each is rated 0–3, giving a maximum score of 24.',
+      },
+    ],
   },
   {
     slug: 'what-is-cns-sensitization',


### PR DESCRIPTION
## Summary

- Adds `faqItems` to the `epworth-sleepiness-scale` entry in `lib/blog-posts.ts`, enabling the existing FAQPage JSON-LD generation in `app/blog/[slug]/page.tsx` to emit structured data for Google rich results
- Extracts all 6 Q&A pairs verbatim from the FAQ section already visible in the page component
- Fixes a pre-existing TypeScript error in `__tests__/upload-hash-cache.test.ts` (redundant trailing timeout arg on an `it()` call that already used the `{ timeout }` options object)

**Note:** The other 3 pages listed in AIR-1837 (`what-are-reras-sleep-apnea`, `what-is-uars`, `what-does-cpap-ahi-mean`) already had `faqItems` populated and were already generating FAQPage JSON-LD.

## Test plan

- [ ] TypeScript: `npx tsc --noEmit` — clean
- [ ] All 2367 tests pass
- [ ] Verify `/blog/epworth-sleepiness-scale` renders a `<script type="application/ld+json">` block with `@type: FAQPage` (Google Rich Results Test)

Closes AIR-1837

🤖 Generated with [Claude Code](https://claude.com/claude-code)