### PR TITLE
fix(blog): correct AirSense 10 vs 11 SD card slot location in FAQ

### DIFF
--- a/app/blog/posts/how-to-download-resmed-cpap-data.tsx
+++ b/app/blog/posts/how-to-download-resmed-cpap-data.tsx
@@ -425,11 +425,11 @@ export default function HowToDownloadResMedCPAPData() {
         <div className="mt-4 space-y-4">
           <div className="rounded-xl border border-border/50 p-5">
             <p className="text-sm font-semibold text-foreground">
-              How do I download data from my ResMed AirSense 10?
+              How do I download data from my ResMed AirSense 10 or AirSense 11?
             </p>
             <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-              Power off the machine, remove the SD card from the left side, behind a small cover panel, insert it into
-              your computer, and open the DATALOG folder. The .edf files inside contain your full
+              Power off the machine. On the <strong className="text-foreground">AirSense 10</strong>, remove the SD card from the right side of the machine. On the <strong className="text-foreground">AirSense 11</strong>, the slot is on the left side, behind a small cover panel. Insert the card into
+              your computer and open the DATALOG folder. The .edf files inside contain your full
               therapy data. Analysis tools like OSCAR and AirwayLab can read these files directly.
             </p>
           </div>


### PR DESCRIPTION
## Summary

- FAQ question updated to cover both AirSense 10 and AirSense 11 (was AirSense 10 only)
- AirSense 10 answer correctly states SD card is on the **right side**
- AirSense 11 answer correctly states SD card is on the **left side, behind a small cover panel**
- Consistent with `resmed-airsense-11-sd-card.tsx:87`

Fixes factual error introduced by PR #790 (AIR-1749) where the AirSense 11 slot location was described under the AirSense 10 FAQ question.

Content draft approved in AIR-2296. Closes AIR-2309.

**Replaces:** #902 (closed — contained out-of-scope AIR-1750 commits)

## Changes

1 file, 6 lines: `app/blog/posts/how-to-download-resmed-cpap-data.tsx`

## Test plan

- [x] TypeScript check passes
- [x] Lint passes
- [x] All 2515 tests pass
- [x] 1 commit, 1 file only — no scope bleed

🤖 Generated with [Claude Code](https://claude.com/claude-code)