### PR TITLE
fix: strip newlines from email subjects before Resend API

### DIFF
--- a/__tests__/email-send-sentry.test.ts
+++ b/__tests__/email-send-sentry.test.ts
@@ -88,4 +88,32 @@ describe('sendEmail Sentry captures', () => {
     const ctx2 = vi.mocked(Sentry.captureException).mock.calls[0]?.[1]
     expect(ctx2).toMatchObject({ tags: { subsystem: 'email-log-insert' } })
   })
+
+  it('strips newlines from subject before sending to Resend API', async () => {
+    let capturedBody: Record<string, unknown> | null = null
+    vi.mocked(fetch).mockImplementationOnce(async (_url, init) => {
+      capturedBody = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>
+      return { ok: true, json: async () => ({ id: 'resend-456' }) } as Response
+    })
+
+    const { sendEmail } = await import('@/lib/email/send')
+    await sendEmail({ to: 'user@example.com', subject: 'Hello\nWorld\r\nBye', text: 'body' })
+
+    expect(capturedBody).not.toBeNull()
+    expect(capturedBody!['subject']).toBe('Hello World Bye')
+    expect(capturedBody!['subject']).not.toMatch(/[\r\n]/)
+  })
+
+  it('trims leading/trailing whitespace from subject after newline replacement', async () => {
+    let capturedBody: Record<string, unknown> | null = null
+    vi.mocked(fetch).mockImplementationOnce(async (_url, init) => {
+      capturedBody = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>
+      return { ok: true, json: async () => ({ id: 'resend-789' }) } as Response
+    })
+
+    const { sendEmail } = await import('@/lib/email/send')
+    await sendEmail({ to: 'user@example.com', subject: '\n\nContact form message\n', text: 'body' })
+
+    expect(capturedBody!['subject']).toBe('Contact form message')
+  })
 })

--- a/lib/email/send.ts
+++ b/lib/email/send.ts
@@ -61,6 +61,9 @@ export async function sendEmail({
     return null
   }
 
+  // Resend rejects subjects containing newlines with HTTP 422
+  const sanitizedSubject = subject.replace(/[\r\n]+/g, ' ').trim()
+
   try {
     const res = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -72,7 +75,7 @@ export async function sendEmail({
         from: 'AirwayLab <noreply@mail.airwaylab.app>',
         reply_to: replyTo ?? 'dev@airwaylab.app',
         to: [to],
-        subject,
+        subject: sanitizedSubject,
         ...(html && { html }),
         ...(text && { text }),
         ...(unsubscribeUrl && {
@@ -89,7 +92,7 @@ export async function sendEmail({
       const err = new Error(`Resend API ${res.status}: ${errBody.slice(0, 200)}`)
       Sentry.captureException(err, {
         tags: { subsystem: 'email-send' },
-        extra: { recipient_hash: hashRecipient(to), subject_pattern: subject.slice(0, 40), status: res.status },
+        extra: { recipient_hash: hashRecipient(to), subject_pattern: sanitizedSubject.slice(0, 40), status: res.status },
       })
       console.error(`[email-send] Resend API error ${res.status}: ${errBody}`)
       return null
@@ -107,7 +110,7 @@ export async function sendEmail({
   } catch (err) {
     Sentry.captureException(err, {
       tags: { subsystem: 'email-send' },
-      extra: { recipient_hash: hashRecipient(to), subject_pattern: subject.slice(0, 40) },
+      extra: { recipient_hash: hashRecipient(to), subject_pattern: sanitizedSubject.slice(0, 40) },
     })
     console.error('[email-send] Failed to send email:', err)
     return null


### PR DESCRIPTION
## Summary

- Resend API rejects email subjects containing `\r` or `\n` with HTTP 422, silently dropping contact form emails (Sentry ID: JAVASCRIPT-NEXTJS-7A)
- Added `subject.replace(/[\r\n]+/g, ' ').trim()` sanitization in `sendEmail()` defensively, so all callers are covered
- Added two unit tests asserting newline-containing subjects are sanitized before the API call

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 2514 tests pass, including 2 new subject-sanitization tests
- [ ] Verify no 422 errors in Resend dashboard / Sentry after deploy

Fixes AIR-2157

🤖 Generated with [Claude Code](https://claude.com/claude-code)