### PR TITLE
fix(webhook): await sendAlert + notifications in after() to prevent drops (AIR-2394)

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -328,9 +328,9 @@ async function processStripeEvent(
         Sentry.captureException(err, { tags: { route: 'stripe-webhook', action: 'email-sequence-update' } });
       });
 
-      void sendWelcomeNotification(supabase, userId, tier, interval);
-      void syncDiscordForUser(supabase, userId, tier, event.id);
-      void sendAlert('revenue', '', [formatRevenueEmbed({
+      await sendWelcomeNotification(supabase, userId, tier, interval);
+      await syncDiscordForUser(supabase, userId, tier, event.id);
+      await sendAlert('revenue', '', [formatRevenueEmbed({
         event: 'new_subscription',
         tier,
         interval,
@@ -406,10 +406,10 @@ async function processStripeEvent(
       });
 
       if (shouldUpdateProfile) {
-        void syncDiscordForUser(supabase, userId!, tier, event.id);
+        await syncDiscordForUser(supabase, userId!, tier, event.id);
       }
 
-      void sendAlert('revenue', '', [formatRevenueEmbed({
+      await sendAlert('revenue', '', [formatRevenueEmbed({
         event: 'tier_change',
         tier,
         interval: updatedInterval,
@@ -467,16 +467,16 @@ async function processStripeEvent(
         }
 
         // Send cancellation email (non-blocking)
-        void sendCancellationNotification(supabase, userId);
+        await sendCancellationNotification(supabase, userId);
 
         // Schedule win-back email 7 days from now for opted-in users (non-blocking)
         void scheduleWinBackForUser(supabase, userId);
 
         // Sync Discord role (revoke if downgraded to community)
-        void syncDiscordForUser(supabase, userId, newTier, event.id);
+        await syncDiscordForUser(supabase, userId, newTier, event.id);
 
-        // Discord #revenue alert (non-blocking)
-        void sendAlert('revenue', '', [formatRevenueEmbed({
+        // Discord #revenue alert
+        await sendAlert('revenue', '', [formatRevenueEmbed({
           event: 'cancellation',
           tier: newTier,
         })]);
@@ -510,8 +510,8 @@ async function processStripeEvent(
           stripeSubscriptionId: subscriptionId,
         });
 
-        // Critical alert: Discord #critical + email to ops (non-blocking, fire-and-forget)
-        void alertStripePaymentFailed();
+        // Critical alert: Discord #critical + email to ops
+        await alertStripePaymentFailed();
       }
 
       break;


### PR DESCRIPTION
## Summary

`void sendAlert()` and other async calls inside `processStripeEvent` were fire-and-forget. Because `after()` only waits for the top-level `await processStripeEvent(...)`, these in-flight fetches could be killed when the serverless function terminated — silently dropping Discord revenue alerts and user emails.

**Changed to `await`:**
- `sendAlert('revenue', ...)` × 3 — new_subscription, tier_change, cancellation
- `alertStripePaymentFailed()` — critical ops alert
- `sendWelcomeNotification()` — welcome email on new subscription
- `sendCancellationNotification()` — confirmation email on cancellation
- `syncDiscordForUser()` × 3 — role sync on all subscription events

`scheduleWinBackForUser()` intentionally stays `void` (schedules a future sequence, non-blocking).

Fixes AIR-2394 / root cause of AIR-2385.

## Test plan

- [ ] `npm test` passes (all 2520 tests, stripe-webhook.test.ts: 46 tests)
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run build` clean
- [ ] New subscription on Vercel preview → Discord #revenue-alerts shows the embed

## Pre-merge checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)