### PR TITLE
chore: update auto-approve workflow to airwaylab-dev identity

### DIFF
--- a/.github/workflows/auto-approve-bot.yml
+++ b/.github/workflows/auto-approve-bot.yml
@@ -1,0 +1,25 @@
+name: Auto-approve PR via airwaylab-bot
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'airwaylab-bot'
+    steps:
+      - name: Approve PR as airwaylab-bot
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          RUN_ID: ${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          gh pr review "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --approve \
+            --body "Approved by airwaylab-bot. Author: ${PR_AUTHOR} != reviewer: airwaylab-bot. Audit: run ${RUN_ID}, sha ${COMMIT_SHA}."

--- a/.github/workflows/auto-approve-bot.yml
+++ b/.github/workflows/auto-approve-bot.yml
@@ -1,4 +1,4 @@
-name: Auto-approve PR via airwaylab-bot
+name: Auto-approve PR via airwaylab-dev
 
 on:
   pull_request:
@@ -9,11 +9,11 @@ permissions: {}
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login != 'airwaylab-bot'
+    if: github.event.pull_request.user.login != 'airwaylab-dev'
     steps:
-      - name: Approve PR as airwaylab-bot
+      - name: Approve PR as airwaylab-dev
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AIRWAYLAB_DEV_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           RUN_ID: ${{ github.run_id }}
@@ -22,4 +22,4 @@ jobs:
           gh pr review "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
             --approve \
-            --body "Approved by airwaylab-bot. Author: ${PR_AUTHOR} != reviewer: airwaylab-bot. Audit: run ${RUN_ID}, sha ${COMMIT_SHA}."
+            --body "Approved by airwaylab-dev. Author: ${PR_AUTHOR} != reviewer: airwaylab-dev. Audit: run ${RUN_ID}, sha ${COMMIT_SHA}."


### PR DESCRIPTION
## Summary

- Updates `.github/workflows/auto-approve-bot.yml` to use `airwaylab-dev` account as the reviewer identity (board decision 2026-05-29)
- 5 substitutions: workflow name, `if` guard, step name, secret reference (`BOT_GITHUB_TOKEN` → `AIRWAYLAB_DEV_TOKEN`), and audit body text
- No other files changed

## Test plan

- [ ] Workflow logic unchanged — only reviewer identity updated
- [ ] `if` guard: `!= 'airwaylab-dev'` prevents the account from approving its own PRs
- [ ] Secret `AIRWAYLAB_DEV_TOKEN` must be provisioned by Demian before workflow goes live (fail-safe: missing secret causes fast-fail, not silent pass)
- [ ] All 2512 existing tests pass

Part of AIR-2148 / AIR-1557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)