### PR TITLE
fix(stripe-webhook): use console.error for deferred event log to flow to Sentry

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -573,6 +573,7 @@ export async function POST(request: NextRequest) {
   // the outbound Stripe API call (checkout.session.completed) and DB writes
   // from exceeding the function timeout under latency spikes (JAVASCRIPT-NEXTJS-56).
   after(async () => {
+    console.error('[stripe-webhook] Processing deferred event:', event.id, event.type);
     try {
       await processStripeEvent(stripe, supabase, event);
     } catch (err) {


### PR DESCRIPTION
## Summary

- Adds `console.error` logging at the start of the `after()` block in `app/api/webhooks/stripe/route.ts` so deferred Stripe event processing is visible in Sentry
- `console.log` does not flow to Sentry per CLAUDE.md conventions; `console.error` does
- 1 file changed, 1 line inserted — standalone fix, no bundled concerns

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` — 2515/2515 tests pass
- [x] `npm run build` passes
- [x] CTO sign-off: PASS ([AIR-2381](/AIR/issues/AIR-2381))

🤖 Generated with [Claude Code](https://claude.com/claude-code)