### PR TITLE
fix(webhook): await Discord revenue alerts inside after() to prevent race condition

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -330,7 +330,9 @@ async function processStripeEvent(
 
       void sendWelcomeNotification(supabase, userId, tier, interval);
       void syncDiscordForUser(supabase, userId, tier, event.id);
-      void sendAlert('revenue', '', [formatRevenueEmbed({
+      // Awaited so the after() callback stays alive until Discord receives the POST.
+      // sendAlert is fail-open (never throws, returns bool) so this is safe.
+      await sendAlert('revenue', '', [formatRevenueEmbed({
         event: 'new_subscription',
         tier,
         interval,
@@ -409,7 +411,7 @@ async function processStripeEvent(
         void syncDiscordForUser(supabase, userId!, tier, event.id);
       }
 
-      void sendAlert('revenue', '', [formatRevenueEmbed({
+      await sendAlert('revenue', '', [formatRevenueEmbed({
         event: 'tier_change',
         tier,
         interval: updatedInterval,
@@ -475,8 +477,8 @@ async function processStripeEvent(
         // Sync Discord role (revoke if downgraded to community)
         void syncDiscordForUser(supabase, userId, newTier, event.id);
 
-        // Discord #revenue alert (non-blocking)
-        void sendAlert('revenue', '', [formatRevenueEmbed({
+        // Discord #revenue alert
+        await sendAlert('revenue', '', [formatRevenueEmbed({
           event: 'cancellation',
           tier: newTier,
         })]);


### PR DESCRIPTION
## Summary

The `after()` refactor (commit `3741362`, 2026-05-21) moved all Stripe event processing into a deferred callback to prevent timeout errors. Inside `processStripeEvent()`, the three `sendAlert("revenue")` calls were `void` (unawaited). When `processStripeEvent` returned after DB writes, the `after()` callback resolved and the serverless function could terminate before the 3-second Discord HTTP fetch completed — silencing `#revenue` channel notifications.

Changing `void → await` keeps the `after()` callback alive until Discord receives the POST. `sendAlert` is fail-open (never throws, returns bool) so awaiting it is safe.

Fixes AIR-2394 / AIR-2385.

## Test plan

- [ ] `npm test` passes (all 2515 tests)
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run build` clean
- [ ] Next subscription event (new/tier_change/cancellation) appears in `#revenue` Discord

## Pre-merge checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)