### PR TITLE
fix(billing): re-drive sweeps stranded pending + stranded-pending alert (G1/G3)

### DIFF
--- a/__tests__/subscription-drift-redrive.test.ts
+++ b/__tests__/subscription-drift-redrive.test.ts
@@ -130,6 +130,7 @@ function stripeEventsBuilder(): Record<string, unknown> {
   builder['order'] = vi.fn(ret);
   builder['limit'] = vi.fn(() => { pending = 'select_rows'; return builder; });
   builder['eq'] = vi.fn(() => { if (pending === null) pending = 'update_eq'; return builder; });
+  builder['neq'] = vi.fn(ret);
   builder['update'] = vi.fn((patch: Record<string, unknown>) => {
     stripeEventsUpdates.push(patch);
     pending = 'update_eq';
@@ -240,15 +241,48 @@ describe('subscription-drift cron — ST1 webhook re-drive', () => {
     expect(stripeEventsUpdates).not.toContainEqual(expect.objectContaining({ status: 'failed' }));
   });
 
-  it('builds an .or() filter that selects failed rows and stale (not fresh) processing rows', async () => {
+  it('builds an .or() filter that selects failed + stale pending + stale processing rows', async () => {
     redriveRows = [];
     const { GET } = await import('@/app/api/cron/subscription-drift/route');
     await GET(makeRequest());
 
-    // failed rows unconditionally + processing rows older than the stale cutoff.
+    // failed rows unconditionally + pending/processing rows older than the cutoff.
     expect(capturedOrFilter).toContain('status.eq.failed');
+    expect(capturedOrFilter).toContain('status.eq.pending');
     expect(capturedOrFilter).toContain('status.eq.processing');
     expect(capturedOrFilter).toContain('updated_at.lt.');
+  });
+
+  it('sweeps a stranded pending row, counts it, and fires the stranded-pending alert (G1/G3)', async () => {
+    redriveRows = [
+      { event_id: 'evt_stranded', event_type: 'customer.created', status: 'pending', attempts: 0, updated_at: '2026-01-01T00:00:00Z' },
+    ];
+    // customer.created is an unhandled type -> processStripeEvent is a no-op -> success.
+    mockEventsRetrieve.mockResolvedValue({
+      id: 'evt_stranded',
+      type: 'customer.created',
+      data: { object: { id: 'cus_x' } },
+    });
+
+    const { GET } = await import('@/app/api/cron/subscription-drift/route');
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    // Picked, swept to done, and counted as stranded pending.
+    expect(body.redrive_picked).toBe(1);
+    expect(body.redrive_recovered).toBe(1);
+    expect(body.redrive_stranded_pending).toBe(1);
+    // The claim ran via the RPC (pending is claimable; attemptsBefore 0 + 1).
+    expect(mockRpc).toHaveBeenCalledWith(
+      'claim_stripe_event',
+      expect.objectContaining({ p_event_id: 'evt_stranded', p_attempts: 1 })
+    );
+    // Fingerprinted stranded-pending regression alert fired.
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'stripe stranded pending: 1',
+      expect.objectContaining({ fingerprint: ['stripe-stranded-pending'] })
+    );
+    expect(mockSendAlert).toHaveBeenCalledWith('ops', '', expect.any(Array));
   });
 
   it('excludes attempts >= MAX_ATTEMPTS via a .lt(attempts, 5) filter (HIGH 3)', async () => {

--- a/app/api/cron/subscription-drift/route.ts
+++ b/app/api/cron/subscription-drift/route.ts
@@ -15,6 +15,8 @@ interface RedriveResult {
   picked: number;
   recovered: number;
   stillFailed: number;
+  /** Rows that were stuck `pending` past the stale window (G3 health signal). */
+  strandedPending: number;
 }
 
 /**
@@ -23,6 +25,10 @@ interface RedriveResult {
  *
  * It scans stripe_events for rows the webhook could not complete:
  *   - status = 'failed'      (processing threw; row was kept, not deleted)
+ *   - status = 'pending'     AND updated_at older than STALE_PROCESSING_MS
+ *                            (G1: stranded — the webhook's inline claim never ran,
+ *                            e.g. the claim itself errored before flipping status.
+ *                            A fresh `pending` row is mid-flight and left alone.)
  *   - status = 'processing'  AND updated_at older than STALE_PROCESSING_MS
  *                            (the worker died mid-flight)
  * and EXCLUDES rows with attempts >= MAX_ATTEMPTS (HIGH 3): a poison event that
@@ -42,19 +48,21 @@ async function redriveStripeEvents(
   stripe: Stripe | null,
   supabase: SupabaseClient
 ): Promise<RedriveResult> {
-  const result: RedriveResult = { picked: 0, recovered: 0, stillFailed: 0 };
+  const result: RedriveResult = { picked: 0, recovered: 0, stillFailed: 0, strandedPending: 0 };
   if (!stripe) return result;
 
   const staleCutoff = new Date(Date.now() - STALE_PROCESSING_MS).toISOString();
 
-  // failed rows: always eligible. stale processing rows: only past the cutoff.
-  // attempts >= MAX_ATTEMPTS are excluded so a poison event cannot re-drive
-  // forever (it has been parked `dead` with its own ops alert).
+  // failed rows: always eligible. stale pending + stale processing rows: only
+  // past the cutoff (G1 — a `pending` row older than the stale window means the
+  // webhook's inline claim never completed; a fresh `pending` row is mid-flight
+  // and left alone). attempts >= MAX_ATTEMPTS are excluded so a poison event
+  // cannot re-drive forever (it has been parked `dead` with its own ops alert).
   const { data: rows, error: queryErr } = await supabase
     .from('stripe_events')
     .select('event_id, event_type, status, attempts, updated_at')
     .lt('attempts', MAX_ATTEMPTS)
-    .or(`status.eq.failed,and(status.eq.processing,updated_at.lt.${staleCutoff})`)
+    .or(`status.eq.failed,and(status.eq.pending,updated_at.lt.${staleCutoff}),and(status.eq.processing,updated_at.lt.${staleCutoff})`)
     .order('updated_at', { ascending: true })
     .limit(REDRIVE_BATCH_LIMIT);
 
@@ -68,6 +76,7 @@ async function redriveStripeEvents(
 
   for (const row of rows ?? []) {
     result.picked++;
+    if ((row as { status?: string }).status === 'pending') result.strandedPending++;
     const attemptsBefore = (row as { attempts?: number }).attempts ?? 0;
     try {
       // Refetch the event payload from Stripe — we only stored id + type.
@@ -99,6 +108,11 @@ async function redriveStripeEvents(
         tags: { route: 'cron-subscription-drift', action: 'redrive-event' },
         extra: { event_id: (row as { event_id: string }).event_id },
       });
+      // Guard: never clobber a row another worker already completed. retrieve()
+      // failed before runStripeJob's atomic claim, so this caller does not own the
+      // row — if a concurrent run (or the webhook) drove it to `done` meanwhile,
+      // leave it. `.neq('status','done')` is a plain filter, safe on a mutation
+      // (an `or` filter is NOT — see migration 063 / claim_stripe_event).
       await supabase
         .from('stripe_events')
         .update({
@@ -106,7 +120,8 @@ async function redriveStripeEvents(
           last_error: err instanceof Error ? err.message : String(err),
           attempts: attemptsNow,
         })
-        .eq('event_id', (row as { event_id: string }).event_id);
+        .eq('event_id', (row as { event_id: string }).event_id)
+        .neq('status', 'done');
       if (terminal) {
         Sentry.captureMessage('Stripe event hit max attempts — parked as dead', {
           level: 'error',
@@ -568,6 +583,32 @@ export async function GET(request: NextRequest) {
     // events are only recovered here.
     const redrive = await redriveStripeEvents(getStripe(), supabase);
 
+    // 5c. G3: rows stranded `pending` past the stale window mean the webhook's
+    // inline atomic claim is not completing (it should within seconds of insert).
+    // The re-drive sweeps them, but the fact they stranded is a regression signal
+    // — alert with its own fingerprint, independent of tier-drift.
+    if (redrive.strandedPending > 0) {
+      Sentry.captureMessage(`stripe stranded pending: ${redrive.strandedPending}`, {
+        level: 'error',
+        fingerprint: ['stripe-stranded-pending'],
+        tags: { route: 'cron-subscription-drift', action: 'stranded-pending' },
+        extra: { strandedPending: redrive.strandedPending, recovered: redrive.recovered },
+      });
+      await sendAlert('ops', '', [
+        {
+          title: ':rotating_light: Stripe events stranded in pending',
+          description: `${redrive.strandedPending} stripe_events row(s) were stuck \`pending\` past the stale window — the webhook's inline claim is not completing. The re-drive swept them (${redrive.recovered} recovered this run). Investigate the webhook claim path.`,
+          color: COLORS.red,
+          fields: [
+            { name: 'Stranded pending', value: String(redrive.strandedPending), inline: true },
+            { name: 'Recovered this run', value: String(redrive.recovered), inline: true },
+          ],
+          footer: { text: 'subscription-drift cron' },
+          timestamp: new Date().toISOString(),
+        },
+      ]);
+    }
+
     // 6. Send Discord ops alert if any drift OR webhook re-drive activity occurred
     if (mismatches.length > 0 || redrive.picked > 0) {
       const downgradeMissed = mismatches.filter((m) => m.drift_type === 'downgrade_missed').length;
@@ -603,7 +644,7 @@ export async function GET(request: NextRequest) {
     }
 
     console.error(
-      `[subscription-drift] completed: checked=${checked}, mismatches=${mismatches.length}, fixed=${fixed}, webhook_never_ran=${webhookNeverRanCount}, stripe_recovered=${stripeRecovered}, redrive_picked=${redrive.picked}, redrive_recovered=${redrive.recovered}, redrive_still_failed=${redrive.stillFailed}`
+      `[subscription-drift] completed: checked=${checked}, mismatches=${mismatches.length}, fixed=${fixed}, webhook_never_ran=${webhookNeverRanCount}, stripe_recovered=${stripeRecovered}, redrive_picked=${redrive.picked}, redrive_recovered=${redrive.recovered}, redrive_still_failed=${redrive.stillFailed}, redrive_stranded_pending=${redrive.strandedPending}`
     );
 
     return NextResponse.json({
@@ -616,6 +657,7 @@ export async function GET(request: NextRequest) {
       redrive_picked: redrive.picked,
       redrive_recovered: redrive.recovered,
       redrive_still_failed: redrive.stillFailed,
+      redrive_stranded_pending: redrive.strandedPending,
     });
   } catch (err) {
     console.error('[subscription-drift] Cron failed:', err);

--- a/supabase/tests/claim_stripe_event_test.sql
+++ b/supabase/tests/claim_stripe_event_test.sql
@@ -1,0 +1,67 @@
+-- Contract test for public.claim_stripe_event (migration 063).
+--
+-- Verifies the atomic-claim predicate: it claims pending / failed / stale-processing
+-- rows, preserves done / dead / fresh-processing rows, and sets status='processing'
+-- with attempts = the supplied value.
+--
+-- Runs entirely inside a transaction and ROLLBACKs, so it never persists test rows.
+-- Run against a test/branch DB (NOT prod) with:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f supabase/tests/claim_stripe_event_test.sql
+-- A failed assertion RAISEs and aborts the run; success emits
+-- 'claim_stripe_event: all assertions passed'.
+--
+-- Not yet wired into CI (no ephemeral test-DB step). Add one to gate the claim
+-- contract automatically.
+
+begin;
+
+insert into public.stripe_events (event_id, event_type, status, attempts, updated_at) values
+  ('__test_pending__', 'test.contract', 'pending',    0, now()),
+  ('__test_failed__',  'test.contract', 'failed',     1, now()),
+  ('__test_done__',    'test.contract', 'done',       1, now()),
+  ('__test_dead__',    'test.contract', 'dead',       5, now()),
+  ('__test_fresh__',   'test.contract', 'processing', 1, now()),
+  ('__test_stale__',   'test.contract', 'processing', 1, now() - interval '1 hour');
+
+do $$
+declare
+  cutoff timestamptz := now() - interval '15 minutes';
+  n int;
+begin
+  -- Claimable states return exactly one row.
+  select count(*) into n from public.claim_stripe_event('__test_pending__', 1, cutoff);
+  if n <> 1 then raise exception 'pending should be claimed (got %)', n; end if;
+
+  select count(*) into n from public.claim_stripe_event('__test_failed__', 2, cutoff);
+  if n <> 1 then raise exception 'failed should be claimed (got %)', n; end if;
+
+  select count(*) into n from public.claim_stripe_event('__test_stale__', 2, cutoff);
+  if n <> 1 then raise exception 'stale processing should be claimed (got %)', n; end if;
+
+  -- Non-claimable states return zero rows (and stay untouched).
+  select count(*) into n from public.claim_stripe_event('__test_fresh__', 2, cutoff);
+  if n <> 0 then raise exception 'fresh processing must NOT be claimed (got %)', n; end if;
+
+  select count(*) into n from public.claim_stripe_event('__test_done__', 2, cutoff);
+  if n <> 0 then raise exception 'done must NOT be claimed (got %)', n; end if;
+
+  select count(*) into n from public.claim_stripe_event('__test_dead__', 6, cutoff);
+  if n <> 0 then raise exception 'dead must NOT be claimed (got %)', n; end if;
+
+  -- A claimed row is now `processing` with attempts set to the supplied value.
+  perform 1 from public.stripe_events
+    where event_id = '__test_pending__' and status = 'processing' and attempts = 1;
+  if not found then raise exception 'claimed pending row must be processing with attempts=1'; end if;
+
+  -- Preserved rows are unchanged.
+  perform 1 from public.stripe_events where event_id = '__test_done__' and status = 'done';
+  if not found then raise exception 'done row must remain done'; end if;
+  perform 1 from public.stripe_events where event_id = '__test_dead__' and status = 'dead';
+  if not found then raise exception 'dead row must remain dead'; end if;
+  perform 1 from public.stripe_events where event_id = '__test_fresh__' and status = 'processing' and attempts = 1;
+  if not found then raise exception 'fresh processing row must be untouched'; end if;
+
+  raise notice 'claim_stripe_event: all assertions passed';
+end $$;
+
+rollback;


### PR DESCRIPTION
## Why
The re-drive cron only swept `failed` / stale-`processing` rows. A `stripe_events` row left **`pending`** by a claim that errored before flipping status (exactly what stranded the #957 checkout) was invisible to recovery. This closes that gap.

## What
- **G1 sweep:** the re-drive SELECT now also picks **stale `pending`** rows (`updated_at` older than `STALE_PROCESSING_MS`). A fresh in-flight `pending` row (being processed by the webhook's `after()`) is left alone. `claim_stripe_event` (migration 063) already accepts `pending`, so no function change.
- **G3 alert:** fingerprinted `stripe-stranded-pending` Sentry message + ops Discord alert + a `redrive_stranded_pending` counter in the response/log. Stranded `pending` is a **regression signal** — the inline claim should complete within seconds of insert.
- **Concurrency guard (Codex HIGH):** the retrieve-failure catch now updates with `.neq('status','done')`, so a concurrent run can't clobber a row another worker already completed. `.neq` is a plain filter — I verified it is safe on a mutation (unlike `or`, which is the #957 bug).
- **SQL contract test** for `claim_stripe_event`: claims pending/failed/stale, preserves done/dead/fresh, sets `attempts`. Runs in a rolled-back transaction (`supabase/tests/`); not yet wired into CI.

## Verify
`vitest` 60/60 · `tsc` clean · `eslint` clean · Codex reviewed (the one HIGH is addressed by the `.neq` guard).

## Follow-up (noted, not in scope)
The cron retrieves the Stripe event **before** the atomic claim, so the catch path acts without owning the row. The `.neq` guard prevents the harmful `done`-overwrite; a fuller fix claims before retrieve. Reprocessing is idempotent (059 dedup), so residual risk is low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)