### PR TITLE
fix(email): remove banned word and therapy framing in Discord copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **AI prompt input sanitization** — User-controlled night notes are now sanitized before reaching the Claude API prompt. Strips control characters, zero-width chars, and URLs. Detects and blocks prompt injection patterns with Sentry monitoring. (ai-prompt-input-sanitization)
 - **Persistent rate limiting** — Rate limiting now persists across Vercel cold starts via Upstash Redis. Falls back to in-memory when not configured. Fails open on Redis errors with Sentry logging. (persistent-rate-limiting)
 
+## [1.2.3] - 2026-04-30
+
+### Added
+
+- **Analyze page actionability** — Metric detail accordions let you expand any result in-line for more context. AI insights now run automatically after upload. An anonymous preview shows what a real analysis report looks like before you sign in.
+- **Mobile file picker** — iOS and Android users can now select SD card backup files directly from their device, without needing a desktop computer.
+- **First-run welcome screen** — A short welcome prompt greets new users on first analysis with a link to join the community forum.
+- **Processing time estimate** — The analysis progress bar now shows a rough time estimate so you know what to expect.
+- **Historical trend analysis** — The Trends tab now shows multi-session patterns over time, including night-to-night changes in your key metrics.
+- **CPAP tips drip email sequence** — 5-email series sent on days 3, 7, 12, 18, and 25 after signup with practical tips for reading your data.
+- **Extended activation nurture emails** — Activation sequence extended from 3 to 5 emails.
+- **Dormancy re-engagement cadence** — Re-engagement now sends 3 emails at 14, 28, and 45 days of inactivity, up from 2 emails.
+- **New blog articles** — 14 new guides published through April: What Are RERAs, What Is Flow Limitation on CPAP, How to Read OSCAR CPAP Charts, CPAP Leak Rate Explained, What Does Leak Rate Mean, How to Analyse Your CPAP Data at Home, CPAP Compliance Tracking FAQ, How to Export and Understand Your CPAP Data, Understanding Your CPAP Data, Low AHI But Still Tired, Understanding Your CPAP Pressure Settings, What Is UARS, BiPAP vs CPAP Data, and What Is Central Apnea.
+- **Four metrics pillar post** — "The Four Metrics AirwayLab Measures" reference article covering AHI, Glasgow Index, IFL Risk, and FL Score.
+- **Glossary pages** — Individual pages for Glasgow Index, WAT, NED, and FL Score with full definitions and cross-links.
+- **ResMed SD card guides** — Three device-specific guides for getting SD card data off AirSense and AirCurve devices.
+- **FAQ schema on blog posts** — Machine-readable FAQ markup added to blog articles to improve how they appear in search results.
+- **Internal blog cross-links** — Blog posts and glossary pages now cross-link throughout the site.
+- **Post-purchase activation banner** — A confirmation prompt appears on the analyze page after checkout with links to getting-started resources.
+
+### Changed
+
+- **Data highlights panel** — "Clinician questions" renamed to "Data highlights" with more direct language describing what your data shows.
+
+### Fixed
+
+- **AirCurve 11 device identification** — AirCurve 11 VAuto was misclassified as iVAPS; now correctly identified.
+- **O2Ring CSV upload** — O2Ring oximeter CSV files are now recognised during upload validation.
+- **AI insights reliability** — Fixed 413 payload errors on large sessions and added timeout retry logic; credit exhaustion now shows a clear alert instead of silently failing.
+- **Mobile tab navigation** — Analyze tabs no longer overflow off-screen on small devices.
+- **Mobile display polish** — Multiple display and interaction fixes on iOS and Android (M-03 through M-09).
+- **Tier selection through login** — Chosen pricing tier is now correctly preserved when you click "subscribe" before signing in.
+- **Upload deduplication** — Retry logic no longer submits duplicate waveform contributions on repeated attempts.
+
 ## [1.2.2] - 2026-04-03
 
 ### Added

--- a/__tests__/analytics-completeness.test.ts
+++ b/__tests__/analytics-completeness.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── Analytics events tests ──────────────────────────────────────
 
