### PR TITLE
test: complete discord-webhook mock factories to stop cross-file contamination

### DIFF
--- a/__tests__/ai-insights-consent-gate.test.ts
+++ b/__tests__/ai-insights-consent-gate.test.ts
@@ -56,7 +56,20 @@ vi.mock('@/lib/email/sequences', () => ({
 
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: vi.fn().mockResolvedValue(undefined),
-  COLORS: { red: 0xff0000, amber: 0xffaa00 },
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }));
 
 const mockMessagesCreate = vi.fn();

--- a/__tests__/ai-insights-schema-validation.test.ts
+++ b/__tests__/ai-insights-schema-validation.test.ts
@@ -55,7 +55,20 @@ vi.mock('@/lib/email/sequences', () => ({
 
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: vi.fn().mockResolvedValue(undefined),
-  COLORS: { red: 0xff0000, amber: 0xffaa00 },
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }));
 
 const mockMessagesCreate = vi.fn();

--- a/__tests__/ai-insights-timeout-config.test.ts
+++ b/__tests__/ai-insights-timeout-config.test.ts
@@ -48,7 +48,20 @@ vi.mock('@/lib/email/sequences', () => ({
 
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: vi.fn().mockResolvedValue(undefined),
-  COLORS: { amber: 0xf59e0b, red: 0xff0000 },
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }));
 
 // Capture the constructor args passed to Anthropic

