### PR TITLE
fix(stripe): guard webhook job-state schema drift

### DIFF
--- a/__tests__/stripe-webhook.test.ts
+++ b/__tests__/stripe-webhook.test.ts
@@ -343,6 +343,43 @@ describe('POST /api/webhooks/stripe', () => {
     expect(captureException).toHaveBeenCalled();
   });
 
+  // ---------- 4b. Schema drift: missing ST1 columns returns 503 before ack ----------
+  it('returns 503 before registering after() when stripe_events job-state columns are missing', async () => {
+    const { captureException } = await import('@sentry/nextjs');
+    const event = makeStripeEvent('checkout.session.completed', {});
+    mockWebhooksConstruct.mockReturnValue(event);
+
+    const schemaError = {
+      code: 'PGRST204',
+      message: "Could not find the 'status' column of 'stripe_events' in the schema cache",
+    };
+    const stripeEventsBuilder = createQueryBuilder({ data: null, error: schemaError });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'stripe_events') return stripeEventsBuilder;
+      return createQueryBuilder({ data: null, error: null });
+    });
+
+    const req = makeRequest('{}', { 'stripe-signature': 'sig_valid' });
+    const res = await callRoute(req);
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: 'Stripe webhook job-state schema is not applied',
+    });
+    expect(stripeEventsBuilder.insert).not.toHaveBeenCalled();
+    expect(afterCallbacks).toHaveLength(0);
+    expect(mockSubscriptionsRetrieve).not.toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalledWith(
+      schemaError,
+      expect.objectContaining({
+        tags: expect.objectContaining({ action: 'job-state-schema-check' }),
+        extra: expect.objectContaining({
+          requiredMigration: '057_stripe_events_job_state.sql',
+        }),
+      })
+    );
+  });
+
   // ---------- 5. checkout.session.completed: happy path ----------
   it('handles checkout.session.completed -- upserts subscription, updates profile, logs event', async () => {
     const checkoutSession = {
@@ -745,10 +782,10 @@ describe('POST /api/webhooks/stripe', () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === 'stripe_events') {
         stripeEventsCallCount++;
-        // The claim is now the claim_stripe_event RPC, not a from('stripe_events')
-        // call, so the stripe_events builder sees only: 1: insert(pending) ok,
-        // 2: update(failed) fails.
-        if (stripeEventsCallCount <= 1) {
+        // The claim is the claim_stripe_event RPC, not a from('stripe_events')
+        // call, so the builder sees: 1: schema guard ok, 2: insert(pending) ok,
+        // 3: update(failed) fails.
+        if (stripeEventsCallCount <= 2) {
           return createQueryBuilder({ data: null, error: null });
         }
         return createQueryBuilder({

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -37,6 +37,44 @@ function getStripe(): Stripe {
   return _stripe;
 }
 
+function isStripeEventsJobStateSchemaError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const err = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
+  const haystack = [err.message, err.details, err.hint]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ')
+    .toLowerCase();
+
+  return (
+    err.code === '42703' ||
+    err.code === 'PGRST204' ||
+    (
+      haystack.includes('stripe_events') &&
+      ['status', 'attempts', 'last_error', 'updated_at'].some((column) =>
+        haystack.includes(column)
+      ) &&
+      (haystack.includes('does not exist') || haystack.includes('could not find'))
+    )
+  );
+}
+
+async function ensureStripeEventsJobStateSchema(
+  supabase: SupabaseClient
+): Promise<{ ok: true } | { ok: false; error: unknown }> {
+  const { error } = await supabase
+    .from('stripe_events')
+    .select('status, attempts, last_error, updated_at')
+    .limit(0);
+
+  if (!error) return { ok: true };
+  if (isStripeEventsJobStateSchemaError(error)) return { ok: false, error };
+
+  // Let the existing insert/claim error handling decide retry semantics for
+  // transient database failures. This guard is only for migration drift.
+  return { ok: true };
+}
+
 /** Compute monthly recurring revenue in cents from a unit amount and interval. */
 function computeMrrCents(unitAmount: number, interval: string): number {
   if (interval === 'year') return Math.round(unitAmount / 12);
@@ -592,6 +630,26 @@ export async function POST(request: NextRequest) {
       },
     });
     return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  const schemaCheck = await ensureStripeEventsJobStateSchema(supabase);
+  if (!schemaCheck.ok) {
+    console.error('[stripe-webhook] stripe_events job-state schema missing:', schemaCheck.error);
+    Sentry.captureException(schemaCheck.error, {
+      level: 'error',
+      tags: {
+        route: 'stripe-webhook',
+        event_type: event.type,
+        action: 'job-state-schema-check',
+      },
+      extra: {
+        requiredMigration: '057_stripe_events_job_state.sql',
+      },
+    });
+    return NextResponse.json(
+      { error: 'Stripe webhook job-state schema is not applied' },
+      { status: 503 }
+    );
   }
 
   // Idempotency + job-state record (ST1). Insert the event as `pending`.


### PR DESCRIPTION
## Summary
- add a pre-ack `stripe_events` job-state schema guard for the Stripe webhook
- return a retryable 503 when migration 057 job-state columns are missing instead of registering post-response processing that cannot claim the event
- cover the Sentry-reported drift case with a regression test that proves no `after()` callback or business processing is registered

Fixes airwaylab-app/airwaylab-app#96.

## Why
The Sentry issue shows `runStripeJob` failing because `stripe_events.status` is missing. Since the current route registers processing in `after()`, a schema-missing claim can happen after the HTTP response has already been sent, risking a paid Stripe event being acknowledged without a reliable durable job state. This patch checks the required ST1 columns before inserting/acking, so Stripe retries while ops applies `057_stripe_events_job_state.sql`.

## Verification
- `npm test -- stripe-webhook.test.ts`
- `npm test -- subscription-drift-redrive.test.ts`
- `npx eslint app/api/webhooks/stripe/route.ts __tests__/stripe-webhook.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run build`

## Note
`npm ci` and the full pre-push suite run on local Node v23.7.0 while this repo declares Node 20.x. The full suite currently fails in unrelated `analytics-completeness.test.ts` and `premium-ai-quality.test.ts` cases; the touched Stripe webhook/redrive tests, ESLint, TypeScript, and production build are green.
