### PR TITLE
chore: add prohibited-terms CI check for blog, insights, and email templates

### DIFF
--- a/.github/workflows/mdr-string-check.yml
+++ b/.github/workflows/mdr-string-check.yml
@@ -1,0 +1,109 @@
+name: MDR String Check
+
+on:
+  pull_request:
+    paths:
+      - 'app/blog/posts/**/*.tsx'
+      - 'lib/blog-posts.ts'
+      - 'lib/insights.ts'
+      - 'lib/email/templates.ts'
+      - '__tests__/insights.test.ts'
+  workflow_dispatch:
+
+jobs:
+  mdr-string-check:
+    name: Check for prohibited MDR language
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run MDR prohibited string check
+        env:
+          BASE_BRANCH: ${{ github.base_ref || 'main' }}
+        run: |
+          set -euo pipefail
+
+          echo "Scanning added lines in watched files against origin/${BASE_BRANCH}..."
+
+          # Prohibited patterns (case-insensitive extended regex)
+          PROHIBITED='rera detection|detects (respiratory|breathing) event|suggests (diagnosis|obstruction|apnea|condition|disorder)|effective treatment|improves outcomes|\bdiagnoses\b|diagnostic tool'
+
+          TARGET_PATTERNS=(
+            "^app/blog/posts/.*\.tsx$"
+            "^lib/blog-posts\.ts$"
+            "^lib/insights\.ts$"
+            "^lib/email/templates\.ts$"
+            "^__tests__/insights\.test\.ts$"
+          )
+
+          # Collect changed files that match target patterns
+          CHANGED_FILES=()
+          while IFS= read -r f; do
+            for pat in "${TARGET_PATTERNS[@]}"; do
+              if echo "$f" | grep -qE "$pat"; then
+                CHANGED_FILES+=("$f")
+                break
+              fi
+            done
+          done < <(git diff --name-only "origin/${BASE_BRANCH}...HEAD")
+
+          if [ ${#CHANGED_FILES[@]} -eq 0 ]; then
+            echo "No target files changed. Skipping check."
+            exit 0
+          fi
+
+          echo "Files to scan: ${CHANGED_FILES[*]}"
+
+          VIOLATIONS=0
+
+          for file in "${CHANGED_FILES[@]}"; do
+            IN_HUNK=false
+            CURRENT_LINE=0
+
+            while IFS= read -r diffline; do
+              # Reset hunk state on new file header
+              if [[ "$diffline" =~ ^diff\ --git ]]; then
+                IN_HUNK=false
+
+              # Hunk header: extract new-file start line number
+              elif [[ "$diffline" =~ ^@@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+) ]]; then
+                CURRENT_LINE=$(( ${BASH_REMATCH[2]} - 1 ))
+                IN_HUNK=true
+
+              elif [ "$IN_HUNK" = false ]; then
+                continue  # skip index / --- / +++ headers before first @@
+
+              elif [[ "$diffline" =~ ^--- ]] || [[ "$diffline" =~ ^\+\+\+ ]]; then
+                continue  # file path headers within diff block
+
+              elif [[ "$diffline" =~ ^- ]]; then
+                : # removed line — not in new file, do not count
+
+              elif [[ "$diffline" =~ ^\+ ]]; then
+                CURRENT_LINE=$(( CURRENT_LINE + 1 ))
+                content="${diffline:1}"
+                if echo "$content" | grep -qiE "$PROHIBITED"; then
+                  matched=$(echo "$content" | grep -oiE "$PROHIBITED" | head -1)
+                  echo "::error file=${file},line=${CURRENT_LINE}::Prohibited term '${matched}' — see docs/mdr-prohibited-terms.md for approved replacements"
+                  VIOLATIONS=$(( VIOLATIONS + 1 ))
+                fi
+
+              else
+                # Context line — counts in new file
+                CURRENT_LINE=$(( CURRENT_LINE + 1 ))
+              fi
+
+            done < <(git diff "origin/${BASE_BRANCH}...HEAD" -- "$file")
+          done
+
+          if [ "$VIOLATIONS" -gt 0 ]; then
+            echo ""
+            echo "::error::Found ${VIOLATIONS} prohibited term(s) in changed lines. See docs/mdr-prohibited-terms.md."
+            exit 1
+          fi
+
+          echo "MDR string check passed — no prohibited language found in changed lines."

--- a/docs/mdr-prohibited-terms.md
+++ b/docs/mdr-prohibited-terms.md
@@ -1,0 +1,44 @@
+# MDR Prohibited Terms Reference
+
+Quick reference for terms that are blocked by the CI gate (`mdr-string-check.yml`).
+Full policy: `.claude/rules/mdr-compliance.md`.
+
+## Why this matters
+
+Under EU MDR Rule 11, software is classified as a medical device when it
+"provides information which is used to take decisions with diagnosis or
+therapeutic purposes." AirwayLab is positioned as an educational/informational
+tool. Using diagnostic or therapeutic language — even incidentally — risks
+regulatory reclassification.
+
+## Prohibited terms and approved replacements
+
+| Prohibited | Approved replacement |
+|---|---|
+| `RERA detection` / `rera detection` | `elevated RERA-like breath sequences` |
+| `detects (respiratory\|breathing) event` | `identifies elevated metrics consistent with...` |
+| `suggests (diagnosis\|obstruction\|apnea\|condition\|disorder)` | `breath-shape scores are elevated` / `both obstructive and central events are elevated` |
+| `effective treatment` | `metrics are in the typical range` |
+| `improves outcomes` | `patterns observed in your data` |
+| `diagnoses` | `describes` / `shows` |
+| `diagnostic tool` | `analysis tool` / `informational tool` |
+
+## Language rules
+
+- **Describe, never diagnose.** Say what the data shows, not what it means clinically.
+- **Describe, never prescribe.** Say what the machine recorded, not what the user should do.
+- **Directional, not judgmental.** Use "lower/typical/higher" rather than "good/bad/effective."
+- **Clinician defers.** Any reference to clinical interpretation must end with
+  "your clinician can help interpret these findings in context" — never
+  "discuss adjustments with your clinician."
+
+## CI gate scope
+
+The check runs on PRs that touch:
+
+- `app/blog/posts/**/*.tsx`
+- `lib/blog-posts.ts`
+- `lib/insights.ts`
+- `lib/email/templates.ts`
+
+Only newly added or changed lines are scanned (git diff additions).


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that scans changed lines in blog posts, insights, and email template files for prohibited clinical/diagnostic language on every PR.

**Files scanned:** `app/blog/posts/**/*.tsx`, `lib/blog-posts.ts`, `lib/insights.ts`, `lib/email/templates.ts`

**What is checked (case-insensitive):**
- `RERA detection`
- `detects (respiratory|breathing) event`
- `suggests (diagnosis|obstruction|apnea|condition|disorder)`
- `effective treatment`
- `improves outcomes`
- `diagnoses` / `diagnostic tool`

Violations surface as GitHub PR check annotations with file + line number. Clean PRs pass silently.

Also adds `docs/mdr-prohibited-terms.md` — a scannable prohibited → approved term reference table for engineers.

## Pre-merge checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] Workflow demonstrated: pass case on clean PR, fail case on deliberate violation
- [ ] PR contains one concern only