### PR TITLE
fix(confirm): retry storage list on empty results to handle eventual consistency

### DIFF
--- a/__tests__/files-api-routes.test.ts
+++ b/__tests__/files-api-routes.test.ts
@@ -547,13 +547,36 @@ describe('POST /api/files/confirm', () => {
     });
     mockFrom.mockReturnValue(chain);
 
-    // All 3 attempts fail
+    // All 4 attempts fail with a list error
     const listMock = vi.fn().mockResolvedValue({ data: null, error: { message: 'Storage unavailable' } });
     mockStorageFrom.mockReturnValue({ list: listMock });
 
     const res = await callConfirm(makePostRequest('/api/files/confirm', validBody));
     expect(res.status).toBe(503);
-    expect(listMock).toHaveBeenCalledTimes(3);
+    expect(listMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('returns 200 when storage list returns empty then finds file on retry (eventual consistency)', async () => {
+    setupAuthenticatedUser();
+    const chain = createChain({
+      data: { id: validBody.fileId, storage_path: 'user-123/2026-01-01/BRP.edf', user_id: 'user-123' },
+      error: null,
+    });
+    chain.update = vi.fn(() => chain);
+    mockFrom.mockReturnValue(chain);
+
+    // First call returns empty (propagation delay), second call finds the file
+    const listMock = vi.fn()
+      .mockResolvedValueOnce({ data: [], error: null })
+      .mockResolvedValueOnce({ data: [{ name: 'BRP.edf' }], error: null });
+
+    mockStorageFrom.mockReturnValue({ list: listMock });
+
+    const res = await callConfirm(makePostRequest('/api/files/confirm', validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.confirmed).toBe(true);
+    expect(listMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/app/api/files/confirm/route.ts
+++ b/app/api/files/confirm/route.ts
@@ -65,25 +65,35 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
     }
 
-    // Verify file exists in storage. Retry up to 2 times for transient list failures.
+    // Verify file exists in storage. Retry on both list errors and empty results.
+    // Supabase Storage can be eventually consistent after a signed PUT — the object
+    // may not appear in a listing immediately after the upload completes, causing a
+    // false-absent result that deletes the metadata row and surfaces as a client-side
+    // cloud_upload_partial_failure event. Retrying with progressive delays handles
+    // both transient list errors and propagation-delay empty results.
     const storageFolder = fileRow.storage_path.split('/').slice(0, -1).join('/');
     const storageFileName = fileRow.storage_path.split('/').pop();
     let storageFile: { name: string }[] | null = null;
     let listError: unknown = null;
+    const LIST_DELAYS_MS = [0, 150, 300, 450];
 
-    for (let attempt = 0; attempt < 3; attempt++) {
+    for (let attempt = 0; attempt < LIST_DELAYS_MS.length; attempt++) {
       if (attempt > 0) {
-        await new Promise((r) => setTimeout(r, 150 * attempt));
+        await new Promise((r) => setTimeout(r, LIST_DELAYS_MS[attempt]!));
       }
       const result = await serviceRole.storage
         .from(STORAGE_BUCKET)
         .list(storageFolder, { search: storageFileName });
-      if (!result.error) {
+      if (result.error) {
+        listError = result.error;
+        continue;
+      }
+      listError = null;
+      if (result.data && result.data.length > 0) {
         storageFile = result.data;
-        listError = null;
         break;
       }
-      listError = result.error;
+      // List succeeded but returned empty — possible propagation delay; retry
     }
 
     if (listError) {


### PR DESCRIPTION
## Summary

- `app/api/files/confirm/route.ts` had a retry loop (3 attempts, 150ms backoff) that only retried on storage **list errors**. When Supabase Storage returned an empty listing (`data: [], error: null`) immediately after a signed PUT due to eventual consistency, the loop broke immediately, deleted the metadata row, and returned 404.
- Client never retries on 404, so each such race became `result.failed++` → `cloud_upload_partial_failure` (Sentry JAVASCRIPT-NEXTJS-4Z).
- **Fix:** 4-attempt loop at `[0, 150, 300, 450]ms` retries on both errors **and** empty results. Files are only declared absent after all 4 attempts confirm emptiness.
- Regression test asserts the empty→found retry path.

**Root cause:** PR #702 (AIR-983) added retry logic for list errors but did not handle the eventual-consistency empty-result path.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (57/57 tests, including new regression test)
- [x] `npm run build` passes
- [ ] Vercel preview deploy verified
- [ ] Monitor Sentry JAVASCRIPT-NEXTJS-4Z event rate after deploy

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [x] Self-review: no regressions, loading/error/empty states handled
- [x] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #600
Fixes AIR-1159