### PR TITLE
fix(ci): claude-code-action v1 input migration (custom prompts were silently ignored)

### DIFF
--- a/.github/workflows/auto-fix-error.yml
+++ b/.github/workflows/auto-fix-error.yml
@@ -29,8 +29,10 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          BRANCH="fix/sentry-${ISSUE_NUMBER}"
-          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+          # v1 names the branch fix/sentry-issue-<n>-<timestamp>; dedup on that prefix.
+          # (Verify the exact format on the first real run; if it differs, the 5/day
+          # rate-limit below is still the hard bound.)
+          if git ls-remote --heads origin | grep -q "refs/heads/fix/sentry-issue-${ISSUE_NUMBER}-"; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -73,16 +75,37 @@ jobs:
               });
             }
 
+      # v1 takes prompt TEXT, not a path: load the file contents into a step output.
+      - name: Load fix prompt
+        if: |
+          steps.check-branch.outputs.exists == 'false' &&
+          steps.rate-limit.outputs.exceeded == 'false'
+        id: load-prompt
+        run: |
+          {
+            echo 'PROMPT<<CLAUDE_PROMPT_EOF'
+            cat .github/prompts/fix-sentry-error.md
+            echo 'CLAUDE_PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code
         if: |
           steps.check-branch.outputs.exists == 'false' &&
           steps.rate-limit.outputs.exceeded == 'false'
+        id: claude
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-opus-4-6
-          prompt_file: .github/prompts/fix-sentry-error.md
-          issue_number: ${{ github.event.issue.number }}
+          claude_args: "--model claude-opus-4-8"
+          branch_prefix: "fix/sentry-"
+          base_branch: ${{ github.event.repository.default_branch }}
+          # The action reads the triggering issue from the event; inline the body
+          # so the fix prompt has the Sentry error to work from.
+          prompt: |
+            Sentry issue #${{ github.event.issue.number }}:
+            ${{ github.event.issue.body }}
+
+            ${{ steps.load-prompt.outputs.PROMPT }}
 
       - name: Gate sensitive file changes
         if: |
@@ -91,9 +114,10 @@ jobs:
         id: file-gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          # Use the branch the action actually created (v1 outputs branch_name);
+          # the old hard-coded fix/sentry-<n> no longer matches v1's branch naming.
+          BRANCH: ${{ steps.claude.outputs.branch_name }}
         run: |
-          BRANCH="fix/sentry-${ISSUE_NUMBER}"
           PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null)
 
           if [ -z "$PR_NUMBER" ]; then

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,9 +34,21 @@ jobs:
         with:
           fetch-depth: 1
 
+      # v1 takes prompt TEXT, not a path: load the file contents into a step output.
+      - name: Load code-review prompt
+        id: prompt
+        run: |
+          {
+            echo 'PROMPT<<CLAUDE_PROMPT_EOF'
+            cat .github/prompts/code-review.md
+            echo 'CLAUDE_PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt_file: .github/prompts/code-review.md
-          review_on_pr: true
+          prompt: ${{ steps.prompt.outputs.PROMPT }}
+          claude_args: "--model claude-opus-4-8"
+          track_progress: true
+          use_sticky_comment: true


### PR DESCRIPTION
## What
Both Claude workflows passed inputs that `claude-code-action@v1` no longer defines, so our custom **MDR/clinical-aware** prompts were silently ignored and the action ran on its defaults — confirmed against the v1 `action.yml` (`prompt_file`, `model`, `issue_number`, `review_on_pr` are NOT valid v1 inputs).

## Changes
- **claude-code-review.yml** (runs on every PR): load `.github/prompts/code-review.md` into `$GITHUB_OUTPUT` via heredoc → `prompt:`; replace `review_on_pr` with `track_progress: true` + `use_sticky_comment: true`; model via `claude_args: --model claude-opus-4-8`.
- **auto-fix-error.yml**: same prompt-file→`prompt` migration for `fix-sentry-error.md` (+ inline the triggering issue body, which v1 reads from the event); `model`→`claude_args`; drop `issue_number`; **find the created PR via the action's `branch_name` output** instead of the hard-coded `fix/sentry-<n>` (v1 names branches `fix/sentry-issue-<n>-<ts>`); dedup updated to that prefix.

## Why it matters
For a medical product, the automated PR review + Sentry auto-fix were NOT applying the clinical/MDR guardrail prompts. This restores them.

## Verify on first runs
- The PR-review sticky comment appears on a test PR.
- The auto-fix branch format matches the `fix/sentry-issue-<n>-` dedup (noted inline); the 5/day rate-limit is the hard bound regardless.
- `claude-opus-4-8` is available on the account (bumped from the stale `claude-opus-4-6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)