### PR TITLE
docs(ops): add Discord webhook URLs to credential inventory

### DIFF
--- a/docs/ops/credentials.md
+++ b/docs/ops/credentials.md
@@ -10,9 +10,15 @@ Update this file whenever a credential is rotated.
 |------|-------|-----------|---------|--------------|-------------------|--------|
 | `SENTRY_AUTH_TOKEN` | CTO / Board | Vercel env var `SENTRY_AUTH_TOKEN` | 90 days | 2026-04-22† | 2026-07-21 | active |
 | `GITHUB_PAT` (airwaylab-dev) | Board (Demian) | Cortis `.netrc` / git remote URL | 90 days | 2026-04-20† | 2026-07-12 | active |
+| `DISCORD_REVENUE_WEBHOOK_URL` | Board (Demian) | Vercel env var | as needed | unknown | — | verify urgently |
+| `DISCORD_OPS_WEBHOOK_URL` | Board (Demian) | Vercel env var | as needed | unknown | — | untracked |
+| `DISCORD_WEBHOOK_CRITICAL` | Board (Demian) | Vercel env var | as needed | unknown | — | untracked |
+| `DISCORD_USER_SIGNALS_WEBHOOK_URL` | Board (Demian) | Vercel env var | as needed | unknown | — | untracked |
+| `DISCORD_PLATFORM_HEALTH_WEBHOOK_URL` | Board (Demian) | Vercel env var | as needed | unknown | — | untracked |
 
 †Estimated from [AIR-927](/AIR/issues/AIR-927) fix date — verify actual expiry in Sentry dashboard and update this row.
 ‡Expiry confirmed via live `GET /rate_limit` header check on 2026-05-11 (`github-authentication-token-expiration: 2026-07-12 14:33:16 UTC`). Doc was previously stale (showed EXPIRED). Updated by [AIR-1358](/AIR/issues/AIR-1358) health check.
+§Discord webhook URLs have no built-in expiry but are permanently invalidated when the target channel or webhook is deleted in Discord. Status "verify urgently" reflects the regression found in [AIR-2385](/AIR/issues/AIR-2385) / [AIR-2389](/AIR/issues/AIR-2389) (2026-06-02): subscription revenue alerts stopped posting to Discord, root cause traced to DISCORD_REVENUE_WEBHOOK_URL missing or pointing to a deleted webhook. Demian must verify in Vercel dashboard and regenerate from Discord server settings if needed.
 
 ---
 
@@ -52,6 +58,35 @@ assigned to the CTO. The CTO agent picks up the issue and:
    - Assignee: CTO (to triage/escalate to board as needed)
    - Links to rotation instructions in this document
 3. Marks the execution issue `done` with a summary
+
+### Discord Webhook URLs
+
+Discord webhook URLs do not expire on a schedule but are permanently invalidated when the Discord channel or webhook is deleted. There is no API to check validity without sending a test message.
+
+**How to verify a webhook URL:**
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"content":"[health check — ignore]"}' \
+  "$DISCORD_REVENUE_WEBHOOK_URL"
+# 204 = valid, 404/410 = deleted/invalid
+```
+
+**How to regenerate:**
+1. Discord server → Server Settings → Integrations → Webhooks
+2. Find the webhook for the relevant channel (or create new)
+3. Copy the webhook URL
+4. Update the corresponding Vercel env var (Production + Preview + Development)
+5. Update `Last Rotated` in the table above
+
+**Channel → env var mapping:**
+| Channel | Env var |
+|---------|---------|
+| `#revenue-alerts` | `DISCORD_REVENUE_WEBHOOK_URL` |
+| `#ops-alerts` | `DISCORD_OPS_WEBHOOK_URL` |
+| `#critical` | `DISCORD_WEBHOOK_CRITICAL` |
+| `#user-signals` | `DISCORD_USER_SIGNALS_WEBHOOK_URL` |
+| `#platform-health` | `DISCORD_PLATFORM_HEALTH_WEBHOOK_URL` |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds 5 Discord admin webhook env vars to `docs/ops/credentials.md` with status, owner, and verification instructions
- Adds regeneration instructions and channel→env var mapping table
- Flags `DISCORD_REVENUE_WEBHOOK_URL` as needing urgent Demian verification (root cause of AIR-2385 subscription alert silence)

Discovered during AIR-2389 investigation: Discord webhook URLs were entirely untracked — no rotation log, no health check procedure, no regeneration docs. The credential gap is what makes AIR-2385 hard to diagnose.

## Test plan

- [ ] Docs-only change — no code, no tests needed
- [ ] Demian verifies `DISCORD_REVENUE_WEBHOOK_URL` in Vercel dashboard and tests with the curl snippet in the new instructions

## Pre-merge checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)