### PR TITLE
fix: align package.json version to 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airwaylab",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

CHANGELOG.md already contains a `## [1.2.3]` entry (added in AIR-1930, commit `586c8df`) but `package.json` was never bumped to match. The `check-version.mjs` build gate compares these and fails when they diverge, breaking all Vercel production deployments since 2026-05-28.

This PR bumps `package.json` from `1.2.2` → `1.2.3` to restore the build.

**Root cause:** version bump commit was omitted when the changelog entry was committed.

## Impact

- Unblocks the Vercel production deployment (currently failing on all commits to main)
- Restores the `what-is-a-good-ahi-on-cpap` blog article deployment (AIR-1477, merged PR #829)

## Test plan

- [x] `npm test` — 2515 tests pass
- [x] `check-version.mjs` will now return ✓ (1.2.3 = 1.2.3)
- [x] No functional changes — package.json version field only

🤖 Generated with [Claude Code](https://claude.com/claude-code)