### PR TITLE
chore(health): expose deployed commit SHA in /api/health

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -16,6 +16,9 @@ export async function GET(request: NextRequest) {
   }
 
   const version = process.env.npm_package_version ?? 'unknown';
+  // Vercel injects the deployed commit SHA at build time. Exposing it lets the
+  // smoke check assert deployed-SHA == merged-SHA after a release.
+  const sha = process.env.VERCEL_GIT_COMMIT_SHA ?? 'unknown';
 
-  return NextResponse.json({ status: 'ok', version });
+  return NextResponse.json({ status: 'ok', version, sha });
 }


### PR DESCRIPTION
`/api/health` returned only `version`, which resolves to `"unknown"` on Vercel, so a release could not be verified as **deployed-SHA == merged-SHA** at runtime (this gap surfaced during the #957 billing fix — I had to infer the deploy from Vercel's deployment record instead of asking production).

This exposes `VERCEL_GIT_COMMIT_SHA` (a Vercel build-time system env) as `sha`:
```json
{ "status": "ok", "version": "unknown", "sha": "451d985…" }
```
Enables the upcoming `awl-smoke.sh` to assert the deployed code matches the merged SHA. No behavior change beyond the added field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)