### PR TITLE
fix(perf): nights routes — maxDuration + batched upsert + lean list query

### DIFF
--- a/__tests__/nights-route.test.ts
+++ b/__tests__/nights-route.test.ts
@@ -25,21 +25,18 @@ const mockGetUser = vi.fn();
 
 // Mutable select chain
 let mockSelectResult: { data: unknown; error: null | { message: string } } = { data: [], error: null };
-const mockOrder = vi.fn(() => ({
-  gte: vi.fn(() => Promise.resolve(mockSelectResult)),
-  then: (resolve: (v: typeof mockSelectResult) => unknown) => Promise.resolve(mockSelectResult).then(resolve),
-  // Make the query itself thenable so .gte() is optional
-  ...{ [Symbol.for('thenable')]: true },
-}));
-// We need the query to be awaitable directly when .gte() is not called
-const mockQueryChain = {
-  gte: vi.fn(() => Promise.resolve(mockSelectResult)),
-  order: mockOrder,
-  // Awaitable without .gte() — Supabase builder is a thenable
-  then: (resolve: (v: typeof mockSelectResult) => unknown) =>
-    Promise.resolve(mockSelectResult).then(resolve),
-};
-mockOrder.mockReturnValue(mockQueryChain);
+// The Supabase builder is a thenable that also exposes chainable filter/modifier
+// methods (.gte, .limit). Each method returns the same chain so the order of
+// .gte()/.limit() calls doesn't matter, and awaiting the chain resolves the result.
+const mockQueryChain: Record<string, unknown> = {};
+const mockGte = vi.fn(() => mockQueryChain);
+const mockLimit = vi.fn(() => mockQueryChain);
+const mockOrder = vi.fn(() => mockQueryChain);
+mockQueryChain.gte = mockGte;
+mockQueryChain.limit = mockLimit;
+mockQueryChain.order = mockOrder;
+mockQueryChain.then = (resolve: (v: typeof mockSelectResult) => unknown) =>
+  Promise.resolve(mockSelectResult).then(resolve);
 
 const mockEq = vi.fn(() => ({ order: mockOrder }));
 const mockSelect = vi.fn(() => ({ eq: mockEq }));
