### PR TITLE
fix: remove redundant Sentry info event on device submission

### DIFF
--- a/app/api/submit-device-data/route.ts
+++ b/app/api/submit-device-data/route.ts
@@ -91,15 +91,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    Sentry.captureMessage('Unsupported device data submitted', {
-      level: 'info',
-      tags: {
-        route: 'submit-device-data',
-        device_guess: deviceGuess ?? 'unknown',
-        total_files: String(fileStructure.totalFiles),
-      },
-    });
-
     return NextResponse.json({ success: true });
   } catch (err) {
     Sentry.captureException(err, {


### PR DESCRIPTION
## Summary

- `JAVASCRIPT-NEXTJS-6A` (AIR-1871) is intentional instrumentation — fires on every successful unsupported-device submission from `UnsupportedDeviceDialog`
- The frontend consent gate is correct; the 3 events represent 3 real users voluntarily submitting SD card metadata
- The `captureMessage` on success is redundant: every submission is already stored durably in `unsupported_device_submissions`. No value over the DB record, only alert noise
- Removed the success-path `captureMessage`; error-path Sentry captures preserved

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean  
- [x] `npm test` — 152 test files / 2367 tests passed
- [ ] Verify Sentry `JAVASCRIPT-NEXTJS-6A` stops generating new events post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)