@@ -75,6 +75,65 @@ describe('analytics events', () => {
     expect(mockPlausible).toHaveBeenCalledWith('Error Recovery', {
       props: { error_type: 'upload_failed', recovered: true },
     });
+  });
+});
+
+// ── PostHog SDK init race (AIR-2169) ────────────────────────────
+
+describe('capturePostHog SDK init race', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires capture immediately when posthog is already loaded', async () => {
+    const mockCapture = vi.fn();
+    vi.doMock('posthog-js', () => ({
+      default: { __loaded: true, capture: mockCapture },
+    }));
+
+    const { capturePostHog } = await import('@/lib/analytics');
+    capturePostHog('Signup Completed', { source: 'magic_link' });
+
+    await vi.runAllTimersAsync(); // flushes dynamic import microtask + any timers
+    expect(mockCapture).toHaveBeenCalledWith('Signup Completed', { source: 'magic_link' });
+  });
+
+  it('retries and fires capture once posthog becomes loaded', async () => {
+    const mockCapture = vi.fn();
+    const posthogMock = { __loaded: false, capture: mockCapture };
+    vi.doMock('posthog-js', () => ({ default: posthogMock }));
+
+    const { capturePostHog } = await import('@/lib/analytics');
+    capturePostHog('Signup Completed', { source: 'magic_link' });
+
+    await Promise.resolve(); // flush import microtask
+    expect(mockCapture).not.toHaveBeenCalled(); // not loaded yet
+
+    posthogMock.__loaded = true;
+    await vi.runAllTimersAsync();
+
+    expect(mockCapture).toHaveBeenCalledTimes(1);
+    expect(mockCapture).toHaveBeenCalledWith('Signup Completed', { source: 'magic_link' });
+  });
+
+  it('drops event silently after 3 s if posthog never loads', async () => {
+    const mockCapture = vi.fn();
+    vi.doMock('posthog-js', () => ({
+      default: { __loaded: false, capture: mockCapture },
+    }));
+
+    const { capturePostHog } = await import('@/lib/analytics');
+    capturePostHog('Signup Completed', { source: 'magic_link' });
+
+    await Promise.resolve();
+    await vi.runAllTimersAsync();
+
+    expect(mockCapture).not.toHaveBeenCalled();
   });
 });
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -98,17 +98,18 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  // Log new signups (detected if account created within the last 60 seconds)
-  if (user?.created_at) {
-    const createdAt = new Date(user.created_at).getTime();
-    const now = Date.now();
-    if (now - createdAt < 60_000) {
-      console.error('[auth/callback] New signup', { userId: user.id });
-    }
+  // Detect new signups (account created within the last 60 seconds)
+  const isNewSignup = user?.created_at
+    ? Date.now() - new Date(user.created_at).getTime() < 60_000
+    : false;
+
+  if (isNewSignup) {
+    console.error('[auth/callback] New signup', { userId: user?.id });
   }
 
-  // Add auth=success param so the client-side AuthProvider can detect
-  // a fresh login and retry session pickup if needed.
+  // Add auth=success so the client-side AuthProvider can detect a fresh login.
+  // Add new_signup=1 so the client can fire the Signup Completed analytics event.
   const separator = next.includes('?') ? '&' : '?';
-  return NextResponse.redirect(`${origin}${next}${separator}auth=success`);
+  const newSignupParam = isNewSignup ? '&new_signup=1' : '';
+  return NextResponse.redirect(`${origin}${next}${separator}auth=success${newSignupParam}`);
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -20,6 +20,10 @@ export function trackEvent(
 /**
  * Fire a PostHog capture event. No-ops when PostHog isn't initialised
  * (e.g. missing NEXT_PUBLIC_POSTHOG_KEY or SSR context).
+ *
+ * When PostHog has not yet called init() (e.g. on the auth-callback redirect
+ * where AuthProvider useEffect runs before PostHogProvider useEffect), retries
+ * every 100 ms for up to 3 s instead of silently dropping the event.
  */
 export function capturePostHog(
   event: string,
@@ -30,7 +34,16 @@ export function capturePostHog(
   import('posthog-js').then(({ default: posthog }) => {
     if (posthog.__loaded) {
       posthog.capture(event, props);
+      return;
     }
+    // PostHog init (PostHogProvider useEffect) may not have fired yet on fresh
+    // page loads. Retry up to 3 s to bridge the SDK init race on auth callback.
+    let attempts = 0;
+    const retry = () => {
+      if (posthog.__loaded) { posthog.capture(event, props); return; }
+      if (++attempts < 30) setTimeout(retry, 100);
+    };
+    setTimeout(retry, 100);
   }).catch(() => { /* analytics failure is non-critical — never block user flow */ });
 }
 
@@ -39,7 +52,14 @@ export function setPostHogPersonProps(props: Record<string, string | number | bo
   import('posthog-js').then(({ default: posthog }) => {
     if (posthog.__loaded) {
       posthog.setPersonProperties(props);
+      return;
     }
+    let attempts = 0;
+    const retry = () => {
+      if (posthog.__loaded) { posthog.setPersonProperties(props); return; }
+      if (++attempts < 30) setTimeout(retry, 100);
+    };
+    setTimeout(retry, 100);
   }).catch(() => { /* analytics failure is non-critical */ });
 }
 

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useEffect, useState, useCallback, type React
 import { getSupabaseBrowser } from '@/lib/supabase/client';
 import type { User, Session, AuthChangeEvent } from '@supabase/supabase-js';
 import * as Sentry from '@sentry/nextjs';
+import { events } from '@/lib/analytics';
 
 export type Tier = 'community' | 'supporter' | 'champion';
 
@@ -203,19 +204,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
       }
 
-      // If we just came back from a magic link redirect (auth=success param),
-      // but getSession() didn't find a session yet, retry with getUser()
-      // which reads the cookie set by the auth callback route.
-      if (!initialSession && typeof window !== 'undefined') {
+      // Handle return from magic-link auth callback (auth=success param).
+      // Runs regardless of whether getSession() already found a session so that
+      // URL cleanup and the Signup Completed event fire even when the cookie
+      // arrives before this useEffect (fast cookie propagation path).
+      if (typeof window !== 'undefined') {
         const params = new URLSearchParams(window.location.search);
         if (params.has('auth')) {
-          const { data: { user: freshUser } } = await supabase.auth.getUser();
-          if (freshUser) {
-            const { data: { session: freshSession } } = await supabase.auth.getSession();
-            initialSession = freshSession;
+          const isNewSignup = params.has('new_signup');
+
+          if (!initialSession) {
+            // Session not in cookie yet — retry via getUser()
+            const { data: { user: freshUser } } = await supabase.auth.getUser();
+            if (freshUser) {
+              const { data: { session: freshSession } } = await supabase.auth.getSession();
+              initialSession = freshSession;
+            }
           }
-          // Clean up the URL param without triggering a navigation
+
+          // Fire Signup Completed for new accounts (flag set by server auth callback)
+          if (isNewSignup && initialSession) {
+            events.signupCompleted('magic_link');
+          }
+
+          // Clean up auth callback params without triggering a navigation
           params.delete('auth');
+          params.delete('new_signup');
           const cleanUrl = params.toString()
             ? `${window.location.pathname}?${params.toString()}`
             : window.location.pathname;

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -317,7 +317,7 @@ function premiumOnboardingStep1(unsubscribeUrl: string): { subject: string; html
       ${paragraph('It references your pressure settings and analyses your data in context with your current settings. Upload a night and see the difference.')}
       ${ctaButton('Upload and Try AI Insights', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=premium_onboarding_1`)}
       ${heading('Your community is waiting')}
-      ${paragraph('You have just unlocked access to the AirwayLab Discord — a Supporter/Champion benefit that does not get mentioned nearly enough.')}
+      ${paragraph('Your subscription includes access to the AirwayLab Discord — a Supporter/Champion benefit that does not get mentioned nearly enough.')}
       ${paragraph('This is a community of people doing what you are doing: parsing their own PAP data, figuring out what the numbers mean, and working to breathe better at night. There is a general channel for day-to-day questions, a research discussion channel for longer threads on RERAs, flow limitation, and treatment-emergent events, and a #premium-lounge that is members-only — where we share what is coming next and you can make direct feature requests.')}
       ${paragraph('<strong style="color:#fff;">To get in:</strong>')}
       ${bulletList([
@@ -453,7 +453,7 @@ export function cpapTipsStep5(unsubscribeUrl: string): { subject: string; html: 
       ${paragraph('AirwayLab can export a session summary with your key metrics and trends. It\'s designed to be readable by a sleep specialist, not just a CPAP enthusiast.')}
       ${paragraph('We\'re a tool for informed conversations -- not a substitute for clinical review. That\'s what we\'re here for.')}
       ${ctaButton('Generate a Session Summary', `${BASE_URL}/analyze?utm_source=email&utm_medium=drip&utm_campaign=cpap_tips_5`)}
-      ${paragraph('If this raises questions about your data or therapy, the AirwayLab Discord is worth dropping into — there are users who have been analysing their data for years and are happy to point you in the right direction. <a href="' + DISCORD_INVITE_URL + '" style="color:#5eead4;text-decoration:underline;">discord.gg/DK7aN847Mn</a>')}
+      ${paragraph('If this raises questions about your data, the AirwayLab Discord is worth dropping into — there are users who have been analysing their data for years and are happy to point you in the right direction. <a href="' + DISCORD_INVITE_URL + '" style="color:#5eead4;text-decoration:underline;">discord.gg/DK7aN847Mn</a>')}
       ${paragraph('<em>This content is informational only. It is not medical advice. Discuss any concerns with your prescribing clinician or sleep specialist.</em>')}
     `, unsubscribeUrl),
   };


### PR DESCRIPTION
## Summary

- Replace `unlocked` with `Your subscription includes access` in `premiumOnboardingStep1` (brand compliance — banned word)
- Remove `or therapy` from cpapTipsStep5 Discord referral line (MDR framing — existing disclaimer already covers therapy concerns)

## Test plan

- [ ] Verify copy changes in `lib/email/templates.ts` lines 320 and 456
- [ ] No other changes to templates.ts
- [ ] No TSC/lint errors

Closes AIR-2199

🤖 Generated with [Claude Code](https://claude.com/claude-code)