### PR TITLE
fix(email): hardcode CAN-SPAM physical address fallback (AIR-1999)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ GMAIL_CLIENT_ID=
 GMAIL_CLIENT_SECRET=
 GMAIL_REFRESH_TOKEN=
 
-# CAN-SPAM Act compliance: physical mailing address shown in re-engagement email footers.
+# CAN-SPAM Act compliance: physical mailing address shown in every commercial email footer.
 # Required by 16 CFR Part 316. Set to the sender's valid physical postal address.
-SENDER_PHYSICAL_ADDRESS=
+# Code falls back to AirwayLab B.V. address if not set, but Vercel Production env var should always be configured.
+SENDER_PHYSICAL_ADDRESS=AirwayLab B.V., Helperpark 274-6, 9723 ZA Groningen, Netherlands

--- a/__tests__/email-re-engagement.test.ts
+++ b/__tests__/email-re-engagement.test.ts
@@ -331,6 +331,14 @@ describe('re-engagement template personalisation', () => {
       expect(html).toContain('utm_source=email');
     }
   });
+
+  it('all three steps include physical mailing address (CAN-SPAM §7704(a)(5))', async () => {
+    const { reEngagementStep1, reEngagementStep2, reEngagementStep3 } = await import('@/lib/email/templates');
+    for (const fn of [reEngagementStep1, reEngagementStep2, reEngagementStep3]) {
+      const { html } = fn(UNSUB_URL, 'Test', '1 January 2026');
+      expect(html).toContain('Helperpark');
+    }
+  });
 });
 
 // ── SEQUENCES registry entry ──────────────────────────────────

--- a/__tests__/email-templates.test.ts
+++ b/__tests__/email-templates.test.ts
@@ -193,6 +193,11 @@ describe('All templates — structural invariants', () => {
     expect(html).toContain('utm_source=email');
     expect(html).toContain('utm_medium=drip');
   });
+
+  it.each(allTemplates)('$name includes physical mailing address (CAN-SPAM §7704(a)(5))', ({ fn }) => {
+    const { html } = fn(UNSUB_URL);
+    expect(html).toContain('Helperpark');
+  });
 });
 
 // ── SEQUENCES registry ─────────────────────────────────────────

--- a/__tests__/transactional-emails.test.ts
+++ b/__tests__/transactional-emails.test.ts
@@ -44,6 +44,11 @@ describe('email helpers', () => {
     expect(result).toContain('<p>Content</p>')
   })
 
+  it('emailShell includes physical mailing address (CAN-SPAM §7704(a)(5))', () => {
+    const result = emailShell('<p>Content</p>')
+    expect(result).toContain('Helperpark')
+  })
+
   it('BASE_URL points to production', () => {
     expect(BASE_URL).toBe('https://airwaylab.app')
   })

--- a/lib/email/helpers.ts
+++ b/lib/email/helpers.ts
@@ -8,7 +8,8 @@
 export const BASE_URL = 'https://airwaylab.app'
 
 /** CAN-SPAM §7704(a)(5): physical postal address shown in every commercial email footer. */
-export const SENDER_PHYSICAL_ADDRESS = process.env.SENDER_PHYSICAL_ADDRESS ?? ''
+export const SENDER_PHYSICAL_ADDRESS =
+  process.env.SENDER_PHYSICAL_ADDRESS ?? 'AirwayLab B.V., Helperpark 274-6, 9723 ZA Groningen, Netherlands'
 
 export function ctaButton(text: string, href: string): string {
   return `<div style="margin:24px 0;">

--- a/lib/email/templates.ts
+++ b/lib/email/templates.ts
@@ -12,7 +12,8 @@
 const BASE_URL = 'https://airwaylab.app';
 
 /** CAN-SPAM §7704(a)(5): physical postal address shown in every commercial email footer. */
-const SENDER_PHYSICAL_ADDRESS = process.env.SENDER_PHYSICAL_ADDRESS ?? '';
+const SENDER_PHYSICAL_ADDRESS =
+  process.env.SENDER_PHYSICAL_ADDRESS ?? 'AirwayLab B.V., Helperpark 274-6, 9723 ZA Groningen, Netherlands';
 
 // ── Shared layout ────────────────────────────────────────────
 
@@ -444,7 +445,8 @@ export function cpapTipsStep5(unsubscribeUrl: string): { subject: string; html: 
  * footer to satisfy CAN-SPAM Act requirements (16 CFR Part 316).
  */
 function reEngagementLayout(content: string, unsubscribeUrl: string): string {
-  const physicalAddress = process.env.SENDER_PHYSICAL_ADDRESS ?? 'AirwayLab';
+  const physicalAddress =
+    process.env.SENDER_PHYSICAL_ADDRESS ?? 'AirwayLab B.V., Helperpark 274-6, 9723 ZA Groningen, Netherlands';
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -479,7 +481,7 @@ function reEngagementLayout(content: string, unsubscribeUrl: string): string {
         AirwayLab is not a medical device. This email contains data summaries for informational purposes. Your clinician can help interpret these findings in the context of your care.
       </p>
       <p style="font-size:10px;color:#52525b;line-height:1.5;margin:8px 0 0 0;">
-        AirwayLab &middot; ${physicalAddress}
+        ${physicalAddress}
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- All three email layouts (`emailShell`, `layout`, `reEngagementLayout`) now fall back to `AirwayLab B.V., Helperpark 274-6, 9723 ZA Groningen, Netherlands` when `SENDER_PHYSICAL_ADDRESS` is not set in the environment
- Fixes `reEngagementLayout` fallback which was `'AirwayLab'` — not a valid postal address for CAN-SPAM §7704(a)(5)
- Removes the redundant `AirwayLab ·` prefix in `reEngagementLayout` footer (address already includes entity name)
- Updates `.env.example` with the production value and an improved comment
- Adds regression tests in all three email test files — 173 tests pass

## Why

AIR-1999 identified that `SENDER_PHYSICAL_ADDRESS` env var is 9 days overdue in Vercel production. Without the env var, the previous code defaulted to `''` (no address in footer) or `'AirwayLab'` (not a postal address) — both are CAN-SPAM §7704(a)(5) violations. This PR adds defense-in-depth at the code layer.

The Vercel production env var (AIR-1999) still needs to be set by Demian; this ensures correct behavior even if the env var is ever misconfigured.

## Test plan
- [x] `npx vitest run __tests__/email-templates.test.ts __tests__/transactional-emails.test.ts __tests__/email-re-engagement.test.ts` — 173 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Verify Vercel preview deploy renders correct footer address in email preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)