--- a/__tests__/device-diagnostic-dedup.test.ts
+++ b/__tests__/device-diagnostic-dedup.test.ts
@@ -18,6 +18,19 @@ let _sendAlertFn = vi.fn().mockResolvedValue(true)
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: (...args: unknown[]) => _sendAlertFn(...args),
   formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }))
 
 vi.mock('@/lib/supabase/server', () => ({

--- a/__tests__/device-diagnostic-timeout.test.ts
+++ b/__tests__/device-diagnostic-timeout.test.ts
@@ -28,6 +28,19 @@ vi.mock('@/lib/supabase/server', () => ({
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: vi.fn(() => Promise.resolve()),
   formatUserSignalEmbed: vi.fn(() => ({})),
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }));
 
 vi.mock('@/app/api/device-diagnostic/_dedup', () => ({

--- a/__tests__/discord-digest-crons.test.ts
+++ b/__tests__/discord-digest-crons.test.ts
@@ -15,7 +15,21 @@ vi.mock('@sentry/nextjs', () => ({
 }))
 
 vi.mock('@/lib/discord-webhook', () => ({
-  COLORS: { green: 0x10b981, red: 0xef4444, blue: 0x3b82f6, amber: 0xf59e0b },
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  sendAlert: vi.fn().mockResolvedValue(false),
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }))
 
 const mockFrom = vi.fn()

--- a/__tests__/discord-sync-cron.test.ts
+++ b/__tests__/discord-sync-cron.test.ts
@@ -28,7 +28,20 @@ vi.mock('@/lib/discord', () => ({
 const mockSendAlert = vi.fn();
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: (...args: unknown[]) => mockSendAlert(...args),
-  COLORS: { amber: 0xf59e0b },
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }));
 
 // Chainable Supabase mock ─────────────────────────────────────────

--- a/__tests__/stripe-webhook-phantom-user.test.ts
+++ b/__tests__/stripe-webhook-phantom-user.test.ts
@@ -53,6 +53,18 @@ vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: vi.fn().mockResolvedValue(undefined),
   formatRevenueEmbed: vi.fn().mockReturnValue({}),
   alertStripePaymentFailed: vi.fn().mockResolvedValue(undefined),
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }));
 
 const mockFrom = vi.fn();

--- a/__tests__/stripe-webhook.test.ts
+++ b/__tests__/stripe-webhook.test.ts
@@ -62,6 +62,19 @@ vi.mock('@/lib/discord', () => ({
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: vi.fn().mockResolvedValue(undefined),
   formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(false),
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }));
 
 // Mock Supabase — builder pattern that supports chaining

--- a/__tests__/subscription-drift-stripe-recovery.test.ts
+++ b/__tests__/subscription-drift-stripe-recovery.test.ts
@@ -26,7 +26,20 @@ vi.mock('@/lib/discord', () => ({
 const mockSendAlert = vi.fn();
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: (...args: unknown[]) => mockSendAlert(...args),
-  COLORS: { amber: 0xf59e0b },
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }));
 
 // Stripe mock — controlled per test via mockStripeSubsList

--- a/__tests__/subscription-drift.test.ts
+++ b/__tests__/subscription-drift.test.ts
@@ -30,7 +30,20 @@ vi.mock('@/lib/discord', () => ({
 const mockSendAlert = vi.fn();
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: (...args: unknown[]) => mockSendAlert(...args),
-  COLORS: { amber: 0xf59e0b },
+  COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
+  _budget: { date: '', count: 0 },
+  routeAlert: vi.fn().mockResolvedValue(false),
+  sendOpsAlert: vi.fn().mockResolvedValue(false),
+  sendCriticalAlert: vi.fn().mockResolvedValue(false),
+  alertCredentialExpiry: vi.fn().mockResolvedValue(false),
+  alertStripePaymentFailed: vi.fn().mockResolvedValue(false),
+  alertSecurityIncident: vi.fn().mockResolvedValue(false),
+  formatMonitorEmbed: vi.fn().mockReturnValue({}),
+  formatRevenueEmbed: vi.fn().mockReturnValue({}),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+  formatBroadcastEmbed: vi.fn().mockReturnValue({}),
+  formatGrowthEmbed: vi.fn().mockReturnValue({}),
 }));
 
 // Supabase mock — tracks insert calls


### PR DESCRIPTION
## Problem
The CI `Test` job (vitest run on a 2-core ubuntu runner, ~2 workers) is flaky. Several test files mock `@/lib/discord-webhook` with **incomplete** factories that omit exports the real module exposes (notably `alertStripePaymentFailed`, and in `discord-digest-crons` even `sendAlert`). When a worker is poisoned by an incomplete mock, unrelated suites that import the real module surface (e.g. via `app/api/ai-insights/route.ts`, which calls `sendAlert` + `COLORS`, or the stripe webhook route, which calls `alertStripePaymentFailed`) can throw. Vitest `retry:2` cannot fix contamination.

## Fix
Completed the mock factory in all 11 files that mock `@/lib/discord-webhook`, so each returns the module's full runtime export surface. Existing intentional bindings (local mock-fn wiring, `{}` return shapes, per-test spies) are preserved; every previously-missing export is added as `vi.fn()`. `COLORS` is normalised to all six real keys.

Full export surface now present in every factory:
`COLORS` (green/amber/red/blue/purple/teal), `_budget`, `routeAlert`, `sendAlert`, `sendOpsAlert`, `sendCriticalAlert`, `alertCredentialExpiry`, `alertStripePaymentFailed`, `alertSecurityIncident`, `formatMonitorEmbed`, `formatRevenueEmbed`, `formatUserSignalEmbed`, `formatEmailAlertEmbed`, `formatBroadcastEmbed`, `formatGrowthEmbed`.

### Files fixed (notably missing exports before)
| File | Notably missing before |
|---|---|
| `discord-digest-crons.test.ts` | `sendAlert` + all fns (only had `COLORS`) |
| `stripe-webhook.test.ts` | `alertStripePaymentFailed` + rest |
| `stripe-webhook-phantom-user.test.ts` | `COLORS` + rest |
| `subscription-drift.test.ts` | all fns except `sendAlert` |
| `subscription-drift-stripe-recovery.test.ts` | all fns except `sendAlert` |
| `discord-sync-cron.test.ts` | all fns except `sendAlert` |
| `device-diagnostic-dedup.test.ts` | all fns except `sendAlert`/`formatUserSignalEmbed` |
| `device-diagnostic-timeout.test.ts` | all fns except `sendAlert`/`formatUserSignalEmbed` |
| `ai-insights-timeout-config.test.ts` | all fns except `sendAlert` |
| `ai-insights-schema-validation.test.ts` | all fns except `sendAlert` |
| `ai-insights-consent-gate.test.ts` | all fns except `sendAlert` |

## Scope
- **Test files only.** No `lib/parsers/`, `lib/analyzers/`, `workers/`, or any production source changed.
- Timing-sensitive tests untouched (handled by existing `retry:2`). Change is strictly mock-completeness.
- Other partial mocks in these files (`@/lib/discord`, `@/lib/email/*`, `@/lib/rate-limit`, `@/lib/csrf`) were audited and left as-is: each supplies the symbols its route-under-test actually consumes, so they do not cause the documented contamination (avoided over-reach).

## Verification
- `npx vitest run --maxWorkers=2` over the 11 edited files + the real-module victim suites (`ai-insights-error-handling`, `ai-insights-profile-error`, `conversion-funnel`), run **5×**: **14 files / 193 tests pass every time**.
- Full suite, `CI=true npx vitest run --maxWorkers=2`: **174/175 files, 2623 tests pass**. The one failing file (`premium-ai-quality.test.ts`) is a **pre-existing, unrelated** failure — its own Supabase mock omits `ai_insights_consent`, so the route's consent gate 403s before the LLM. It fails identically on clean `origin/main` in isolation and does not mock discord-webhook, so it is out of scope here.
- `npx tsc --noEmit`: **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)