### PR TITLE
test: data integrity integration tests (AIR-1902 / AIR-1877 Phase 4.4)

### DIFF
--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -83,7 +83,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // After retry, "Lock was stolen" is still transient — suppress Sentry to avoid noise.
       if (profileError.message?.includes('Lock was stolen')) return;
       console.error('[auth-context] Failed to fetch profile:', profileError.message);
-      // "Lock was stolen" is transient navigator.locks contention — already retried once, skip Sentry noise
       if (!profileError.message?.includes('Lock was stolen')) {
         Sentry.captureMessage(`Profile fetch failed: ${profileError.message}`, {
           level: 'warning',


### PR DESCRIPTION
## Summary

Splits the AIR-1902 data integrity tests out of `fix/air-1912-email-send-observability` as required by CTO review.

- `__tests__/checkout-profile-race.test.ts` (181 lines)
- `__tests__/email-reuse-after-deletion.test.ts` (209 lines)
- `__tests__/stripe-webhook-phantom-user.test.ts` (304 lines)
- `__tests__/validate-profile-exists.test.ts` (207 lines)
- `lib/profile-guard.ts` (39 lines — new functional module)

**Closes AIR-1902.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)