### PR TITLE
fix: add no_flow_signal Sentry checkpoint for missing flow signal (AIR-1490)

### DIFF
--- a/__tests__/edf-parser-truncation.test.ts
+++ b/__tests__/edf-parser-truncation.test.ts
@@ -308,4 +308,17 @@ describe('EDF Parser — Flow Signal Detection (AIR-1364)', () => {
     });
     expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(/"PressureX"/);
   });
+
+  it('error message starts with "No flow signal found" — worker checkpoint routing depends on this prefix', () => {
+    // The worker uses detail.startsWith('No flow signal found') to route to the
+    // no_flow_signal Sentry checkpoint. Verify the parser error begins with that prefix.
+    const buffer = buildEDFBuffer({
+      numDataRecords: 5,
+      samplesPerRecord: 25,
+      signalLabel: 'UnknownChan',
+      physicalMin: 0,
+      physicalMax: 30,
+    });
+    expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(/^No flow signal found/);
+  });
 });

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -234,9 +234,12 @@ async function processFiles(
     } catch (err) {
       const filename = brp.path.split('/').pop() || brp.path;
       const detail = err instanceof Error ? err.message : String(err);
+      // Use a dedicated checkpoint for missing flow signals so Sentry can group
+      // this device/firmware pattern separately from generic parse failures.
+      const isNoFlowSignal = detail.startsWith('No flow signal found');
       const warning: WorkerWarning = {
         type: 'WARNING',
-        checkpoint: 'parse_file_failed',
+        checkpoint: isNoFlowSignal ? 'no_flow_signal' : 'parse_file_failed',
         detail: `Failed to parse ${filename}: ${detail}`,
         tags: { file: filename, error: detail },
       };


### PR DESCRIPTION
## Summary

- Adds a dedicated `no_flow_signal` Sentry checkpoint when a BRP.edf file is missing a flow signal, so these events are grouped separately from generic parse failures
- Adds a regression test pinning the parser error prefix — the worker checkpoint routing depends on it

## Context

Sentry JAVASCRIPT-NEXTJS-68 (9 events, 0 users): `No flow signal found in EDF file` for specific BRP.edf files. [AIR-1364](/AIR/issues/AIR-1364) already made label matching case-insensitive and included signal labels in the error message. The remaining gap: all BRP parse failures shared `checkpoint: parse_file_failed`, making this pattern unfilterable in Sentry.

## Changes

**`workers/analysis-worker.ts`** — detect "No flow signal found" prefix and route to `no_flow_signal` Sentry checkpoint

**`__tests__/edf-parser-truncation.test.ts`** — 1 new test: pins parser error prefix as a contract test between parser and worker

## Pre-merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] Bundle size impact: no bundle changes (worker only)
- [ ] Vercel preview deploy verified by Demian
- [x] PR contains one concern only
- [x] Self-review: no regressions, logic confined to checkpoint classification

**Note:** 2 pre-existing test failures in `stripe-webhook-phantom-user.test.ts` (AIR-1873) exist on `main` — not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)