### PR TITLE
ci: exempt negated/descriptor uses from MDR prohibited-terms gate

### DIFF
--- a/.github/workflows/mdr-string-check.yml
+++ b/.github/workflows/mdr-string-check.yml
@@ -58,6 +58,27 @@ jobs:
           # still catching the bare medical words diagnose/diagnoses/diagnosis/diagnostic.
           PROHIBITED='rera detection|detects (respiratory|breathing) event|suggests (diagnosis|obstruction|apnea|condition|disorder)|effective treatment|improves outcomes|\bdiagnos(e|es|is|tic)\b|diagnostic tool|indicates? (apnea|obstruction|a problem)|may need adjustment'
 
+          # APPROVED-CONTEXT allowlist (case-insensitive extended regex).
+          # A line that matches PROHIBITED is EXONERATED only if it ALSO matches
+          # this allowlist AND does NOT match NEVER_EXEMPT below. This stops the
+          # gate false-flagging legitimate disclaimer/descriptor language:
+          #   - negations / disclaimers: "not a diagnosis", "does not provide
+          #     medical advice, diagnosis, or treatment", "is not a diagnostic test",
+          #     "for informational purposes", "not a substitute/replacement";
+          #   - standard clinical descriptors: "diagnostic AHI/test/study/sleep study",
+          #     and the canonical disclaimer collocation "diagnosis, or treatment" /
+          #     "diagnosis and treatment plan".
+          # See docs/mdr-prohibited-terms.md ("Approved-context exemptions").
+          ALLOWLIST='not a |not an |is not |does not (provide|constitute|offer)|no diagnos|without [^|]*diagnos|informational purposes|not a (medical|substitute|replacement)|diagnostic (ahi|test|study|sleep study)|diagnosis,? (and|or) treatment|diagnosis and treatment plan'
+
+          # NEVER_EXEMPT: prohibited claims with no legitimate disclaimer/descriptor
+          # form. A line matching any of these can NEVER be exonerated, even if it
+          # also matches ALLOWLIST. This keeps real MDR violations caught — most
+          # importantly "diagnostic tool" (claiming AirwayLab IS a diagnostic tool),
+          # so "AirwayLab is a diagnostic tool, not a substitute for a doctor" still
+          # fails. It is PROHIBITED minus only the exemptible bare \bdiagnos...\b word.
+          NEVER_EXEMPT='rera detection|detects (respiratory|breathing) event|suggests (diagnosis|obstruction|apnea|condition|disorder)|effective treatment|improves outcomes|diagnostic tool|indicates? (apnea|obstruction|a problem)|may need adjustment'
+
           TARGET_PATTERNS=(
             "^app/blog/posts/.*\.tsx$"
             "^lib/blog-posts\.ts$"
@@ -115,9 +136,16 @@ jobs:
                 CURRENT_LINE=$(( CURRENT_LINE + 1 ))
                 content="${diffline:1}"
                 if echo "$content" | grep -qiE "$PROHIBITED"; then
-                  matched=$(echo "$content" | grep -oiE "$PROHIBITED" | head -1)
-                  echo "::error file=${file},line=${CURRENT_LINE}::Prohibited term '${matched}' — see docs/mdr-prohibited-terms.md for approved replacements"
-                  VIOLATIONS=$(( VIOLATIONS + 1 ))
+                  # Exonerate the line only if it is approved-context (ALLOWLIST)
+                  # AND carries no hard-prohibited claim (NEVER_EXEMPT).
+                  if echo "$content" | grep -qiE "$ALLOWLIST" && ! echo "$content" | grep -qiE "$NEVER_EXEMPT"; then
+                    exonerated=$(echo "$content" | grep -oiE "$ALLOWLIST" | head -1)
+                    echo "::notice file=${file},line=${CURRENT_LINE}::Prohibited-term match exempted by approved context '${exonerated}' — see docs/mdr-prohibited-terms.md"
+                  else
+                    matched=$(echo "$content" | grep -oiE "$PROHIBITED" | head -1)
+                    echo "::error file=${file},line=${CURRENT_LINE}::Prohibited term '${matched}' — see docs/mdr-prohibited-terms.md for approved replacements"
+                    VIOLATIONS=$(( VIOLATIONS + 1 ))
+                  fi
                 fi
 
               else

--- a/docs/mdr-prohibited-terms.md
+++ b/docs/mdr-prohibited-terms.md
@@ -25,6 +25,43 @@ regulatory reclassification.
 | `indicates (apnea\|obstruction\|a problem)` | `metrics consistent with...` / `elevated metrics` |
 | `may need adjustment` | `patterns observed in your data` (defer changes to a clinician) |
 
+## Approved-context exemptions (allowlist)
+
+The gate scans each added line against the prohibited list, then **exonerates**
+that line if it also matches the approved-context allowlist **and** does not
+contain a hard-prohibited claim. This stops the gate false-flagging legitimate
+disclaimer and standard-descriptor language while still catching real claims.
+
+A flagged line is exonerated only when **both** hold:
+
+1. It matches an approved context (negation/disclaimer or standard descriptor), and
+2. It does **not** match a never-exempt claim.
+
+**Approved contexts (any one exonerates):**
+
+| Category | Patterns (case-insensitive) | Example that now passes |
+|---|---|---|
+| Negation / disclaimer | `not a ` / `not an ` / `is not ` / `does not (provide\|constitute\|offer)` / `no diagnos` / `without ...diagnos` / `informational purposes` / `not a (medical\|substitute\|replacement)` | "data-quality signal, **not a** diagnosis"; "**does not provide** medical advice, diagnosis, or treatment"; "**is not** a diagnostic test" |
+| Standard clinical descriptor | `diagnostic (ahi\|test\|study\|sleep study)` | "your **diagnostic AHI** from the lab"; "rather than a standalone **diagnostic test**" |
+| Disclaimer collocation | `diagnosis,? (and\|or) treatment` / `diagnosis and treatment plan` | "...substitute for clinical advice, **diagnosis, or treatment**"; "in the context of your **diagnosis and treatment plan**" |
+
+**Never exempt (always a violation, even inside an approved context):**
+
+These prohibited claims have no legitimate disclaimer/descriptor form, so the
+allowlist can never rescue them: `rera detection`, `detects respiratory/breathing
+event`, `suggests (diagnosis/obstruction/apnea/condition/disorder)`, `effective
+treatment`, `improves outcomes`, **`diagnostic tool`**, `indicates
+(apnea/obstruction/a problem)`, `may need adjustment`.
+
+Concretely: **"AirwayLab is a diagnostic tool, not a substitute for a doctor"
+still fails** — claiming AirwayLab IS a diagnostic tool is a real MDR Rule 11
+violation, and the trailing negation does not exempt it. The exemption only
+removes the bare descriptive word `diagnose`/`diagnosis`/`diagnostic` when it
+appears in disclaimer or standard-descriptor language.
+
+Exonerated lines emit a CI `::notice` (visible in the run log) rather than an
+`::error`, so the exemption stays auditable.
+
 ## Language rules
 
 - **Describe, never diagnose.** Say what the data shows, not what it means clinically.


### PR DESCRIPTION
## Problem

`.github/workflows/mdr-string-check.yml` scans each added/changed line against a prohibited medical-claim regex (including `\bdiagnos(e|es|is|tic)\b`, `diagnostic tool`, etc.) with **no notion of context**. It false-positives on legitimate language and blocks two PRs:

- **#903** (leak/epworth/oscar disclaimers): "data-quality signal, not a diagnosis", "does not provide medical advice, diagnosis, or treatment", "rather than a standalone diagnostic test", "in the context of your diagnosis and treatment plan".
- **#906** (`lib/blog-posts.ts`): "...as distinct from your **diagnostic AHI** measured during your pre-treatment sleep study".

These are disclaimers and standard clinical descriptors, not MDR Rule 11 claims.

## Change (allowlist-skip, prohibited list unchanged)

Adds an **approved-context allowlist** plus a **never-exempt guard** to the per-line scan. The prohibited list is **not weakened**. A flagged line is exonerated only if it matches the allowlist AND does not match `NEVER_EXEMPT`.

- **ALLOWLIST** (exonerates): negations/disclaimers (`not a `, `not an `, `is not `, `does not (provide|constitute|offer)`, `no diagnos`, `without ...diagnos`, `informational purposes`, `not a (medical|substitute|replacement)`) and standard descriptors (`diagnostic (ahi|test|study|sleep study)`, plus the disclaimer collocations `diagnosis, or treatment` / `diagnosis and treatment plan`).
- **NEVER_EXEMPT** (never exonerated): the prohibited list minus only the bare `\bdiagnos...\b` word. Most importantly, **`diagnostic tool` stays prohibited** — claiming AirwayLab IS a diagnostic tool is a real MDR violation, so "AirwayLab is a diagnostic tool, not a substitute for a doctor" still fails.
- Exonerated lines emit a CI `::notice` (auditable in the run log) instead of `::error`.

## Verification (real `git diff`, both directions)

Ran the **verbatim workflow scan logic** against real git diffs.

**Now PASS (exit 0)** — all six #903/#906 lines exonerated via `::notice`:
- "data-quality signal, **not a** diagnosis" → `not a `
- "**is not** a substitute for clinical advice, diagnosis, or" → `is not `
- "of your **diagnosis and treatment plan**" → `diagnosis and treatment plan`
- "does not provide medical advice, **diagnosis, or treatment**" → `diagnosis, or treatment`
- "rather than a standalone **diagnostic test**" → `diagnostic test`
- "your **diagnostic AHI** measured during..." → `diagnostic AHI`

**Still FAIL (exit 1)** — synthetic claims flagged via `::error`:
- "AirwayLab diagnoses sleep apnea"
- "our diagnostic tool detects apnea"
- "this is an effective treatment"
- "suggests obstruction"
- adversarial: "AirwayLab is a diagnostic tool, not a substitute for a doctor" (allowlist token present, blocked by NEVER_EXEMPT)
- adversarial: "this is an effective treatment, not a cure"

`actionlint` clean. Exemptions documented in `docs/mdr-prohibited-terms.md`.

> Regulated surface. Draft for review. Do not merge without compliance sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)