### PR TITLE
feat: add email fallback for critical Discord alert classes

### DIFF
--- a/__tests__/critical-alert-email-fallback.test.ts
+++ b/__tests__/critical-alert-email-fallback.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for critical alert email fallback (AIR-1848).
+ *
+ * Verifies that alertStripePaymentFailed, alertCredentialExpiry, and
+ * alertSecurityIncident each send both a Discord push AND a Resend email,
+ * and that Resend failures are captured to Sentry without throwing.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Use vi.hoisted so mock factories can reference these before module import
+const { mockSentryCaptureException, mockSentryCaptureMessage, mockSendEmail } = vi.hoisted(() => ({
+  mockSentryCaptureException: vi.fn(),
+  mockSentryCaptureMessage: vi.fn(),
+  mockSendEmail: vi.fn().mockResolvedValue('resend-msg-id'),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: mockSentryCaptureException,
+  captureMessage: mockSentryCaptureMessage,
+}))
+
+vi.mock('@/lib/email/send', () => ({
+  sendEmail: mockSendEmail,
+}))
+
+// Mock fetch for Discord webhook
+const mockFetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+vi.stubGlobal('fetch', mockFetch)
+
+import {
+  alertStripePaymentFailed,
+  alertCredentialExpiry,
+  alertSecurityIncident,
+  sendCriticalAlert,
+} from '@/lib/discord-webhook'
+
+describe('critical alert email fallback (AIR-1848)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendEmail.mockResolvedValue('resend-msg-id')
+    mockFetch.mockResolvedValue(new Response(null, { status: 204 }))
+    process.env.DISCORD_WEBHOOK_CRITICAL = 'https://discord.com/api/webhooks/test/critical'
+    process.env.RESEND_API_KEY = 're_test_key'
+  })
+
+  describe('alertStripePaymentFailed', () => {
+    it('sends both Discord and Resend email', async () => {
+      await alertStripePaymentFailed()
+
+      // Discord fired
+      expect(mockFetch).toHaveBeenCalledOnce()
+      const discordUrl = (mockFetch.mock.calls[0] as unknown[])[0] as string
+      expect(discordUrl).toBe('https://discord.com/api/webhooks/test/critical')
+
+      // Email fired to ops address
+      expect(mockSendEmail).toHaveBeenCalledOnce()
+      const emailArgs = (mockSendEmail.mock.calls[0] as unknown[])[0] as {
+        to: string
+        subject: string
+        text: string
+      }
+      expect(emailArgs.to).toBe('d.voorhagen@gmail.com')
+      expect(emailArgs.subject).toBe('[AirwayLab URGENT] Stripe payment failed')
+      expect(emailArgs.text).toContain('Stripe')
+    })
+
+    it('fires email even when Discord webhook is not configured', async () => {
+      delete process.env.DISCORD_WEBHOOK_CRITICAL
+
+      await alertStripePaymentFailed()
+
+      // Discord skipped (no URL)
+      expect(mockFetch).not.toHaveBeenCalled()
+
+      // Email still fires independently
+      expect(mockSendEmail).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('alertCredentialExpiry', () => {
+    it('sends Discord and email with correct subject', async () => {
+      await alertCredentialExpiry(48, 'GitHub PAT')
+
+      expect(mockFetch).toHaveBeenCalledOnce()
+
+      expect(mockSendEmail).toHaveBeenCalledOnce()
+      const emailArgs = (mockSendEmail.mock.calls[0] as unknown[])[0] as {
+        to: string
+        subject: string
+      }
+      expect(emailArgs.to).toBe('d.voorhagen@gmail.com')
+      expect(emailArgs.subject).toBe('[AirwayLab URGENT] Credential expires in 48h: GitHub PAT')
+    })
+  })
+
+  describe('alertSecurityIncident', () => {
+    it('sends Discord and email with description', async () => {
+      await alertSecurityIncident('Unauthorized access to admin API')
+
+      expect(mockFetch).toHaveBeenCalledOnce()
+
+      expect(mockSendEmail).toHaveBeenCalledOnce()
+      const emailArgs = (mockSendEmail.mock.calls[0] as unknown[])[0] as {
+        to: string
+        subject: string
+        text: string
+      }
+      expect(emailArgs.to).toBe('d.voorhagen@gmail.com')
+      expect(emailArgs.subject).toContain('[AirwayLab URGENT] Security incident:')
+      expect(emailArgs.text).toContain('Unauthorized access to admin API')
+    })
+  })
+
+  describe('Resend failure handling', () => {
+    it('captures to Sentry when sendEmail returns null, does not throw', async () => {
+      mockSendEmail.mockResolvedValue(null)
+
+      await expect(alertStripePaymentFailed()).resolves.not.toThrow()
+
+      expect(mockSentryCaptureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Critical ops email failed'),
+        expect.objectContaining({ level: 'error' })
+      )
+    })
+
+    it('captures to Sentry when sendEmail throws, does not throw', async () => {
+      mockSendEmail.mockRejectedValue(new Error('network timeout'))
+
+      await expect(alertStripePaymentFailed()).resolves.not.toThrow()
+
+      expect(mockSentryCaptureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ level: 'error' })
+      )
+    })
+
+    it('returns Discord result even if email fails', async () => {
+      mockSendEmail.mockRejectedValue(new Error('Resend down'))
+
+      const result = await alertStripePaymentFailed()
+
+      // Discord succeeded → true
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('sendCriticalAlert', () => {
+    it('fires Discord and email in parallel, returns Discord result', async () => {
+      const result = await sendCriticalAlert(
+        '[AirwayLab URGENT] Test',
+        'Test body',
+        'Test content'
+      )
+
+      expect(mockFetch).toHaveBeenCalledOnce()
+      expect(mockSendEmail).toHaveBeenCalledOnce()
+      expect(result).toBe(true)
+    })
+  })
+})

--- a/__tests__/stripe-webhook-phantom-user.test.ts
+++ b/__tests__/stripe-webhook-phantom-user.test.ts
@@ -52,6 +52,7 @@ vi.mock('@/lib/discord', () => ({
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: vi.fn().mockResolvedValue(undefined),
   formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(undefined),
 }));
 
 const mockFrom = vi.fn();
@@ -189,7 +190,6 @@ describe('stripe-webhook-phantom-user: checkout.session.completed with non-exist
   });
 
   it('fires Sentry captureMessage with phantom-user-id tag', async () => {
-    const { captureMessage } = await import('@sentry/nextjs');
     const event = makeCheckoutSessionEvent(PHANTOM_USER_ID);
     mockWebhooksConstruct.mockReturnValue(event);
     mockSubscriptionsRetrieve.mockResolvedValue(makeSubscriptionObject(PHANTOM_USER_ID));
@@ -206,6 +206,8 @@ describe('stripe-webhook-phantom-user: checkout.session.completed with non-exist
 
     await callRoute(makeWebhookRequest());
 
+    // Import after callRoute so we get the same Sentry instance vi.resetModules() created for the route
+    const { captureMessage } = await import('@sentry/nextjs');
     expect(captureMessage).toHaveBeenCalledWith(
       'Stripe webhook: supabase_user_id in metadata has no matching profile',
       expect.objectContaining({
@@ -247,7 +249,6 @@ describe('stripe-webhook-phantom-user: checkout.session.completed with non-exist
   });
 
   it('includes userId, eventId, subscriptionId, and stripeCustomerId in Sentry extra', async () => {
-    const { captureMessage } = await import('@sentry/nextjs');
     const event = makeCheckoutSessionEvent(PHANTOM_USER_ID, 'sub_phantom_456');
     mockWebhooksConstruct.mockReturnValue(event);
     mockSubscriptionsRetrieve.mockResolvedValue(makeSubscriptionObject(PHANTOM_USER_ID));
@@ -258,6 +259,8 @@ describe('stripe-webhook-phantom-user: checkout.session.completed with non-exist
 
     await callRoute(makeWebhookRequest());
 
+    // Import after callRoute so we get the same Sentry instance vi.resetModules() created for the route
+    const { captureMessage } = await import('@sentry/nextjs');
     expect(captureMessage).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -7,7 +7,7 @@ import { cancelSequence, scheduleSequence, scheduleWinBackForUser } from '@/lib/
 import { sendEmail } from '@/lib/email/send';
 import { welcomeEmail, cancellationEmail } from '@/lib/email/transactional';
 import { isDiscordConfigured, syncRole, searchGuildMember } from '@/lib/discord';
-import { sendAlert, formatRevenueEmbed } from '@/lib/discord-webhook';
+import { sendAlert, formatRevenueEmbed, alertStripePaymentFailed } from '@/lib/discord-webhook';
 
 export const maxDuration = 30;
 
@@ -492,10 +492,8 @@ async function processStripeEvent(
           stripeSubscriptionId: subscriptionId,
         });
 
-        // Discord #revenue alert (non-blocking)
-        void sendAlert('revenue', '', [formatRevenueEmbed({
-          event: 'payment_failed',
-        })]);
+        // Critical alert: Discord #critical + email to ops (non-blocking, fire-and-forget)
+        void alertStripePaymentFailed();
       }
 
       break;

--- a/lib/discord-webhook.ts
+++ b/lib/discord-webhook.ts
@@ -5,6 +5,7 @@
  * Separate from lib/discord.ts which handles community role management.
  *
  * Channels:
+ *   #critical         — Payment failures, credential expiry <72h, security incidents
  *   #ops-alerts       — Sentry, monitor cron, GitHub, deploys
  *   #revenue          — Stripe payments, cancellations, tier changes
  *   #user-signals     — Feedback, contact forms, provider interest, deletions
@@ -13,7 +14,14 @@
  *
  * Fail-open: if a webhook URL is not configured or the request fails,
  * the caller continues without error.
+ *
+ * Critical alerts (sendCriticalAlert / alertCredentialExpiry / alertSecurityIncident):
+ *   Both Discord AND email are fired independently. Discord failure does not block
+ *   the email attempt, and vice versa. Resend errors are logged to Sentry only.
  */
+
+import * as Sentry from '@sentry/nextjs'
+import { sendEmail } from '@/lib/email/send'
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -32,7 +40,7 @@ interface DiscordEmbed {
   timestamp?: string
 }
 
-export type AlertChannel = 'ops' | 'revenue' | 'user-signals' | 'growth' | 'platform-health'
+export type AlertChannel = 'critical' | 'ops' | 'revenue' | 'user-signals' | 'growth' | 'platform-health'
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -47,12 +55,15 @@ export const COLORS = {
 } as const
 
 const CHANNEL_ENV_MAP: Record<AlertChannel, string> = {
+  critical: 'DISCORD_WEBHOOK_CRITICAL',
   ops: 'DISCORD_OPS_WEBHOOK_URL',
   revenue: 'DISCORD_REVENUE_WEBHOOK_URL',
   'user-signals': 'DISCORD_USER_SIGNALS_WEBHOOK_URL',
   growth: 'DISCORD_GROWTH_WEBHOOK_URL',
   'platform-health': 'DISCORD_PLATFORM_HEALTH_WEBHOOK_URL',
 }
+
+const CRITICAL_OPS_EMAIL = 'd.voorhagen@gmail.com'
 
 // ── Core sender ──────────────────────────────────────────────
 
@@ -105,6 +116,99 @@ export async function sendOpsAlert(
   embeds?: DiscordEmbed[]
 ): Promise<boolean> {
   return sendAlert('ops', content, embeds)
+}
+
+// ── Critical alert helpers ───────────────────────────────────
+
+/**
+ * Send a plain-text email fallback to the ops contact.
+ * Called after the Discord push — never throws.
+ * Resend failures are captured to Sentry for ops visibility.
+ */
+async function sendCriticalOpsEmail(subject: string, body: string): Promise<void> {
+  try {
+    const id = await sendEmail({ to: CRITICAL_OPS_EMAIL, subject, text: body })
+    if (id === null) {
+      Sentry.captureMessage('Critical ops email failed to send (Resend returned null)', {
+        level: 'error',
+        tags: { source: 'discord-webhook', subject },
+      })
+    }
+  } catch (err) {
+    Sentry.captureException(err, {
+      level: 'error',
+      tags: { source: 'discord-webhook', action: 'critical_ops_email' },
+    })
+  }
+}
+
+/**
+ * Send a critical-tier alert: Discord #critical + plain-text email to ops.
+ * Discord and email fire independently — neither blocks the other.
+ * Returns true if Discord was delivered, false otherwise.
+ */
+export async function sendCriticalAlert(
+  emailSubject: string,
+  emailBody: string,
+  content: string,
+  embeds?: DiscordEmbed[]
+): Promise<boolean> {
+  const [discordResult] = await Promise.all([
+    sendAlert('critical', content, embeds),
+    sendCriticalOpsEmail(emailSubject, emailBody),
+  ])
+  return discordResult
+}
+
+/**
+ * Alert: credential expiring within 72 hours.
+ * Fires to Discord #critical and emails the ops contact.
+ */
+export async function alertCredentialExpiry(hoursLeft: number, credentialName: string): Promise<boolean> {
+  const subject = `[AirwayLab URGENT] Credential expires in ${hoursLeft}h: ${credentialName}`
+  const body = `AirwayLab credential alert\n\nCredential: ${credentialName}\nExpires in: ${hoursLeft} hours\n\nRenew immediately to avoid service disruption.`
+  const embed: DiscordEmbed = {
+    title: `:rotating_light: Credential Expiring Soon`,
+    description: `**${credentialName}** expires in **${hoursLeft}h**`,
+    color: COLORS.red,
+    footer: { text: 'Credential monitor' },
+    timestamp: new Date().toISOString(),
+  }
+  return sendCriticalAlert(subject, body, '', [embed])
+}
+
+/**
+ * Alert: Stripe payment failed on the board card.
+ * Fires to Discord #critical and emails the ops contact.
+ */
+export async function alertStripePaymentFailed(): Promise<boolean> {
+  const subject = `[AirwayLab URGENT] Stripe payment failed`
+  const body = `AirwayLab critical alert\n\nStripe invoice payment failed. Check the Stripe dashboard immediately — active subscriptions may be at risk.\n\nhttps://dashboard.stripe.com`
+  const embed: DiscordEmbed = {
+    title: `:x: Stripe Payment Failed`,
+    description: 'Invoice payment failed. Check Stripe dashboard.',
+    color: COLORS.red,
+    footer: { text: 'Stripe webhook' },
+    timestamp: new Date().toISOString(),
+  }
+  return sendCriticalAlert(subject, body, '', [embed])
+}
+
+/**
+ * Alert: security incident detected.
+ * Fires to Discord #critical and emails the ops contact.
+ */
+export async function alertSecurityIncident(description: string): Promise<boolean> {
+  const subject = `[AirwayLab URGENT] Security incident: ${description.slice(0, 80)}`
+  const body = `AirwayLab security incident\n\n${description}\n\nTimestamp: ${new Date().toISOString()}`
+  const embed: DiscordEmbed = {
+    title: `:rotating_light: Security Incident`,
+    description: description.slice(0, 500),
+    color: COLORS.red,
+    footer: { text: 'Security monitor' },
+    timestamp: new Date().toISOString(),
+  }
+  return sendCriticalAlert(subject, body, '', [embed])
 }
 
 // ── Embed builders ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds Resend email fallback to the 3 critical alert classes: Stripe payment failures, credential expiry (<72h), and security incidents
- Discord and email fire independently via `Promise.all` — neither blocks the other
- Resend failures are captured to Sentry only (never thrown), so the primary Discord push result is always returned
- Updates `invoice.payment_failed` Stripe webhook handler to use `alertStripePaymentFailed()` instead of `sendAlert('revenue',...)`

## Changes

- `lib/discord-webhook.ts`: adds `sendCriticalOpsEmail()` helper and `sendCriticalAlert()` wrapper; updates all 3 critical alert functions
- `app/api/webhooks/stripe/route.ts`: swaps revenue-channel alert for critical-tier alert on payment failure
- `__tests__/critical-alert-email-fallback.test.ts`: 8-test suite covering all 3 alert classes, Resend failure paths (null + throw), and fire-and-forget contract

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 164 files / 2470 tests passing
- [x] `npm run build` — passes
- [x] All 3 alert class tests assert Resend called with correct `to` and `subject`
- [x] Resend-null path → Sentry captureMessage (not throw)
- [x] Resend-throw path → Sentry captureException (not throw)
- [x] Discord result returned correctly even when Resend fails

Closes AIR-1848. Part (c) of AIR-1841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)