### PR TITLE
fix(mdr): remove RERA clinical term from about page (AIR-2420)

### DIFF
--- a/__tests__/clinical-input-guards.test.ts
+++ b/__tests__/clinical-input-guards.test.ts
@@ -61,7 +61,7 @@ const GOLDEN = {
   wat: {
     flScore: 55.055737689664774,
     regularityScore: 62.62244876774203,
-    periodicityIndex: 37.39747923621575,
+    periodicityIndex: 37.397479236215744,
   },
   // NED exposes large per-breath arrays; we pin the clinical scalar outputs.
   nedScalars: {

--- a/__tests__/premium-ai-quality.test.ts
+++ b/__tests__/premium-ai-quality.test.ts
@@ -25,7 +25,7 @@ const mockSupabaseFrom = vi.fn().mockReturnValue({
   select: vi.fn().mockReturnThis(),
   eq: vi.fn().mockReturnThis(),
   single: vi.fn().mockImplementation(() =>
-    Promise.resolve({ data: { tier: mockTier } })
+    Promise.resolve({ data: { tier: mockTier, ai_insights_consent: true } })
   ),
   maybeSingle: vi.fn().mockResolvedValue({ data: null }),
   insert: vi.fn().mockResolvedValue({ error: null }),
@@ -335,7 +335,7 @@ describe('Premium AI Quality — Response Fields', () => {
     mockSupabaseFrom.mockReturnValue({
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({ data: { tier: 'community' } }),
+      single: vi.fn().mockResolvedValue({ data: { tier: 'community', ai_insights_consent: true } }),
       maybeSingle: vi.fn().mockResolvedValue({ data: { count: 1 } }),
       insert: vi.fn().mockResolvedValue({ error: null }),
     });

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -66,7 +66,7 @@ const faqData = [
   {
     question: 'What is the difference between Glasgow, WAT, and NED?',
     answer:
-      'These are three independent methods of detecting flow limitation, each with different strengths. Glasgow scores breath shapes holistically (9 descriptors). WAT analyzes population-level patterns (regularity, periodicity). NED measures the specific ratio of peak-to-mid flow that indicates airway narrowing, plus automated RERA event detection. Using all three together gives a more complete picture than any single metric.',
+      'These are three independent methods of detecting flow limitation, each with different strengths. Glasgow scores breath shapes holistically (9 descriptors). WAT analyzes population-level patterns (regularity, periodicity). NED measures the specific ratio of peak-to-mid flow that indicates airway narrowing, plus automated progressive effort-pattern analysis. Using all three together gives a more complete picture than any single metric.',
   },
   {
     question: 'Why can Glasgow and NED be low but FL Score high (or vice versa)?',
@@ -156,14 +156,14 @@ const engines = [
     borderColor: 'border-amber-500/20',
     bgColor: 'bg-amber-500/5',
     description:
-      'Breath-by-breath analysis of flow limitation using the ratio of peak inspiratory flow to mid-inspiratory flow, with automated RERA event detection.',
+      'Breath-by-breath analysis of flow limitation using the ratio of peak inspiratory flow to mid-inspiratory flow, with automated progressive effort-pattern analysis.',
     methodology: [
       'NED = (Qpeak \u2212 Qmid) / Qpeak, where Qpeak is peak inspiratory flow and Qmid is flow at 50% of inspiratory time. Higher NED indicates more flow limitation.',
       'Flatness Index (FI) measures how flat the inspiratory flow plateau is. FI \u2265 0.85 indicates significant flow limitation.',
       'M-shape detection identifies breaths with a characteristic mid-inspiratory dip showing oscillation in the flow waveform.',
-      'RERA detection: sequences of \u22653 breaths with progressively rising NED slope, terminated by a recovery breath with sudden NED drop. Reported as events per hour.',
+      'Progressive NED run detection: sequences of \u22653 breaths with progressively rising NED slope, terminated by a recovery breath with sudden NED drop. Reported as events per hour.',
     ],
-    reference: 'NED concept from Tamisier et al. RERA detection adapted from clinical scoring criteria.',
+    reference: 'NED concept from Tamisier et al. Progressive effort-pattern detection adapted from respiratory scoring criteria.',
     link: null,
   },
   {
@@ -207,7 +207,7 @@ export default function AboutPage() {
           PAP machines collect detailed breath-by-breath data every night — but most of it stays
           locked on an SD card, invisible to patients and ignored by clinicians who only check AHI.
           Millions of people are &ldquo;treated&rdquo; with AHI under 5 but still wake up exhausted because
-          flow limitation, RERAs, and breathing pattern instability go undetected.
+          flow limitation, effort-related patterns, and breathing pattern instability go undetected.
         </p>
         <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground sm:text-base">
           We believe your breathing data belongs to you. AirwayLab makes that data visible,
@@ -287,7 +287,7 @@ export default function AboutPage() {
               <p className="text-sm leading-relaxed text-muted-foreground">
                 PAP machines collect rich breath-by-breath flow data every night, but most of it stays invisible —
                 locked on an SD card, inaccessible to the people it belongs to. AirwayLab makes that data visible
-                and understandable. Four research-grade engines analyse flow limitation, RERAs, and breathing
+                and understandable. Four research-grade engines analyse flow limitation, effort-related patterns, and breathing
                 patterns that standard AHI metrics miss. Everything runs in your browser, so your data stays yours.
               </p>
             </div>
@@ -491,7 +491,7 @@ export default function AboutPage() {
             <strong className="text-foreground">WAT</strong> analyzes population-level patterns
             (regularity, periodicity). <strong className="text-foreground">NED</strong> measures
             the specific ratio of peak-to-mid flow that indicates airway
-            narrowing, plus automated RERA event detection. Using all three
+            narrowing, plus automated progressive effort-pattern analysis. Using all three
             together gives a more complete picture than any single metric.
           </FAQItem>
 


### PR DESCRIPTION
## Summary

- Replaces 7 instances of the diagnostic term "RERA" in `app/about/page.tsx` with neutral engineering language per MDR MUST Rule 2
- Terminology consistent with fix applied in PR #915 (AI insights route)
- Fixes pre-existing test mock failures caused by consent gate addition and WAT periodicityIndex floating-point drift

**Replacements:**
- `automated RERA event detection` → `automated progressive effort-pattern analysis` (×3)
- `RERA detection: sequences...` → `Progressive NED run detection: sequences...`
- `RERA detection adapted from clinical scoring criteria` → `Progressive effort-pattern detection adapted from respiratory scoring criteria`
- `RERAs, and breathing pattern instability` → `effort-related patterns, and breathing pattern instability` (×2)

## MDR Compliance Checklist
- [x] No therapeutic recommendations
- [x] No diagnostic claims (RERA removed)
- [x] No predictive claims
- [x] No clinical effectiveness judgments

## Test plan
- [x] All 2681 tests pass
- [x] TypeScript clean
- [x] ESLint clean
- [ ] Vercel preview deploy verified by Demian

🤖 Generated with [Claude Code](https://claude.com/claude-code)