@@ -97,7 +94,10 @@ describe('GET /api/nights', () => {
     mockFrom.mockReturnValue({ select: mockSelect });
     mockSelect.mockReturnValue({ eq: mockEq });
     mockEq.mockReturnValue({ order: mockOrder });
+    // clearAllMocks wipes implementations; restore the chainable returns.
     mockOrder.mockReturnValue(mockQueryChain);
+    mockGte.mockReturnValue(mockQueryChain);
+    mockLimit.mockReturnValue(mockQueryChain);
   });
 
   it('returns 401 when unauthenticated', async () => {
@@ -179,28 +179,31 @@ describe('GET /api/nights', () => {
     const rows = [makeNightRow('2024-03-15')];
     mockSelectResult = { data: rows, error: null };
 
-    const gteSpy = vi.fn(() => Promise.resolve(mockSelectResult));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockOrder.mockReturnValueOnce({ gte: gteSpy, then: mockQueryChain.then } as any);
-
     const { GET } = await import('@/app/api/nights/route');
     await GET(makeRequest({ since: '2024-03-01' }));
 
-    expect(gteSpy).toHaveBeenCalledWith('night_date', '2024-03-01');
+    expect(mockGte).toHaveBeenCalledWith('night_date', '2024-03-01');
   });
 
   it('does not apply since filter when param is absent', async () => {
     mockSelectResult = { data: [], error: null };
 
-    const gteSpy = vi.fn(() => Promise.resolve(mockSelectResult));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockOrder.mockReturnValueOnce({ gte: gteSpy, then: mockQueryChain.then } as any);
-
     const { GET } = await import('@/app/api/nights/route');
     await GET(makeRequest());
 
     // No since param → .gte() should not have been called
-    expect(gteSpy).not.toHaveBeenCalled();
+    expect(mockGte).not.toHaveBeenCalled();
+  });
+
+  it('caps the result set with a limit on every fetch', async () => {
+    mockSelectResult = { data: [], error: null };
+
+    const { GET } = await import('@/app/api/nights/route');
+    await GET(makeRequest());
+
+    // Payload is bounded server-side (MAX_NIGHTS_RETURNED) since the consumer
+    // needs the full analysis_data blob and cannot use a summary projection.
+    expect(mockLimit).toHaveBeenCalledWith(365);
   });
 
   it('returns 500 when database query fails', async () => {

--- a/__tests__/nights-sync-route.test.ts
+++ b/__tests__/nights-sync-route.test.ts
@@ -122,12 +122,16 @@ describe('POST /api/nights/sync', () => {
     expect(body.skipped).toBe(0);
 
     expect(mockFrom).toHaveBeenCalledWith('user_nights');
+    // Single batched upsert: rows passed as an array, not one call per row.
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
     expect(mockUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        user_id: 'user-uuid-1234',
-        night_date: '2024-03-10',
-        analysis_data: expect.any(Object),
-      }),
+      [
+        expect.objectContaining({
+          user_id: 'user-uuid-1234',
+          night_date: '2024-03-10',
+          analysis_data: expect.any(Object),
+        }),
+      ],
       { onConflict: 'user_id,night_date' }
     );
   });
@@ -141,8 +145,8 @@ describe('POST /api/nights/sync', () => {
     const { POST } = await import('@/app/api/nights/sync/route');
     await POST(makeRequest({ nights: [nightWithBulk] }));
 
-    const calls = mockUpsert.mock.calls as unknown as Array<[{ analysis_data: { ned: Record<string, unknown> } }]>;
-    const storedNed = (calls[0]?.[0])?.analysis_data.ned;
+    const calls = mockUpsert.mock.calls as unknown as Array<[Array<{ analysis_data: { ned: Record<string, unknown> } }>]>;
+    const storedNed = (calls[0]?.[0])?.[0]?.analysis_data.ned;
     expect(storedNed?.breaths).toBeUndefined();
     expect(storedNed?.reras).toBeUndefined();
     expect(storedNed?.nedMean).toBe(12);
@@ -157,13 +161,28 @@ describe('POST /api/nights/sync', () => {
     const { POST } = await import('@/app/api/nights/sync/route');
     await POST(makeRequest({ nights: [nightWithCsl] }));
 
-    const calls = mockUpsert.mock.calls as unknown as Array<[{ analysis_data: { csl: Record<string, unknown> } }]>;
-    const storedCsl = (calls[0]?.[0])?.analysis_data.csl;
+    const calls = mockUpsert.mock.calls as unknown as Array<[Array<{ analysis_data: { csl: Record<string, unknown> } }>]>;
+    const storedCsl = (calls[0]?.[0])?.[0]?.analysis_data.csl;
     expect((storedCsl?.episodes as unknown[]).length).toBe(0);
     expect(storedCsl?.score).toBe(0.08);
   });
 
-  it('counts skipped nights when upsert errors', async () => {
+  it('batches all nights into a single upsert call', async () => {
+    const nights = [makeNight('2024-03-12'), makeNight('2024-03-13'), makeNight('2024-03-14')];
+    const { POST } = await import('@/app/api/nights/sync/route');
+    const res = await POST(makeRequest({ nights }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { synced: number; skipped: number };
+    expect(body.synced).toBe(3);
+    expect(body.skipped).toBe(0);
+    // One round-trip for the whole batch, not one per row.
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const calls = mockUpsert.mock.calls as unknown as Array<[unknown[]]>;
+    expect(calls[0]?.[0]).toHaveLength(3);
+  });
+
+  it('fails the whole batch atomically (500) when upsert errors — no silent partial loss', async () => {
     const supabaseError = { message: 'db error', code: '23505', details: '', hint: '' };
     mockUpsert.mockResolvedValue({ error: supabaseError as unknown as null });
 
@@ -171,9 +190,10 @@ describe('POST /api/nights/sync', () => {
     const { POST } = await import('@/app/api/nights/sync/route');
     const res = await POST(makeRequest({ nights }));
 
-    expect(res.status).toBe(200);
-    const body = await res.json() as { synced: number; skipped: number };
-    expect(body.synced).toBe(0);
-    expect(body.skipped).toBe(2);
+    // Atomic failure: the client retries the whole batch rather than getting a
+    // 200 that lies about what persisted.
+    expect(res.status).toBe(500);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('Failed to sync nights');
   });
 });

--- a/app/api/nights/route.ts
+++ b/app/api/nights/route.ts
@@ -4,8 +4,21 @@ import * as Sentry from '@sentry/nextjs';
 import { getSupabaseServer } from '@/lib/supabase/server';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 
+// Allow up to 30s: a full-history hydration for a champion-tier user can return
+// hundreds of analysis_data rows. The Vercel default (10s) was killing the function
+// mid-response on large accounts, producing truncated/aborted payloads.
+export const maxDuration = 30;
+
 // 120 fetches/hour per user — generous for page loads and background refreshes
 const rateLimiter = new RateLimiter({ windowMs: 3_600_000, max: 120 });
+
+// Hard cap on rows returned per fetch. The dashboard consumer (app/analyze/page.tsx)
+// needs the full analysis_data blob — it hydrates the restore/merge path and every
+// chart reads deep NightResult fields — so we cannot project to summary columns.
+// Instead we bound the worst-case payload: 365 most-recent nights covers a full year,
+// far exceeding the supporter (90d) and community (14d) windows, and is a sane ceiling
+// for the unbounded champion window. Ordered night_date DESC, so the newest are kept.
+const MAX_NIGHTS_RETURNED = 365;
 
 const querySchema = z.object({
   since: z
@@ -49,6 +62,10 @@ export async function GET(request: NextRequest) {
     if (parsed.data.since) {
       query = query.gte('night_date', parsed.data.since);
     }
+
+    // Bound the payload (see MAX_NIGHTS_RETURNED). Applied after order DESC, so the
+    // most recent nights are always returned.
+    query = query.limit(MAX_NIGHTS_RETURNED);
 
     const { data, error: queryError } = await query;
 

--- a/app/api/nights/sync/route.ts
+++ b/app/api/nights/sync/route.ts
@@ -5,6 +5,11 @@ import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import { validateOrigin } from '@/lib/csrf';
 
+// Allow up to 30s. Previously there was no maxDuration, so the Vercel default (10s)
+// could kill the function mid-loop, returning truncated synced/skipped counts that
+// lied to the client about what actually persisted.
+export const maxDuration = 30;
+
 // ~1000 nights/hour per user
 const rateLimiter = new RateLimiter({ windowMs: 3_600_000, max: 1000 });
 
@@ -84,29 +89,40 @@ export async function POST(request: NextRequest) {
     // Strip bulk data server-side as defence-in-depth
     const nights = parsed.data.nights.map(stripBulkData);
 
-    // Upsert each night — idempotent on (user_id, night_date)
-    let synced = 0;
-    let skipped = 0;
+    // Build all rows up front and validate before touching the DB. A row is only
+    // valid if it carries a non-empty night_date (the conflict key); reject the whole
+    // batch otherwise rather than silently dropping rows.
+    const rows = nights.map((night) => ({
+      user_id: user.id,
+      night_date: night.dateStr,
+      analysis_data: night,
+    }));
 
-    for (const night of nights) {
-      const nightDate = night.dateStr;
-      const { error } = await serviceRole
-        .from('user_nights')
-        .upsert(
-          { user_id: user.id, night_date: nightDate, analysis_data: night },
-          { onConflict: 'user_id,night_date' }
-        );
-
-      if (error) {
-        Sentry.captureException(error, {
-          tags: { route: 'nights/sync', step: 'upsert' },
-          extra: { nightDate, userId: user.id.slice(0, 8) },
-        });
-        skipped++;
-      } else {
-        synced++;
-      }
+    const invalid = rows.find(
+      (row) => typeof row.night_date !== 'string' || row.night_date.length === 0
+    );
+    if (invalid) {
+      console.error('[nights/sync] 400 row missing night_date');
+      return NextResponse.json({ error: 'Each night requires a dateStr' }, { status: 400 });
     }
+
+    // Single batched upsert — idempotent on (user_id, night_date), atomic for the batch.
+    // On DB error we fail the whole request (500) instead of returning 200 with a
+    // partial/silent loss, so the client's retry covers every row it sent.
+    const { error } = await serviceRole
+      .from('user_nights')
+      .upsert(rows, { onConflict: 'user_id,night_date' });
+
+    if (error) {
+      Sentry.captureException(error, {
+        tags: { route: 'nights/sync', step: 'upsert' },
+        extra: { count: rows.length, userId: user.id.slice(0, 8) },
+      });
+      return NextResponse.json({ error: 'Failed to sync nights' }, { status: 500 });
+    }
+
+    const synced = rows.length;
+    const skipped = 0;
 
     // Anonymised user ID in logs (first 8 chars of UUID)
     const anonymisedId = user.id.slice(0, 8);


### PR DESCRIPTION
## Problem
Three verified roots in the nights routes (no band-aid `Promise.race` timeouts, per #894/#893 review):

- **D2** No `export const maxDuration` on either nights route. The Vercel default (10s) killed the function mid-work, so sync returned `synced`/`skipped` counts that lied about what persisted, and large GETs got truncated.
- **D3** `nights/sync` did a sequential per-row upsert loop (up to 50 round-trips), and on a per-row DB error returned **200** with a silent `skipped++` (partial loss the client could not detect).
- **D4** `nights` GET pulled the full per-night `analysis_data` JSONB for **every** row with no bound — multi-MB payload bloat on every dashboard load.

## Changes
- **maxDuration = 30** on `GET /api/nights` and `POST /api/nights/sync`.
- **Batched upsert (D3):** rows are built and validated (non-empty `night_date`) up front, then written in a single `.upsert(rows, { onConflict: 'user_id,night_date' })`. On DB error the whole batch fails atomically with **500** — no more 200-with-silent-loss. Response shape `{ synced, skipped }` is preserved (`skipped` is now always 0; the client already treats a non-OK as a full-batch retry).
- **Bounded GET (D4):** I traced the only consumer — `fetchNightsFromCloud` (`lib/storage/nights-sync.ts`) → `app/analyze/page.tsx`, which merges the result into `persistedData.nights` and renders it as the full dashboard `NightResult[]`. Every chart reads deep fields and the client does its own tier windowing + `hiddenNightCount` over the **whole** set, so a summary projection would break the dashboard. Per the task's fallback, I kept the full `analysis_data` select and added `.limit(365)` after the DESC order to cap the worst-case payload. 365 nights exceeds the supporter (90d) and community (14d) windows and is a sane ceiling for the unbounded champion window; newest nights are always returned.

## Explicitly NOT done
- **No composite index** — `unique(user_id, night_date)` already exists, so it was redundant.
- **No DB migration** — the batched upsert and limit need no schema change.
- **No `Promise.race` 8s timeouts** (the #894/#893 band-aids).

## Verification
- `npx tsc --noEmit` clean (also confirms the GET/sync response shapes still satisfy the `NightResult[]` consumers).
- `npx eslint` clean on all 4 changed files.
- `npx vitest run` on `nights-route`, `nights-sync-route`, `nights-sync` — **30/30 pass**. Test updates: the sync route's "skipped on error" test now asserts atomic 500; field assertions updated for the batched-array upsert; added a single-batch-call test and a GET `.limit(365)` test.

Files changed: `app/api/nights/route.ts`, `app/api/nights/sync/route.ts`, and their two `__tests__` specs. No `lib/parsers/`, `lib/analyzers/`, or `workers/` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)