### PR TITLE
Add good-AHI-on-CPAP and CPAP data report blog articles

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -58,10 +58,12 @@ import DreamMapperShuttingDown from '../posts/dreammapper-shutting-down';
 import HowToReadCPAPTherapyReport from '../posts/how-to-read-cpap-therapy-report';
 import CPAPVsBiPAP from '../posts/cpap-vs-bipap';
 import OSCARCPAPSoftwareAlternatives from '../posts/oscar-cpap-software-alternatives';
+import CPAPDataReportWhatDoctorSees from '../posts/cpap-data-report-what-doctor-sees';
 
 const postComponents: Record<string, React.ComponentType> = {
   'cpap-vs-bipap': CPAPVsBiPAP,
   'how-to-read-cpap-therapy-report': HowToReadCPAPTherapyReport,
+  'cpap-data-report-what-doctor-sees': CPAPDataReportWhatDoctorSees,
   'dreammapper-shutting-down': DreamMapperShuttingDown,
   'what-does-cpap-ahi-mean': WhatDoesCpapAhiMean,
   'how-to-download-resmed-cpap-data': HowToDownloadResMedCPAPData,

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -59,8 +59,10 @@ import HowToReadCPAPTherapyReport from '../posts/how-to-read-cpap-therapy-report
 import CPAPVsBiPAP from '../posts/cpap-vs-bipap';
 import OSCARCPAPSoftwareAlternatives from '../posts/oscar-cpap-software-alternatives';
 import CPAPDataReportWhatDoctorSees from '../posts/cpap-data-report-what-doctor-sees';
+import GoodAHIOnCPAP from '../posts/good-ahi-on-cpap';
 
 const postComponents: Record<string, React.ComponentType> = {
+  'good-ahi-on-cpap': GoodAHIOnCPAP,
   'cpap-vs-bipap': CPAPVsBiPAP,
   'how-to-read-cpap-therapy-report': HowToReadCPAPTherapyReport,
   'cpap-data-report-what-doctor-sees': CPAPDataReportWhatDoctorSees,

--- a/app/blog/posts/cpap-data-report-what-doctor-sees.tsx
+++ b/app/blog/posts/cpap-data-report-what-doctor-sees.tsx
@@ -1,0 +1,450 @@
+import Link from 'next/link';
+import {
+  Activity,
+  ArrowRight,
+  BarChart3,
+  BookOpen,
+  ClipboardList,
+  FileText,
+  Info,
+  Shield,
+} from 'lucide-react';
+
+export default function CPAPDataReportWhatDoctorSees() {
+  return (
+    <article>
+      <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
+        If your doctor or insurance company has asked for a &quot;CPAP compliance report&quot; and
+        you&apos;ve stared at the numbers wondering what any of it means — you&apos;re not alone.
+        Most CPAP users are handed a machine, told to use it, and then asked months later to prove
+        they&apos;ve been using it correctly. Nobody explains the numbers.
+      </p>
+
+      <p className="mt-4 text-base leading-relaxed text-muted-foreground sm:text-lg">
+        This article walks you through exactly what&apos;s in a{' '}
+        <strong className="text-foreground">CPAP data report</strong>, what each metric is
+        measuring, and what &quot;compliance&quot; actually means in the context of insurance and
+        clinical follow-up.
+      </p>
+
+      <div className="mt-6 rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">
+        <p className="text-sm text-muted-foreground">
+          <strong className="text-foreground">Medical disclaimer:</strong> AirwayLab is a
+          data-visualization tool, not a medical device. Nothing in this article constitutes medical
+          advice. Always discuss your therapy data and any questions about your treatment with your
+          prescribing physician or sleep specialist.
+        </p>
+      </div>
+
+      {/* What Is a CPAP Compliance Report */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <FileText className="h-5 w-5 text-blue-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">What Is a CPAP Compliance Report?</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            A CPAP compliance report is a summary of how you&apos;ve been using your CPAP or BiPAP
+            machine, pulled from the data stored on your device&apos;s SD card or transmitted via
+            the manufacturer&apos;s cloud app (like ResMed&apos;s myAir or Philips DreamMapper).
+          </p>
+          <p>
+            The report captures session-level data: when you used the machine, for how long, and
+            how the machine behaved while you were asleep. Most devices record this data
+            automatically — you don&apos;t need to do anything to generate it.
+          </p>
+          <p>
+            Your doctor uses this data at follow-up appointments to see how therapy is going. Your
+            insurance company uses a subset of it to confirm that you&apos;re meeting coverage
+            requirements.
+          </p>
+        </div>
+      </section>
+
+      {/* Key Metrics */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <BarChart3 className="h-5 w-5 text-purple-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">The Key Metrics in Your Report</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>Here&apos;s what you&apos;ll actually see, and what each number represents.</p>
+
+          {/* AHI */}
+          <div className="rounded-xl border border-border/50 p-5">
+            <p className="font-semibold text-foreground">AHI (Apnea-Hypopnea Index)</p>
+            <div className="mt-3 space-y-3 text-sm text-muted-foreground">
+              <p>
+                AHI is the number of apneas (complete pauses in breathing) and hypopneas (partial
+                reductions in airflow) recorded per hour of sleep, as detected by your CPAP device.
+              </p>
+              <p>
+                Your CPAP machine estimates AHI based on the airflow it measures through the mask
+                circuit. Device-reported AHI is a machine estimate — not the same as a
+                lab-measured AHI from a polysomnography study. The machine is using pressure and
+                flow data to infer events, which is useful context but not a clinical diagnosis.
+              </p>
+              <p>
+                Your device reports a <em>residual</em> AHI — the events recorded while CPAP
+                therapy was running. A lower residual AHI is the figure your insurer reviews for
+                coverage purposes — your clinician can put that number in context.
+              </p>
+            </div>
+          </div>
+
+          {/* Usage Hours */}
+          <div className="rounded-xl border border-border/50 p-5">
+            <p className="font-semibold text-foreground">Usage Hours</p>
+            <div className="mt-3 space-y-3 text-sm text-muted-foreground">
+              <p>
+                This is the simplest metric: how many hours per night you actually used the machine.
+                Most devices log usage from when air starts flowing to when it stops.
+              </p>
+              <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+                <p className="text-sm font-semibold text-amber-500">Why this matters for insurance</p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  US insurance companies and many employer wellness programs typically require at
+                  least 4 hours of use per night on at least 70% of nights over a 30-day period.
+                  This is the Medicare compliance threshold, and most private insurers follow a
+                  similar standard. If usage hours fall below this threshold, coverage for CPAP
+                  supplies or replacement equipment may be affected. If your data is borderline,
+                  talk to your DME supplier and prescribing physician.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Mask Leak Rate */}
+          <div className="rounded-xl border border-border/50 p-5">
+            <p className="font-semibold text-foreground">Mask Leak Rate</p>
+            <div className="mt-3 space-y-3 text-sm text-muted-foreground">
+              <p>
+                Your mask needs to maintain a seal for the device to work as intended.
+                &quot;Unintentional leak&quot; (or &quot;large mask leak&quot;) refers to air
+                escaping around the mask seal — not the intentional exhalation vents built into
+                every CPAP mask.
+              </p>
+              <p>
+                Leak rate is measured in liters per minute (L/min). Your device manual or clinical
+                documentation will specify the threshold for your particular model. High leak data
+                in your report can prompt your doctor to look at mask fit or recommend a refitting
+                appointment.
+              </p>
+            </div>
+          </div>
+
+          {/* Events Per Hour */}
+          <div className="rounded-xl border border-border/50 p-5">
+            <p className="font-semibold text-foreground">Events Per Hour / Event Breakdown</p>
+            <div className="mt-3 space-y-3 text-sm text-muted-foreground">
+              <p>
+                Some reports break down residual AHI further — separating obstructive apneas (OA),
+                central apneas (CA), hypopneas (H), and flow limitations. BiPAP devices often also
+                report RERAs (respiratory effort-related arousals).
+              </p>
+              <p>
+                These breakdowns describe the character of any residual breathing disruptions
+                recorded during the session. Interpreting what that breakdown means clinically —
+                and whether any follow-up is needed — is a conversation for you and your sleep
+                physician.
+              </p>
+            </div>
+          </div>
+
+          {/* Pressure Data */}
+          <div className="rounded-xl border border-border/50 p-5">
+            <p className="font-semibold text-foreground">Pressure Data</p>
+            <div className="mt-3 space-y-3 text-sm text-muted-foreground">
+              <p>
+                If you&apos;re on a fixed-pressure CPAP, your prescribed pressure is constant and
+                won&apos;t vary night to night. If you&apos;re on APAP (auto-adjusting), your
+                report will show the pressure range the device used — typically the 95th percentile
+                (P95) and median pressure. This gives your doctor a record of how the machine was
+                responding on a nightly basis.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Insurance Compliance */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Shield className="h-5 w-5 text-emerald-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            What &quot;Compliance&quot; Actually Means for Insurance
+          </h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            The word &quot;compliance&quot; gets used in two ways, and it&apos;s worth keeping them
+            separate.
+          </p>
+          <div className="space-y-3">
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Insurance compliance</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Mechanical: did you use the machine enough? The US standard is at least 4 hours of
+                use per night, on at least 70% of nights, measured over any 30-consecutive-day
+                period. This threshold is the Medicare benchmark, and most private insurers use the
+                same or similar standard. Compliance is typically verified 90 days after your
+                initial CPAP setup. Ongoing coverage for resupply and equipment renewals can depend
+                on meeting this threshold.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Clinical compliance</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                A broader term your doctor uses — it refers to the overall picture of how therapy
+                is going: AHI trends over time, leak patterns, symptoms, how you feel. It involves
+                more than just hours logged.
+              </p>
+            </div>
+          </div>
+          <p>
+            If you&apos;re worried about your insurance status, the right first call is to your DME
+            (durable medical equipment) supplier and your prescribing clinician. They have access
+            to your full compliance record and can help you navigate coverage requirements.
+          </p>
+        </div>
+      </section>
+
+      {/* How to Pull Your Own Report */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <ClipboardList className="h-5 w-5 text-blue-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">How to Pull Your Own Compliance Report</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            You don&apos;t need to wait for your doctor to access this data. Both major
+            manufacturers offer ways to view your own summary.
+          </p>
+          <div className="space-y-3">
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">
+                ResMed devices (AirSense 10, AirSense 11, AirCurve)
+              </p>
+              <ul className="mt-2 ml-4 list-disc space-y-1 text-sm text-muted-foreground">
+                <li>
+                  Log in to myAir (resmed.com/myair) — usage hours, AHI, and leak data are
+                  displayed on your dashboard
+                </li>
+                <li>
+                  For more detailed data, export your SD card and load it into OSCAR or AirwayLab
+                </li>
+              </ul>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">
+                Philips Respironics devices (DreamStation, System One)
+              </p>
+              <ul className="mt-2 ml-4 list-disc space-y-1 text-sm text-muted-foreground">
+                <li>DreamMapper provides a basic cloud dashboard</li>
+                <li>
+                  For detailed session data, OSCAR (free, open-source) reads Philips SD cards
+                </li>
+              </ul>
+            </div>
+          </div>
+          <p>
+            For the most granular data — flow waveforms, pressure graphs, RERA counts — the SD
+            card route gives you the full record of what the machine captured.
+          </p>
+        </div>
+      </section>
+
+      {/* How AirwayLab Shows You This Data */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Activity className="h-5 w-5 text-primary" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            How AirwayLab Shows You This Data
+          </h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            AirwayLab brings together your compliance metrics, nightly AHI data, leak trends, and
+            event breakdowns into one dashboard — the same underlying data that goes into your
+            doctor&apos;s report, formatted so it&apos;s readable without a clinical background.
+          </p>
+          <div className="space-y-3">
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Usage and AHI trends</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                AirwayLab plots your nightly usage hours and AHI across all sessions on the SD
+                card. Trends across multiple nights are easier to spot in a chart than in your
+                device&apos;s rolling 7-day average.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Event type breakdown</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                AirwayLab separates obstructive and central events across your sessions. Knowing
+                how that ratio changes over time is useful context to bring to a clinician review.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Beyond the compliance report</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                The four AirwayLab analysis engines run on your raw flow waveform — not just the
+                device-reported events. This gives you access to flow limitation scores, breathing
+                regularity analysis, and RERA-related pattern detection that are invisible in your
+                nightly compliance summary. All of it runs entirely in your browser; your data
+                never leaves your device.
+              </p>
+            </div>
+          </div>
+          <p>
+            AirwayLab shows you all of this in one dashboard — upload your SD card or ResMed myAir
+            data to get started. It&apos;s free, and always will be.
+          </p>
+        </div>
+      </section>
+
+      {/* Before You Interpret */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Info className="h-5 w-5 text-muted-foreground" />
+          <h2 className="text-xl font-bold sm:text-2xl">Before You Interpret Your Numbers</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            The data in your report is a record of what the machine measured — not a verdict on how
+            you&apos;re doing. A single night with a higher AHI, a flagged leak, or a pressure range
+            that looks unfamiliar doesn&apos;t tell you much on its own. Trends over time matter
+            more than any individual reading, and context matters most of all.
+          </p>
+          <p>
+            If you see something in your data that concerns you — a spike in events, a persistent
+            leak flag, an unusual pressure pattern — bring it to your sleep physician or prescribing
+            clinician. They can interpret it alongside your full clinical history and symptoms.
+          </p>
+          <p>
+            AirwayLab helps you <em>see</em> your data clearly. What to do with it is a
+            conversation for you and your doctor.
+          </p>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <BookOpen className="h-5 w-5 text-emerald-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">Frequently Asked Questions</h2>
+        </div>
+        <div className="mt-4 space-y-4">
+          {[
+            {
+              q: 'What is a CPAP compliance report?',
+              a: "A CPAP compliance report is a summary of your therapy usage data — how often you used the machine, for how long, and key metrics like AHI and leak rate. It's generated from your device's SD card or cloud app data. Your doctor uses it to review therapy progress; your insurance company uses it to verify coverage requirements.",
+            },
+            {
+              q: 'How many hours do I need to use my CPAP to be compliant?',
+              a: 'The US Medicare standard — and the benchmark most private insurers follow — is at least 4 hours of use per night on at least 70% of nights over a 30-day period. If you fall below this threshold, coverage for equipment and supplies may be affected. Your DME supplier can pull your detailed usage record if you need to review your status.',
+            },
+            {
+              q: 'What AHI does my insurance company look at?',
+              a: "Insurers typically look at your residual AHI — the events recorded while therapy was running — as a favorable data point in compliance reviews. Your clinician can put your specific number in context and explain what it means for your care.",
+            },
+            {
+              q: 'What does "large mask leak" mean on my CPAP report?',
+              a: 'A large mask leak flag means unintentional air escaped around your mask seal beyond the threshold your device uses to flag data-quality concerns. High or persistent leak can reduce the reliability of AHI readings for that session and may prompt your doctor to review mask fit. Your clinician can help assess recurring leak flags in your specific context.',
+            },
+            {
+              q: 'Can I access my own CPAP compliance data?',
+              a: "Yes. ResMed users can view a summary in the myAir app, or export their SD card for detailed data. Philips DreamStation users can use DreamMapper for cloud summary data, or OSCAR (free, open-source) for full SD card data. AirwayLab reads ResMed SD card data directly in your browser — no upload required.",
+            },
+            {
+              q: 'What is the difference between CPAP compliance and CPAP effectiveness?',
+              a: 'Compliance (for insurance purposes) is largely about usage hours — did you use the machine enough. Clinical effectiveness is a broader judgment that includes AHI trends, leak patterns, and how you actually feel. Compliance is a prerequisite for coverage; effectiveness is what your clinician evaluates at follow-up.',
+            },
+            {
+              q: 'Does AirwayLab show my compliance data?',
+              a: "Yes. AirwayLab reads your usage hours, AHI, event breakdowns, leak rate, and pressure data from your ResMed SD card and displays it in one dashboard — the same data that goes into your doctor's compliance report. It also runs four additional analysis engines on your raw flow waveform, surfacing metrics like flow limitation scores and RERA-related patterns that don't appear in standard compliance reports. Everything runs in your browser; your data never leaves your device.",
+            },
+          ].map(({ q, a }) => (
+            <div key={q} className="rounded-xl border border-border/50 p-5">
+              <p className="text-sm font-semibold text-foreground">{q}</p>
+              <p className="mt-2 text-sm text-muted-foreground">{a}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="mt-10 rounded-xl border border-primary/20 bg-primary/5 p-6 text-center">
+        <h3 className="text-lg font-bold">See Your CPAP Report in One Dashboard</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          AirwayLab shows you all of this in one dashboard — upload your SD card or ResMed MyAir
+          data. It&apos;s free, browser-based, and your data never leaves your device.
+        </p>
+        <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+          <Link
+            href="/analyze"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-glow transition-colors hover:bg-primary/90"
+          >
+            Analyse Your CPAP Data <ArrowRight className="h-4 w-4" />
+          </Link>
+          <Link
+            href="/blog/what-does-cpap-ahi-mean"
+            className="inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Read: What Does My AHI Mean?
+          </Link>
+        </div>
+      </section>
+
+      {/* Related reading */}
+      <section className="mt-8 border-t border-border/30 pt-6">
+        <p className="mb-2 text-xs font-semibold text-foreground">Related reading</p>
+        <div className="space-y-1 text-sm text-muted-foreground">
+          <p>
+            <Link
+              href="/blog/what-does-cpap-ahi-mean"
+              className="text-primary hover:text-primary/80"
+            >
+              What Does My CPAP AHI Number Mean?
+            </Link>{' '}
+            — a plain-language guide to the metric at the centre of your report.
+          </p>
+          <p>
+            <Link
+              href="/blog/cpap-leak-rate-meaning"
+              className="text-primary hover:text-primary/80"
+            >
+              CPAP Leak Rate: What It Means and When to Worry
+            </Link>{' '}
+            — understanding unintentional leak and what the data shows.
+          </p>
+          <p>
+            <Link
+              href="/blog/what-are-reras-sleep-apnea"
+              className="text-primary hover:text-primary/80"
+            >
+              What Are RERAs?
+            </Link>{' '}
+            — the breathing events your compliance report doesn&apos;t count.
+          </p>
+          <p>
+            <Link
+              href="/blog/cpap-compliance-tracking"
+              className="text-primary hover:text-primary/80"
+            >
+              CPAP Compliance Tracking
+            </Link>{' '}
+            — how to track usage trends and what to do if you&apos;re falling short.
+          </p>
+        </div>
+      </section>
+
+      {/* Bottom disclaimer */}
+      <p className="mt-8 text-xs italic text-muted-foreground/60">
+        AirwayLab is a data-visualization tool, not a medical device. The metrics described in this
+        article are data recorded by your CPAP device. Nothing on this page constitutes medical
+        advice — always discuss your therapy data and any questions about your treatment with your
+        prescribing physician or sleep specialist.
+      </p>
+    </article>
+  );
+}

--- a/app/blog/posts/good-ahi-on-cpap.tsx
+++ b/app/blog/posts/good-ahi-on-cpap.tsx
@@ -1,0 +1,483 @@
+import Link from 'next/link';
+import {
+  Activity,
+  AlertTriangle,
+  ArrowRight,
+  BarChart3,
+  CheckCircle,
+  HelpCircle,
+  Info,
+  TrendingUp,
+} from 'lucide-react';
+
+export default function GoodAHIOnCPAP() {
+  return (
+    <article>
+      <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
+        If you&apos;ve just loaded your CPAP data and you&apos;re staring at your AHI number,
+        you&apos;re probably asking the same question thousands of other CPAP users ask every week:
+        is this good? Should it be lower? Why isn&apos;t it lower?
+      </p>
+
+      <p className="mt-4 text-base leading-relaxed text-muted-foreground sm:text-lg">
+        &quot;What is a good AHI on CPAP?&quot; is one of the most-searched questions in CPAP
+        communities — and for good reason. AHI is the number your machine tracks most prominently,
+        and it&apos;s the closest thing to a score that summarises your therapy data at a glance.
+        But interpreting it requires context, and that context is what this article covers.
+      </p>
+
+      <div className="mt-6 rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">
+        <p className="text-sm text-muted-foreground">
+          <strong className="text-foreground">Medical disclaimer:</strong> AirwayLab is a
+          data-visualization tool, not a medical device. Nothing in this article constitutes medical
+          advice, diagnosis, or treatment. Always discuss your therapy data and any concerns with
+          your sleep physician or qualified clinician.
+        </p>
+      </div>
+
+      {/* What is AHI */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Info className="h-5 w-5 text-blue-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">What is AHI?</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            AHI stands for <strong className="text-foreground">Apnea-Hypopnea Index</strong> — the
+            count of apneas (complete breathing pauses) and hypopneas (partial obstructions) per
+            hour of sleep.
+          </p>
+          <p>
+            Your AHI before treatment — from your diagnostic sleep study — is what led to your CPAP
+            prescription. Your <strong className="text-foreground">residual AHI</strong>, sometimes
+            called treatment AHI, is the figure recorded by your CPAP machine while you&apos;re on
+            therapy. It reflects how many qualifying events occur per hour even with the machine
+            running.
+          </p>
+          <p>
+            Most CPAP and APAP devices record this automatically. With data from your SD card,
+            tools like AirwayLab display your residual AHI night by night so you can review trends
+            over weeks and months.
+          </p>
+        </div>
+      </section>
+
+      {/* What AHI is normal */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <BarChart3 className="h-5 w-5 text-emerald-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            What AHI is considered &quot;normal&quot; on CPAP therapy?
+          </h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            There is no single universally mandated target — your clinician sets the goal
+            appropriate to your situation. That said, the sleep medicine field uses established
+            thresholds:
+          </p>
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border/50">
+                  <th className="py-2 pr-4 text-left font-semibold text-foreground">
+                    AHI (events/hour)
+                  </th>
+                  <th className="py-2 text-left font-semibold text-foreground">
+                    Common classification
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/30">
+                <tr>
+                  <td className="py-2 pr-4 text-foreground">&lt; 5</td>
+                  <td className="py-2 text-muted-foreground">Within normal range</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 text-foreground">5–14</td>
+                  <td className="py-2 text-muted-foreground">Mild</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 text-foreground">15–29</td>
+                  <td className="py-2 text-muted-foreground">Moderate</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 text-foreground">≥ 30</td>
+                  <td className="py-2 text-muted-foreground">Severe</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p>
+            These classifications come from American Academy of Sleep Medicine (AASM) guidance and
+            are most commonly applied in diagnostic contexts. For therapy monitoring,{' '}
+            <strong className="text-foreground">
+              many sleep specialists consider a residual AHI below 5 a reasonable treatment
+              benchmark.
+            </strong>{' '}
+            Some clinicians aim for below 2 — particularly where certain conditions are present —
+            but your sleep physician is best placed to establish a specific target for you.
+          </p>
+          <p>
+            On therapy, residual AHI is generally expected to be substantially lower than the AHI
+            recorded during your diagnostic sleep study. What constitutes adequate reduction depends
+            on individual clinical context.
+          </p>
+
+          <div className="rounded-xl border border-blue-500/20 bg-blue-500/5 p-4">
+            <p className="text-sm text-muted-foreground">
+              AirwayLab shows you your residual AHI data as recorded by your device. What that
+              number means for your specific health situation is a question for your sleep physician.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Why residual AHI might still be high */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <AlertTriangle className="h-5 w-5 text-amber-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            Why might residual AHI still be high on CPAP?
+          </h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            A residual AHI above the typical threshold doesn&apos;t always mean nothing can be
+            done. Several common factors can contribute — and all are worth raising with your
+            clinician.
+          </p>
+
+          <div className="space-y-3">
+            <div className="rounded-xl border border-border/50 p-5">
+              <p className="font-semibold text-foreground">Mask fit and seal</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                A mask that leaks air can reduce the effectiveness of delivered pressure. Most CPAP
+                machines log total leak rate alongside AHI. If your leak data shows elevated or
+                variable leak on the same nights your AHI is high, that&apos;s a useful data point
+                to bring to your next appointment.
+              </p>
+            </div>
+
+            <div className="rounded-xl border border-border/50 p-5">
+              <p className="font-semibold text-foreground">Pressure delivery</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Fixed-pressure CPAP delivers the same pressure all night. Auto-titrating CPAP
+                (APAP) adjusts within a clinician-set range. If the pressure range isn&apos;t
+                matched to your nightly needs — which can vary with sleep position, nasal
+                congestion, alcohol, or weight changes — some events may not be prevented.
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Whether any pressure adjustment is appropriate is a clinical decision. Your sleep
+                physician or respiratory therapist can review your full therapy data and advise
+                accordingly. AirwayLab does not recommend or suggest pressure changes.
+              </p>
+            </div>
+
+            <div className="rounded-xl border border-border/50 p-5">
+              <p className="font-semibold text-foreground">Sleep position</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Back-sleeping (supine position) is associated with increased airway narrowing in
+                many people. If you notice higher AHI on specific nights, and your machine records
+                positional data, this is worth discussing with your clinician.
+              </p>
+            </div>
+
+            <div className="rounded-xl border border-border/50 p-5">
+              <p className="font-semibold text-foreground">Mask interface type</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Different mask styles (nasal pillow, nasal, full-face) interact differently with
+                airway mechanics and leak patterns. If your data shows a consistent pattern across
+                nights, a different mask type may be something to discuss with your provider.
+              </p>
+            </div>
+
+            <div className="rounded-xl border border-border/50 p-5">
+              <p className="font-semibold text-foreground">Central versus obstructive events</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Not all events counted in your AHI have the same origin. Some residual events may
+                be central in nature — originating in the respiratory control system rather than
+                upper airway obstruction — and respond differently to CPAP therapy. Identifying the
+                nature of events requires clinical assessment.
+              </p>
+            </div>
+
+            <div className="rounded-xl border border-border/50 p-5">
+              <p className="font-semibold text-foreground">Alcohol, sedatives, and congestion</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                These factors can temporarily increase airway collapsibility. If your data shows
+                isolated spikes, lifestyle context may be relevant to note when you discuss the
+                data with your clinician.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Flow limitations and RERAs */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <TrendingUp className="h-5 w-5 text-purple-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            AHI doesn&apos;t tell the whole story: flow limitations and RERAs
+          </h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            AHI counts complete apneas and hypopneas, but it doesn&apos;t capture everything that
+            can affect sleep quality.{' '}
+            <strong className="text-foreground">Flow limitations</strong> — partial reductions in
+            airflow that don&apos;t meet the threshold for a hypopnea — and{' '}
+            <strong className="text-foreground">RERAs</strong> (Respiratory Effort-Related
+            Arousals) can disrupt sleep continuity even when AHI appears low.
+          </p>
+          <p>
+            Some CPAP devices, particularly certain ResMed models, record detailed flow waveform
+            data. AirwayLab can visualise flow limitation patterns alongside AHI where your device
+            supports it, giving you additional data to bring to clinical appointments.
+          </p>
+          <p>
+            A night with an AHI of 2 and frequent flow limitation events may warrant a different
+            conversation than a night with an AHI of 2 and clean waveforms. Your sleep physician
+            can help you interpret what these patterns mean in your case.
+          </p>
+          <div className="flex gap-3 rounded-xl border border-purple-500/20 bg-purple-500/5 p-4">
+            <Info className="mt-0.5 h-4 w-4 shrink-0 text-purple-400" />
+            <p className="text-sm text-muted-foreground">
+              Learn more:{' '}
+              <Link href="/blog/low-ahi-still-tired-flow-limitation-reras" className="text-primary hover:text-primary/80">
+                Low AHI but still tired? Flow limitation and RERAs may be why.
+              </Link>
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* When to contact your sleep physician */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <CheckCircle className="h-5 w-5 text-emerald-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">
+            When to contact your sleep physician
+          </h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            Bring your therapy data to your clinician if any of the following apply:
+          </p>
+          <ul className="ml-4 list-disc space-y-2 text-sm text-muted-foreground sm:text-base">
+            <li>
+              Your residual AHI consistently reads above 5 across multiple weeks of data
+            </li>
+            <li>
+              You&apos;re still experiencing symptoms — fatigue, unrefreshing sleep, morning
+              headaches — despite apparently normal AHI readings
+            </li>
+            <li>Your data shows high leak on most nights</li>
+            <li>
+              You notice a sudden change in your AHI trend without an obvious explanation
+            </li>
+            <li>
+              Your AHI was previously stable and has risen over recent weeks or months
+            </li>
+          </ul>
+          <p>
+            This list isn&apos;t exhaustive. If something in your data concerns you, that&apos;s
+            reason enough to raise it. Your sleep physician or respiratory therapist is the right
+            person to review your therapy in full clinical context.
+          </p>
+        </div>
+      </section>
+
+      {/* How AirwayLab helps */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <Activity className="h-5 w-5 text-primary" />
+          <h2 className="text-xl font-bold sm:text-2xl">How AirwayLab helps you track AHI over time</h2>
+        </div>
+        <div className="mt-4 space-y-4 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <p>
+            A single night&apos;s AHI is a data point. Tracked across weeks and months, it becomes
+            a pattern — and patterns are what help you and your clinician have informed
+            conversations.
+          </p>
+          <p>
+            AirwayLab reads your CPAP machine&apos;s SD card data directly in your browser. Your
+            data never leaves your device. It renders your AHI, leak rate, pressure, and flow
+            waveforms as an interactive timeline so you can:
+          </p>
+          <div className="space-y-3">
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Night-by-night AHI trends</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Review AHI with trend lines across any date range. Patterns across weeks are easier
+                to spot in a chart than in your device&apos;s rolling 7-day average.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Leak and AHI correlation</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                See which nights had elevated leak alongside elevated AHI — a useful data point
+                when discussing mask fit with your provider.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Pressure data for APAP users</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Review session-level pressure ranges and percentile data across your nights.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/50 p-4">
+              <p className="text-sm font-semibold text-foreground">Flow limitation visualisation</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Where your device supports it, AirwayLab visualises flow limitation patterns
+                alongside AHI — additional data to bring to clinical appointments.
+              </p>
+            </div>
+          </div>
+          <p>
+            This is the data your clinician may ask you to bring to appointments. Having it
+            organised in one place — without uploading it to a cloud server — makes those
+            conversations easier.
+          </p>
+          <p>
+            AirwayLab is free and always will be. The source code is GPL-3.0 licensed and publicly
+            auditable. If you&apos;re also using OSCAR, AirwayLab works alongside it — the two
+            tools serve different viewing needs and neither replaces the other.
+          </p>
+        </div>
+      </section>
+
+      {/* Inline CTA */}
+      <section className="mt-10 rounded-xl border border-primary/20 bg-primary/5 p-6 text-center">
+        <h3 className="text-lg font-bold">Track Your Nightly AHI from Your CPAP SD Card</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          AirwayLab tracks your nightly AHI automatically from your CPAP SD card — see your trends
+          over weeks and months. Free, browser-based, and your data never leaves your device.
+        </p>
+        <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
+          <Link
+            href="/analyze"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-glow transition-colors hover:bg-primary/90"
+          >
+            Analyse Your CPAP Data <ArrowRight className="h-4 w-4" />
+          </Link>
+          <Link
+            href="/blog/what-does-cpap-ahi-mean"
+            className="inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Read: What Does My AHI Number Mean?
+          </Link>
+        </div>
+      </section>
+
+      {/* Summary */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <CheckCircle className="h-5 w-5 text-emerald-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">Summary</h2>
+        </div>
+        <ul className="mt-4 ml-4 list-disc space-y-2 text-sm leading-relaxed text-muted-foreground sm:text-base">
+          <li>
+            Many sleep specialists consider a residual AHI below 5 a common treatment benchmark,
+            but your clinician determines what&apos;s appropriate for your situation
+          </li>
+          <li>
+            Factors that can contribute to elevated residual AHI include mask fit, pressure
+            delivery, sleep position, and event type — all worth discussing with your provider
+          </li>
+          <li>
+            AHI alone doesn&apos;t capture flow limitations and RERAs, which are also relevant to
+            overall sleep quality
+          </li>
+          <li>
+            If your AHI stays consistently elevated or you remain symptomatic, contact your sleep
+            physician
+          </li>
+          <li>
+            AirwayLab lets you track your nightly AHI trends privately from your SD card, with no
+            cloud upload required
+          </li>
+        </ul>
+      </section>
+
+      {/* FAQ */}
+      <section className="mt-10">
+        <div className="flex items-center gap-2.5">
+          <HelpCircle className="h-5 w-5 text-blue-400" />
+          <h2 className="text-xl font-bold sm:text-2xl">Frequently Asked Questions</h2>
+        </div>
+        <div className="mt-4 space-y-4">
+          {[
+            {
+              q: 'What AHI is considered good on CPAP?',
+              a: 'Many sleep specialists use a residual AHI below 5 as a common benchmark for CPAP therapy. The right target for you depends on your individual situation — your sleep physician can advise.',
+            },
+            {
+              q: 'Why is my AHI still high on CPAP?',
+              a: 'Common contributing factors include mask leak, pressure settings, sleep position, and the type of events occurring. A clinician can review your full therapy data and advise on next steps.',
+            },
+            {
+              q: 'Is an AHI of 2 good on CPAP?',
+              a: 'An AHI below 5 falls within the range many clinicians consider typical on therapy. Whether it\'s optimal for your specific situation is something your sleep physician can assess in context.',
+            },
+            {
+              q: 'What is residual AHI?',
+              a: 'Residual AHI is the Apnea-Hypopnea Index recorded by your CPAP device while you\'re on therapy — as distinct from your diagnostic AHI measured during your pre-treatment sleep study.',
+            },
+            {
+              q: 'Can CPAP make AHI worse?',
+              a: 'In some cases, pressure settings that don\'t match your needs may result in certain event types. Your sleep physician or respiratory therapist can review your data and determine whether any clinical adjustments are warranted.',
+            },
+          ].map(({ q, a }) => (
+            <div key={q} className="rounded-xl border border-border/50 p-5">
+              <p className="text-sm font-semibold text-foreground">{q}</p>
+              <p className="mt-2 text-sm text-muted-foreground">{a}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Related reading */}
+      <section className="mt-8 border-t border-border/30 pt-6">
+        <p className="mb-2 text-xs font-semibold text-foreground">Related reading</p>
+        <div className="space-y-1 text-sm text-muted-foreground">
+          <p>
+            <Link href="/blog/what-does-cpap-ahi-mean" className="text-primary hover:text-primary/80">
+              What Does My CPAP AHI Number Mean?
+            </Link>{' '}
+            — a plain-language guide to the metric at the centre of your report.
+          </p>
+          <p>
+            <Link href="/blog/low-ahi-still-tired-flow-limitation-reras" className="text-primary hover:text-primary/80">
+              Low AHI but Still Tired?
+            </Link>{' '}
+            — why flow limitations and RERAs can matter even when AHI looks normal.
+          </p>
+          <p>
+            <Link href="/blog/what-are-reras-sleep-apnea" className="text-primary hover:text-primary/80">
+              What Are RERAs?
+            </Link>{' '}
+            — the breathing events your compliance report doesn&apos;t count.
+          </p>
+          <p>
+            <Link href="/blog/ahi-vs-rdi-sleep-apnea" className="text-primary hover:text-primary/80">
+              AHI vs RDI: What&apos;s the Difference?
+            </Link>{' '}
+            — understanding how the two indices are calculated and what each captures.
+          </p>
+        </div>
+      </section>
+
+      {/* Bottom disclaimer */}
+      <p className="mt-8 text-xs italic text-muted-foreground/60">
+        AirwayLab is a data-visualization tool, not a medical device. The metrics described in this
+        article are data recorded by your CPAP device. Nothing on this page constitutes medical
+        advice, diagnosis, or treatment — always discuss your therapy data and any concerns with
+        your sleep physician or qualified clinician.
+      </p>
+    </article>
+  );
+}

--- a/lib/blog-posts.ts
+++ b/lib/blog-posts.ts
@@ -1720,6 +1720,56 @@ export const blogPosts: BlogPost[] = [
       },
     ],
   },
+  {
+    slug: 'cpap-data-report-what-doctor-sees',
+    title: 'How to Read Your CPAP Data Report (What Your Doctor Sees)',
+    seoTitle:
+      'How to Read Your CPAP Data Report: AHI, Usage, Leak Rate | AirwayLab',
+    description:
+      'Learn what\'s in a CPAP compliance report — AHI, usage hours, leak rate — and what your doctor and insurance company actually look at.',
+    date: '2026-05-18',
+    readTime: '8 min read',
+    tags: ['CPAP Compliance', 'CPAP Data', 'AHI', 'Insurance', 'ResMed'],
+    ogDescription:
+      'Learn what\'s in a CPAP compliance report — AHI, usage hours, leak rate, and event breakdown — and what your doctor and insurance company are actually looking at when they review your therapy report.',
+    faqItems: [
+      {
+        question: 'What is a CPAP compliance report?',
+        answer:
+          "A CPAP compliance report is a summary of your therapy usage data — how often you used the machine, for how long, and key metrics like AHI and leak rate. It's generated from your device's SD card or cloud app data. Your doctor uses it to review therapy progress; your insurance company uses it to verify coverage requirements.",
+      },
+      {
+        question: 'How many hours do I need to use my CPAP to be compliant?',
+        answer:
+          'The US Medicare standard — and the benchmark most private insurers follow — is at least 4 hours of use per night on at least 70% of nights over a 30-day period. If you fall below this threshold, coverage for equipment and supplies may be affected. Your DME supplier can pull your detailed usage record if you need to review your status.',
+      },
+      {
+        question: 'What AHI does my insurance company look at?',
+        answer:
+          'Insurers typically look at your residual AHI — the events recorded while therapy was running — as a favorable data point in compliance reviews. Your clinician can put your specific number in context and explain what it means for your care.',
+      },
+      {
+        question: 'What does "large mask leak" mean on my CPAP report?',
+        answer:
+          'A large mask leak flag means unintentional air escaped around your mask seal beyond the threshold your device uses to flag data-quality concerns. High or persistent leak can reduce the reliability of AHI readings for that session and may prompt your doctor to review mask fit. Your clinician can help assess recurring leak flags in your specific context.',
+      },
+      {
+        question: 'Can I access my own CPAP compliance data?',
+        answer:
+          "Yes. ResMed users can view a summary in the myAir app, or export their SD card for detailed data. Philips DreamStation users can use DreamMapper for cloud summary data, or OSCAR (free, open-source) for full SD card data. AirwayLab reads ResMed SD card data directly in your browser — no upload required.",
+      },
+      {
+        question: 'What is the difference between CPAP compliance and CPAP effectiveness?',
+        answer:
+          'Compliance (for insurance purposes) is largely about usage hours — did you use the machine enough. Clinical effectiveness is a broader judgment that includes AHI trends, leak patterns, and how you actually feel. Compliance is a prerequisite for coverage; effectiveness is what your clinician evaluates at follow-up.',
+      },
+      {
+        question: 'Does AirwayLab show my compliance data?',
+        answer:
+          "Yes. AirwayLab reads your usage hours, AHI, event breakdowns, leak rate, and pressure data from your ResMed SD card and displays it in one dashboard — the same data that goes into your doctor's compliance report. It also runs four additional analysis engines on your raw flow waveform, surfacing metrics like flow limitation scores and RERA-related patterns that don't appear in standard compliance reports. Everything runs in your browser; your data never leaves your device.",
+      },
+    ],
+  },
 ];
 
 export function getPostBySlug(slug: string): BlogPost | undefined {

--- a/lib/blog-posts.ts
+++ b/lib/blog-posts.ts
@@ -1770,6 +1770,45 @@ export const blogPosts: BlogPost[] = [
       },
     ],
   },
+  {
+    slug: 'good-ahi-on-cpap',
+    title: 'What Is a Good AHI on CPAP? (And What to Do If Yours Is Still High)',
+    seoTitle: 'What Is a Good AHI on CPAP? Residual AHI Explained | AirwayLab',
+    description:
+      'Wondering what AHI is good on CPAP therapy? Learn what residual AHI means, what numbers are typical, and what to ask your doctor if yours stays elevated.',
+    date: '2026-05-18',
+    readTime: '7 min read',
+    tags: ['AHI', 'Residual AHI', 'CPAP Data', 'Sleep Apnea', 'CPAP Metrics'],
+    ogDescription:
+      'Wondering what AHI is good on CPAP therapy? Learn what residual AHI means, what numbers are typical, and what to ask your doctor if yours stays elevated.',
+    faqItems: [
+      {
+        question: 'What AHI is considered good on CPAP?',
+        answer:
+          'Many sleep specialists use a residual AHI below 5 as a common benchmark for CPAP therapy. The right target for you depends on your individual situation — your sleep physician can advise.',
+      },
+      {
+        question: 'Why is my AHI still high on CPAP?',
+        answer:
+          'Common contributing factors include mask leak, pressure settings, sleep position, and the type of events occurring. A clinician can review your full therapy data and advise on next steps.',
+      },
+      {
+        question: 'Is an AHI of 2 good on CPAP?',
+        answer:
+          "An AHI below 5 falls within the range many clinicians consider typical on therapy. Whether it's optimal for your specific situation is something your sleep physician can assess in context.",
+      },
+      {
+        question: 'What is residual AHI?',
+        answer:
+          "Residual AHI is the Apnea-Hypopnea Index recorded by your CPAP device while you're on therapy — as distinct from your diagnostic AHI measured during your pre-treatment sleep study.",
+      },
+      {
+        question: 'Can CPAP make AHI worse?',
+        answer:
+          "In some cases, pressure settings that don't match your needs may result in certain event types. Your sleep physician or respiratory therapist can review your data and determine whether any clinical adjustments are warranted.",
+      },
+    ],
+  },
 ];
 
 export function getPostBySlug(slug: string): BlogPost | undefined {


### PR DESCRIPTION
## Summary

- Adds `/blog/good-ahi-on-cpap` — "What Is a Good AHI on CPAP?" (~1,350 words, MDR compliance PASS per AIR-1473)
- Adds `/blog/cpap-data-report-what-doctor-sees` — "How to Read Your CPAP Data Report" (AIR-1474)

Both articles include FAQ JSON-LD schema, inline CTAs to `/analyze`, medical disclaimers, and MDR-compliant clinical language.

## Test plan

- [ ] `/blog/good-ahi-on-cpap` renders without 404
- [ ] `/blog/cpap-data-report-what-doctor-sees` renders without 404
- [ ] Both appear in `/blog` index
- [ ] FAQPage structured data present
- [ ] CTA links to `/analyze`
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)