### PR TITLE
fix(safety): guard EDF/analyzer against malformed input (b5) — input-validation only

### DIFF
--- a/__tests__/clinical-input-guards.test.ts
+++ b/__tests__/clinical-input-guards.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Clinical input-validation guards (b5)
+ *
+ * These tests cover the input-validation guards added to the PROTECTED
+ * parser/analyzer modules:
+ *   - lib/parsers/edf-parser.ts  (headerBytes / recordDuration / numSamples / samplingRate)
+ *   - lib/analyzers/wat-engine.ts (samplingRate entry guard)
+ *
+ * The guards are input-validation ONLY. The first describe block is a
+ * GOLDEN-OUTPUT REGRESSION: it parses a real, representative EDF night through
+ * all three engines and asserts the Glasgow / WAT / NED outputs are IDENTICAL
+ * to a captured baseline, proving the guards do not change results for any
+ * valid input. The remaining blocks prove malformed inputs are rejected with a
+ * clear error instead of being silently mis-decoded or hanging the worker.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { parseEDF, EDFValidationError } from '@/lib/parsers/edf-parser';
+import { computeGlasgowIndex } from '@/lib/analyzers/glasgow-index';
+import { computeWAT } from '@/lib/analyzers/wat-engine';
+import { computeNED } from '@/lib/analyzers/ned-engine';
+import type { EDFFile } from '@/lib/types';
+
+const FIXTURES = path.resolve(__dirname, 'fixtures/sd-card');
+
+function parseFixture(relativePath: string): EDFFile {
+  const buf = fs.readFileSync(path.join(FIXTURES, relativePath));
+  return parseEDF(
+    buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
+    relativePath
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// GOLDEN-OUTPUT REGRESSION
+//
+// Baseline captured from origin/main (commit 4f4fb65), BEFORE the guards were
+// added, by parsing the real fixture below and running all three engines.
+// If a guard ever alters a computed result for valid input, one of these exact
+// assertions will fail.
+// ──────────────────────────────────────────────────────────────────────────
+
+const GOLDEN_FIXTURE = 'DATALOG/20260309/20260310_000159_BRP.edf';
+
+const GOLDEN = {
+  samplingRate: 25,
+  flowLength: 676500,
+  glasgow: {
+    overall: 0.74,
+    skew: 0.09,
+    spike: 0.16,
+    flatTop: 0,
+    topHeavy: 0.01,
+    multiPeak: 0.02,
+    noPause: 0.06,
+    inspirRate: 0.01,
+    multiBreath: 0,
+    variableAmp: 0.39,
+  },
+  wat: {
+    flScore: 55.055737689664774,
+    regularityScore: 62.62244876774203,
+    periodicityIndex: 37.39747923621575,
+  },
+  // NED exposes large per-breath arrays; we pin the clinical scalar outputs.
+  nedScalars: {
+    breathCount: 6907,
+    nedMean: 9.79,
+    nedMedian: 5.38,
+    nedP95: 40,
+    nedClearFLPct: 6.6,
+    nedBorderlinePct: 19.76,
+    fiMean: 0.56,
+    fiFL85Pct: 0,
+    tpeakMean: 0.55,
+    mShapePct: 0.72,
+    reraIndex: 2.79,
+    reraCount: 21,
+    h1NedMean: 9.43,
+    h2NedMean: 10.14,
+    combinedFLPct: 6.6,
+    estimatedArousalIndex: 2.8,
+    hypopneaCount: 2,
+    hypopneaIndex: 0.27,
+    hypopneaSource: 'algorithm',
+    hypopneaMeanDropPct: 91.13,
+    hypopneaMeanDurationS: 12.48,
+    briefObstructionCount: 254,
+    briefObstructionIndex: 33.79,
+    amplitudeCvOverall: 31,
+    amplitudeCvMedianEpoch: 24.81,
+    unstableEpochPct: 49.45,
+  },
+} as const;
+
+describe('Golden-output regression — guards do not change valid results', () => {
+  it('parses the real fixture and reproduces the captured baseline exactly', () => {
+    const edf = parseFixture(GOLDEN_FIXTURE);
+
+    expect(edf.samplingRate).toBe(GOLDEN.samplingRate);
+    expect(edf.flowData.length).toBe(GOLDEN.flowLength);
+
+    const glasgow = computeGlasgowIndex(edf.flowData, edf.samplingRate);
+    expect(glasgow).toEqual(GOLDEN.glasgow);
+
+    const wat = computeWAT(edf.flowData, edf.samplingRate);
+    expect(wat).toEqual(GOLDEN.wat);
+
+    const ned = computeNED(edf.flowData, edf.samplingRate) as unknown as Record<
+      string,
+      unknown
+    >;
+    for (const [key, value] of Object.entries(GOLDEN.nedScalars)) {
+      expect(ned[key], `NED.${key}`).toEqual(value);
+    }
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Minimal valid EDF builder (single flow signal), used for the
+// malformed-input tests. Mirrors the builder in edf-parser-truncation.test.ts.
+// ──────────────────────────────────────────────────────────────────────────
+
+function buildEDFBuffer(opts: {
+  numDataRecords: number;
+  samplesPerRecord: number;
+  /** Override the headerBytes field written into the file (default: correct value). */
+  headerBytesOverride?: number;
+  /** Override the recordDuration field written into the file (default: '1'). */
+  recordDurationField?: string;
+  /** Override the samplesPerRecord field written into the signal header. */
+  samplesPerRecordField?: string;
+}): ArrayBuffer {
+  const { numDataRecords, samplesPerRecord } = opts;
+  const numSignals = 1;
+  const headerBytes = 256 + numSignals * 256;
+  const bytesPerRecord = samplesPerRecord * 2;
+  const dataBytes = numDataRecords * bytesPerRecord;
+  const totalSize = headerBytes + dataBytes;
+
+  const buffer = new ArrayBuffer(totalSize);
+  const view = new DataView(buffer);
+  const encoder = new TextEncoder();
+
+  function writeField(offset: number, length: number, value: string): void {
+    const padded = value.padEnd(length, ' ');
+    const bytes = encoder.encode(padded.slice(0, length));
+    new Uint8Array(buffer, offset, length).set(bytes);
+  }
+
+  // Fixed header (256 bytes)
+  writeField(0, 8, '0');
+  writeField(8, 80, '');
+  writeField(88, 80, '');
+  writeField(168, 8, '10.01.25');
+  writeField(176, 8, '22.30.00');
+  writeField(184, 8, String(opts.headerBytesOverride ?? headerBytes));
+  writeField(192, 44, '');
+  writeField(236, 8, String(numDataRecords));
+  writeField(244, 8, opts.recordDurationField ?? '1');
+  writeField(252, 4, String(numSignals));
+
+  // Per-signal header (1 signal)
+  let offset = 256;
+  writeField(offset, 16, 'Flow'); offset += numSignals * 16;
+  writeField(offset, 80, ''); offset += numSignals * 80;
+  writeField(offset, 8, 'L/min'); offset += numSignals * 8;
+  writeField(offset, 8, '-100'); offset += numSignals * 8;
+  writeField(offset, 8, '100'); offset += numSignals * 8;
+  writeField(offset, 8, '-32768'); offset += numSignals * 8;
+  writeField(offset, 8, '32767'); offset += numSignals * 8;
+  writeField(offset, 80, ''); offset += numSignals * 80;
+  writeField(offset, 8, opts.samplesPerRecordField ?? String(samplesPerRecord));
+  offset += numSignals * 8;
+  writeField(offset, 32, ''); offset += numSignals * 32;
+
+  // Data records
+  let dataPtr = headerBytes;
+  for (let rec = 0; rec < numDataRecords; rec++) {
+    for (let s = 0; s < samplesPerRecord; s++) {
+      const value = Math.round(10000 * Math.sin((2 * Math.PI * s) / samplesPerRecord));
+      view.setInt16(dataPtr, value, true);
+      dataPtr += 2;
+    }
+  }
+
+  return buffer;
+}
+
+describe('EDF parser — malformed input is rejected (input-validation guards)', () => {
+  it('parses a correctly-formed buffer (control)', () => {
+    const buffer = buildEDFBuffer({ numDataRecords: 10, samplesPerRecord: 25 });
+    const result = parseEDF(buffer, 'test/BRP.edf');
+    expect(result.flowData.length).toBe(10 * 25);
+    expect(result.samplingRate).toBe(25);
+  });
+
+  it('throws EDFValidationError when headerBytes is under-reported', () => {
+    // Correct value is 256 + 1*256 = 512; report 256 (drops the signal header).
+    const buffer = buildEDFBuffer({
+      numDataRecords: 10,
+      samplesPerRecord: 25,
+      headerBytesOverride: 256,
+    });
+    expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(EDFValidationError);
+    expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(/headerBytes=256/);
+  });
+
+  it('throws EDFValidationError when headerBytes does not match (over-reported)', () => {
+    const buffer = buildEDFBuffer({
+      numDataRecords: 10,
+      samplesPerRecord: 25,
+      headerBytesOverride: 1024,
+    });
+    expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(EDFValidationError);
+  });
+
+  it('throws EDFValidationError when recordDuration is zero', () => {
+    const buffer = buildEDFBuffer({
+      numDataRecords: 10,
+      samplesPerRecord: 25,
+      recordDurationField: '0',
+    });
+    expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(EDFValidationError);
+    expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(/recordDuration/);
+  });
+
+  it('throws EDFValidationError when recordDuration is non-numeric (NaN)', () => {
+    const buffer = buildEDFBuffer({
+      numDataRecords: 10,
+      samplesPerRecord: 25,
+      recordDurationField: 'abc',
+    });
+    expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(EDFValidationError);
+    expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(/recordDuration/);
+  });
+
+  it('throws EDFValidationError when flow numSamples is zero (zero sampling rate)', () => {
+    const buffer = buildEDFBuffer({
+      numDataRecords: 10,
+      samplesPerRecord: 25,
+      samplesPerRecordField: '0',
+    });
+    expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(EDFValidationError);
+    expect(() => parseEDF(buffer, 'test/BRP.edf')).toThrow(/numSamples/);
+  });
+});
+
+describe('WAT engine — samplingRate guard prevents worker hang', () => {
+  // A non-positive samplingRate makes stepSize = floor(5 * rate) = 0, so the
+  // minute-vent loop never advances → infinite loop / worker hang. The guard
+  // converts that into an immediate throw. Tests run with a finite timeout so a
+  // regression (re-introduced hang) fails instead of stalling the suite.
+  const flow = new Float32Array(10000).map((_, i) => 20 * Math.sin(i / 10));
+
+  it('throws on samplingRate = 0 (does not hang)', { timeout: 3000 }, () => {
+    expect(() => computeWAT(flow, 0)).toThrow(RangeError);
+    expect(() => computeWAT(flow, 0)).toThrow(/samplingRate/);
+  });
+
+  it('throws on negative samplingRate (does not hang)', { timeout: 3000 }, () => {
+    expect(() => computeWAT(flow, -25)).toThrow(RangeError);
+  });
+
+  it('throws on non-finite samplingRate (NaN)', { timeout: 3000 }, () => {
+    expect(() => computeWAT(flow, NaN)).toThrow(RangeError);
+  });
+
+  it('still computes normally for a valid samplingRate', () => {
+    const result = computeWAT(flow, 25);
+    expect(result.flScore).toBeGreaterThanOrEqual(0);
+    expect(result.flScore).toBeLessThanOrEqual(100);
+  });
+});

--- a/lib/analyzers/wat-engine.ts
+++ b/lib/analyzers/wat-engine.ts
@@ -8,8 +8,21 @@ import type { WATResults } from '../types';
 
 /**
  * Run the complete WAT analysis on flow data.
+ *
+ * Input-validation guard only: a non-finite or non-positive samplingRate makes
+ * stepSize = Math.floor(5 * samplingRate) evaluate to 0, so the minute-vent loop
+ * never advances and the worker hangs. The EDF parser already validates the
+ * sampling rate at its source (validate-once); this entry guard protects any
+ * direct caller of computeWAT. It does not alter the computed output for any
+ * valid sampling rate.
  */
 export function computeWAT(flowData: Float32Array, samplingRate: number): WATResults {
+  if (!Number.isFinite(samplingRate) || samplingRate <= 0) {
+    throw new RangeError(
+      `computeWAT: samplingRate must be a finite positive number, got ${samplingRate}.`
+    );
+  }
+
   const flScore = analyzeFlowLimitation(flowData, samplingRate);
   const minuteVent = calculateMinuteVent(flowData, samplingRate);
 

--- a/lib/parsers/edf-parser.ts
+++ b/lib/parsers/edf-parser.ts
@@ -6,6 +6,21 @@
 import type { EDFHeader, EDFSignal, EDFFile } from '../types';
 
 /**
+ * Thrown when an EDF file fails structural input validation (e.g. an
+ * under-reported header byte count, or a non-finite/non-positive record
+ * duration or sample count). These guards reject malformed files outright so
+ * header bytes are never silently decoded as flow samples, which would
+ * otherwise produce silently-wrong Glasgow/WAT/NED metrics. Input validation
+ * only: no analysis logic, threshold, or output for any valid file changes.
+ */
+export class EDFValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EDFValidationError';
+  }
+}
+
+/**
  * Parse an EDF file from an ArrayBuffer.
  * Returns header, signal metadata, flow data (Float32Array), optional pressure data,
  * optional resp event data (BiPAP trigger/cycle markers), sampling rate, duration,
@@ -16,6 +31,10 @@ export function parseEDF(buffer: ArrayBuffer, filePath: string): EDFFile {
   const decoder = new TextDecoder('ascii');
 
   // --- Fixed header (256 bytes) ---
+  // Raw recordDuration is validated below before the `|| 1` fallback is applied,
+  // so a genuinely malformed 0/NaN duration is rejected rather than silently
+  // becoming 1 (which would corrupt the derived sampling rate).
+  const rawRecordDuration = parseFloat(readField(buffer, decoder, 244, 8));
   const header: EDFHeader = {
     version: readField(buffer, decoder, 0, 8),
     patientId: readField(buffer, decoder, 8, 80),
@@ -25,9 +44,29 @@ export function parseEDF(buffer: ArrayBuffer, filePath: string): EDFFile {
     headerBytes: Math.max(0, parseInt(readField(buffer, decoder, 184, 8)) || 0),
     reserved: readField(buffer, decoder, 192, 44),
     numDataRecords: Math.max(0, parseInt(readField(buffer, decoder, 236, 8)) || 0),
-    recordDuration: parseFloat(readField(buffer, decoder, 244, 8)) || 1,
+    recordDuration: rawRecordDuration || 1,
     numSignals: Math.max(0, parseInt(readField(buffer, decoder, 252, 4)) || 0),
   };
+
+  // --- Input-validation guards (reject malformed files; never alter valid output) ---
+  // 1. headerBytes MUST equal the structural size 256 + numSignals*256. An
+  //    under-reported value shifts the data offset so fixed/signal header bytes
+  //    get decoded AS flow samples, silently corrupting Glasgow/WAT/NED.
+  const expectedHeaderBytes = 256 + header.numSignals * 256;
+  if (header.headerBytes !== expectedHeaderBytes) {
+    throw new EDFValidationError(
+      `Invalid EDF header: headerBytes=${header.headerBytes} does not match the expected ` +
+        `${expectedHeaderBytes} for ${header.numSignals} signal(s) (256 + numSignals*256). ` +
+        `File rejected to avoid decoding header bytes as flow samples.`
+    );
+  }
+  // 2. recordDuration MUST be finite and positive; it is the denominator of the
+  //    derived sampling rate (numSamples / recordDuration).
+  if (!Number.isFinite(rawRecordDuration) || rawRecordDuration <= 0) {
+    throw new EDFValidationError(
+      `Invalid EDF header: recordDuration=${rawRecordDuration} must be a finite positive number.`
+    );
+  }
 
   // --- Parse recording date ---
   const dateParts = header.startDate.split('.');
@@ -133,7 +172,27 @@ export function parseEDF(buffer: ArrayBuffer, filePath: string): EDFFile {
   });
 
   const flowSignal = signals[flowIdx]!;
+
+  // 3. The flow signal's per-record sample count MUST be finite and positive.
+  //    It drives the sampling rate and every downstream window/step size; a
+  //    zero/NaN value yields a 0/NaN sampling rate that hangs or NaN-poisons
+  //    the WAT/NED engines.
+  if (!Number.isFinite(flowSignal.numSamples) || flowSignal.numSamples <= 0) {
+    throw new EDFValidationError(
+      `Invalid EDF flow signal: numSamples=${flowSignal.numSamples} must be a finite positive number.`
+    );
+  }
+
   const samplingRate = flowSignal.numSamples / header.recordDuration;
+
+  // 4. The derived sampling rate MUST be finite and positive. Validate-once here
+  //    so every analyzer downstream (WAT stepSize, NED windows) can trust it.
+  if (!Number.isFinite(samplingRate) || samplingRate <= 0) {
+    throw new EDFValidationError(
+      `Invalid EDF sampling rate: ${samplingRate} (numSamples=${flowSignal.numSamples}, ` +
+        `recordDuration=${header.recordDuration}) must be finite and positive.`
+    );
+  }
 
   // --- Validate buffer size ---
   const samplesPerRecord = signals.reduce((sum, s) => sum + s.numSamples, 0);


### PR DESCRIPTION
## Summary

Adds **input-validation guards only** to the PROTECTED clinical parser/analyzer modules. No algorithm, threshold, or computed output for any **valid** input is changed — proven by a golden-output regression test.

Root causes (b5):
1. `lib/parsers/edf-parser.ts` did not validate `headerBytes` against `256 + numSignals*256`. An under-reported header shifts the data offset so header bytes get decoded **as flow samples** → silently-wrong Glasgow/WAT/NED.
2. `lib/analyzers/wat-engine.ts`: `stepSize = Math.floor(5 * samplingRate)` becomes `0` when `samplingRate <= 0`, so the minute-vent loop never advances → infinite loop / worker hang.

## Changes (guards only)

`lib/parsers/edf-parser.ts`
- New typed `EDFValidationError`.
- Reject when `headerBytes !== 256 + numSignals*256`.
- Reject non-finite/non-positive `recordDuration` (validated on the raw parsed value, before the `|| 1` fallback that would otherwise mask a bad `0`/`NaN`).
- Reject non-finite/non-positive flow `numSamples`.
- Reject non-finite/non-positive derived `samplingRate` — validate-once at the parser (earliest point) so all downstream analyzers can trust it.

`lib/analyzers/wat-engine.ts`
- `computeWAT` entry guard: throw `RangeError` on non-finite / `<= 0` `samplingRate` (protects any direct caller; prevents the worker hang).

## Tests — `__tests__/clinical-input-guards.test.ts`
- **Golden-output regression**: parses the real `DATALOG/20260309/20260310_000159_BRP.edf` fixture and asserts Glasgow / WAT / NED outputs are **identical** to a baseline captured from `origin/main` *before* the guards. Proves valid results are unchanged.
- **Malformed-input**: under-/over-reported `headerBytes`, zero/NaN `recordDuration`, zero `numSamples` → throw `EDFValidationError`.
- **Worker-hang**: `samplingRate` of `0` / negative / `NaN` → `computeWAT` throws (with finite test timeouts, so a re-introduced hang fails the suite).

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` parser + analyzer + integration + new tests — 56 passed (golden regression reproduces baseline exactly).

> Requires the `clinical-signoff` label (protected-module change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)