### PR TITLE
fix(auth): catch lock contention steal-option variant in Sentry filter

### DIFF
--- a/__tests__/auth-context-profile-fetch.test.tsx
+++ b/__tests__/auth-context-profile-fetch.test.tsx
@@ -160,4 +160,25 @@ describe('AuthProvider fetchProfile — AIR-1486 regression', () => {
     expect(vi.mocked(Sentry.captureMessage)).not.toHaveBeenCalled();
     expect(vi.mocked(Sentry.captureException)).not.toHaveBeenCalled();
   });
+
+  // AIR-1763: Chrome 116+ / newer GoTrue surfaces a different error string for the same
+  // navigator.locks race — "Lock broken by another request with the 'steal' option."
+  // The previous check (includes('Lock was stolen')) missed this variant, leaking events
+  // to Sentry (JAVASCRIPT-NEXTJS-2M + 5M).
+  it('suppresses Sentry on "steal option" lock contention variant (AIR-1763)', async () => {
+    vi.mocked(getSupabaseBrowser).mockReturnValue(
+      makeSupabaseMock({
+        profileResult: {
+          data: null,
+          error: { message: "Lock broken by another request with the 'steal' option." },
+        },
+      }) as ReturnType<typeof getSupabaseBrowser>
+    );
+
+    render(<AuthProvider><TestConsumer /></AuthProvider>);
+
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('ready'));
+    expect(vi.mocked(Sentry.captureMessage)).not.toHaveBeenCalled();
+    expect(vi.mocked(Sentry.captureException)).not.toHaveBeenCalled();
+  });
 });

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -47,6 +47,15 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+// Supabase uses navigator.locks internally; two variants surface as AbortErrors:
+//   "Lock was stolen by another request" (older Supabase GoTrue)
+//   "Lock broken by another request with the 'steal' option." (newer GoTrue / Chrome 116+)
+// Both are transient cross-tab races that self-heal — retry once, then suppress Sentry.
+function isLockContention(message: string | undefined): boolean {
+  if (!message) return false;
+  return message.includes('Lock was stolen') || message.includes("'steal' option");
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
@@ -67,9 +76,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .eq('id', userId)
       .maybeSingle();
 
-    // "Lock was stolen" is transient Supabase navigator.locks contention across tabs -- retry once.
+    // Lock contention is transient cross-tab races — retry once before giving up.
     // Without the retry the profile stays null, silently downgrading the user's tier to 'community'.
-    if (profileResult.error?.message?.includes('Lock was stolen')) {
+    if (isLockContention(profileResult.error?.message)) {
       await new Promise((r) => setTimeout(r, 100));
       profileResult = await supabase
         .from('profiles')
@@ -81,16 +90,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const { data: profileData, error: profileError } = profileResult;
 
     if (profileError) {
-      // After retry, "Lock was stolen" is still transient — suppress Sentry to avoid noise.
-      if (profileError.message?.includes('Lock was stolen')) return;
+      // Lock contention is transient — already retried once above; suppress Sentry noise.
+      if (isLockContention(profileError.message)) return;
       console.error('[auth-context] Failed to fetch profile:', profileError.message);
-      // "Lock was stolen" is transient navigator.locks contention — already retried once, skip Sentry noise
-      if (!profileError.message?.includes('Lock was stolen')) {
-        Sentry.captureMessage(`Profile fetch failed: ${profileError.message}`, {
-          level: 'warning',
-          tags: { context: 'auth-profile-fetch' },
-        });
-      }
+      Sentry.captureMessage(`Profile fetch failed: ${profileError.message}`, {
+        level: 'warning',
+        tags: { context: 'auth-profile-fetch' },
+      });
       return;
     }
 
@@ -131,7 +137,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .maybeSingle();
 
     // Same lock contention guard for the subscription query
-    if (subResult.error?.message?.includes('Lock was stolen')) {
+    if (isLockContention(subResult.error?.message)) {
       await new Promise((r) => setTimeout(r, 100));
       subResult = await supabase
         .from('subscriptions')
@@ -147,7 +153,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (subError) {
       // Suppress Sentry for lock contention — transient, self-heals on next auth state change
-      if (subError.message?.includes('Lock was stolen')) { setSubscription(null); return; }
+      if (isLockContention(subError.message)) { setSubscription(null); return; }
       console.error('[auth-context] Failed to fetch subscription:', subError.message);
       Sentry.captureMessage(`Subscription fetch failed: ${subError.message}`, {
         level: 'warning',
@@ -212,10 +218,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const result = await supabase.auth.getSession();
         initialSession = result.data.session;
       } catch (err) {
-        // "Lock was stolen by another request" is a transient Supabase SSR
-        // error from navigator.locks contention across tabs/concurrent requests.
-        // The token refresh still succeeds via the winning request -- retry once.
-        if (err instanceof Error && err.message.includes('Lock was stolen')) {
+        // Lock contention is a transient cross-tab race from navigator.locks.
+        // The token refresh still succeeds via the winning request — retry once.
+        if (err instanceof Error && isLockContention(err.message)) {
           await new Promise((r) => setTimeout(r, 100));
           const retry = await supabase.auth.getSession();
           initialSession = retry.data.session;


### PR DESCRIPTION
## Summary

- Adds `isLockContention()` helper covering both Supabase lock error variants: `"Lock was stolen"` (older GoTrue) and `"Lock broken by another request with the 'steal' option."` (Chrome 116+ / newer GoTrue)
- Applies the helper to all four guard sites in `auth-context.tsx` (profile fetch retry, profile error suppress, sub fetch retry, sub error suppress, `initSession` catch)
- Adds regression test for the steal-option variant to prevent future regressions

Fixes JAVASCRIPT-NEXTJS-2M (10 events) + JAVASCRIPT-NEXTJS-5M (5 events) in Sentry.

## Root Cause

The previous check `includes("Lock was stolen")` did not match the newer error string `"Lock broken by another request with the 'steal' option."`, so the error bypassed the retry logic and was reported to Sentry as a real failure.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes (0 warnings)
- [x] `npm test` passes — 2516 tests across 168 files including new AIR-1763 regression test
- [ ] Vercel preview deploy verified by Demian

🤖 Generated with [Claude Code](https://claude.com/claude-code)