### PR TITLE
test: fix stale mock reference in stripe-webhook-phantom-user tests

### DIFF
--- a/__tests__/stripe-webhook-phantom-user.test.ts
+++ b/__tests__/stripe-webhook-phantom-user.test.ts
@@ -189,7 +189,6 @@ describe('stripe-webhook-phantom-user: checkout.session.completed with non-exist
   });
 
   it('fires Sentry captureMessage with phantom-user-id tag', async () => {
-    const { captureMessage } = await import('@sentry/nextjs');
     const event = makeCheckoutSessionEvent(PHANTOM_USER_ID);
     mockWebhooksConstruct.mockReturnValue(event);
     mockSubscriptionsRetrieve.mockResolvedValue(makeSubscriptionObject(PHANTOM_USER_ID));
@@ -206,6 +205,8 @@ describe('stripe-webhook-phantom-user: checkout.session.completed with non-exist
 
     await callRoute(makeWebhookRequest());
 
+    // Import after callRoute so we get the fresh mock created by vi.resetModules() inside callRoute
+    const { captureMessage } = await import('@sentry/nextjs');
     expect(captureMessage).toHaveBeenCalledWith(
       'Stripe webhook: supabase_user_id in metadata has no matching profile',
       expect.objectContaining({
@@ -247,7 +248,6 @@ describe('stripe-webhook-phantom-user: checkout.session.completed with non-exist
   });
 
   it('includes userId, eventId, subscriptionId, and stripeCustomerId in Sentry extra', async () => {
-    const { captureMessage } = await import('@sentry/nextjs');
     const event = makeCheckoutSessionEvent(PHANTOM_USER_ID, 'sub_phantom_456');
     mockWebhooksConstruct.mockReturnValue(event);
     mockSubscriptionsRetrieve.mockResolvedValue(makeSubscriptionObject(PHANTOM_USER_ID));
@@ -258,6 +258,8 @@ describe('stripe-webhook-phantom-user: checkout.session.completed with non-exist
 
     await callRoute(makeWebhookRequest());
 
+    // Import after callRoute so we get the fresh mock created by vi.resetModules() inside callRoute
+    const { captureMessage } = await import('@sentry/nextjs');
     expect(captureMessage).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({


### PR DESCRIPTION
## Summary

- `callRoute()` calls `vi.resetModules()` before importing the Stripe webhook route, creating fresh `vi.fn()` instances for all mocked modules
- Two tests imported `captureMessage` from `@sentry/nextjs` **before** `callRoute()`, capturing a stale reference that predates the module reset — the real call happened on the fresh mock, not the stale one
- Fix: move `captureMessage` import to **after** `await callRoute()` in both failing tests so the assertion sees the correct mock instance

**Root cause:** PR #843 moved checkout processing into `after()` — an async callback — which shifted the execution timing relative to the existing mock pattern. The `callRoute`/`vi.resetModules()` pattern was already present; the combination with deferred `after()` exposed the stale-reference issue.

Unblocks: AIR-1509 CI gate PR (pre-push hook was failing on main before this fix).

## Test plan

- [x] `npx vitest run __tests__/stripe-webhook-phantom-user.test.ts` — was 2 failed, now 5 passed
- [x] Full suite: 2462 tests pass (pre-push hook confirmed)
- [x] No production code changed — test-only fix

## Pre-merge checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] Bundle size impact — none (test file only)
- [x] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)