### PR TITLE
fix(webhook): maxDuration 30→60 + Stripe SDK timeout 20s (AIR-2368)

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -9,7 +9,9 @@ import { welcomeEmail, cancellationEmail } from '@/lib/email/transactional';
 import { isDiscordConfigured, syncRole, searchGuildMember } from '@/lib/discord';
 import { sendAlert, formatRevenueEmbed, alertStripePaymentFailed } from '@/lib/discord-webhook';
 
-export const maxDuration = 30;
+// 60s: stripe.subscriptions.retrieve can take 20s under load; after() processing
+// (DB writes + Discord + email) needs the remaining headroom (JAVASCRIPT-NEXTJS-56).
+export const maxDuration = 60;
 
 const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
@@ -17,7 +19,9 @@ const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 let _stripe: Stripe | null = null;
 function getStripe(): Stripe {
   if (!_stripe) {
-    _stripe = new Stripe(stripeSecretKey!, { apiVersion: '2026-02-25.clover' });
+    // 20s SDK timeout — caps the Stripe API call well within maxDuration,
+    // leaving headroom for DB writes and after() notifications.
+    _stripe = new Stripe(stripeSecretKey!, { apiVersion: '2026-02-25.clover', timeout: 20_000 });
   }
   return _stripe;
 }


### PR DESCRIPTION
## Summary

**Root cause of JAVASCRIPT-NEXTJS-56 regression (2026-06-01):** The Stripe SDK had no explicit timeout (default 80s) on a function with `maxDuration=30`. A single slow `stripe.subscriptions.retrieve()` call could exhaust the entire function budget before `processStripeEvent` could return.

**Fix (mirrors `app/api/ai-insights/route.ts` pattern):**
- `maxDuration` 30 → 60: provides enough budget for Stripe API + DB writes + Discord + email inside `after()`
- Stripe client `timeout: 20_000` (20s): caps the API call, leaving 40s for the rest of `processStripeEvent`

## Budget breakdown (worst-case p99)

| Operation | Time |
|-----------|------|
| `stripe.subscriptions.retrieve` | ≤ 20s (now capped) |
| DB operations (supabase) | ~5s |
| `sendWelcomeNotification` (Resend) | ~3s |
| `syncDiscordForUser` (Discord API) | ~3s |
| `sendAlert` × 3 (Discord webhook) | ~9s (3s each, AbortSignal.timeout) |
| **Total worst case** | ~40s → within 60s |

Previous `maxDuration=30` gave only 30s total; a 25s Stripe API response alone exceeded it.

## Test plan

- [ ] `npm test` passes (stripe-webhook.test.ts: 46 tests)
- [ ] `npx tsc --noEmit` clean
- [ ] No new JAVASCRIPT-NEXTJS-56 events in Sentry for 7 days after deploy
- [ ] Demian: verify Vercel plan supports 60s `maxDuration` (Pro plan: up to 300s)

## Pre-merge checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked (partial pass = no merge)
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)