### PR TITLE
ci: guard against or-on-mutation (PostgREST 42703)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,19 @@ jobs:
             exit 1
           fi
 
+  mutation-guard:
+    name: Supabase mutation guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      # No deps: pure node + git. Fails on any `.update/.delete/.upsert().or()`
+      # (PostgREST 42703 on or-mutations — 2026-06-04 billing incident).
+      - run: node scripts/check-no-mutation-or.mjs
+
   # Single build lives here: `npx playwright test` starts the built app via
   # playwright.config.ts webServer (`npm run start`, reuseExistingServer=false on CI).
   e2e:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "node scripts/check-version.mjs && next build --webpack",
     "start": "next start",
     "lint": "eslint .",
+    "lint:mutations": "node scripts/check-no-mutation-or.mjs",
     "check": "tsc --noEmit && eslint . && vitest run",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/check-no-mutation-or.mjs
+++ b/scripts/check-no-mutation-or.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Fail CI if a Supabase mutation chains an `.or()` filter.
+ *
+ * PostgREST CANNOT build an `or` filter on a MUTATION (UPDATE/DELETE): it rejects
+ * the request with Postgres `42703 "column … does not exist"` even when the
+ * column exists. The same `or` works on a SELECT, which is why this slips past
+ * unit tests + typecheck + a clean deploy (2026-06-04 billing incident — the
+ * Stripe claim's `.update().or(status…)` stranded every checkout). Fix: move the
+ * conditional UPDATE/DELETE into a SQL function (RPC). See migration 063 /
+ * `claim_stripe_event`. Plain filters (`eq`, `in`, `neq`) ARE fine on mutations.
+ */
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+// Directory pathspecs catch every nested AND top-level file under each dir.
+const files = execSync('git ls-files app lib workers', { encoding: 'utf8' })
+  .split('\n')
+  .filter((f) => /\.(ts|tsx)$/.test(f));
+
+// Strip comments so a doc-comment mentioning `.update().or()` is not flagged.
+// Keep `://` so a URL is not mistaken for a line comment.
+function stripComments(s) {
+  return s
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/gm, '$1');
+}
+
+const violations = [];
+for (const file of files) {
+  const src = stripComments(readFileSync(file, 'utf8'));
+  // From each mutation call, scan to the end of the statement (`;`) and flag if
+  // an `.or(` filter appears in that chain. A mutation chain is a single
+  // statement, so the first `;` after the call terminates it.
+  const re = /\.(update|delete|upsert)\s*\(/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const start = m.index;
+    const semi = src.indexOf(';', start);
+    const chunk = src.slice(start, semi === -1 ? src.length : semi);
+    if (/\.or\s*\(/.test(chunk)) {
+      const line = src.slice(0, start).split('\n').length;
+      violations.push(`${file}:${line}  .${m[1]}(...) … .or(...)`);
+    }
+  }
+}
+
+if (violations.length) {
+  console.error('✖ or-on-mutation detected (PostgREST 42703 risk):');
+  for (const v of violations) console.error('  ' + v);
+  console.error('\nPostgREST cannot do an `or` filter on a MUTATION. Move the conditional');
+  console.error('UPDATE/DELETE into a SQL function (RPC). See migration 063 / claim_stripe_event.');
+  process.exit(1);
+}
+console.log('✓ no or-on-mutation patterns found');


### PR DESCRIPTION
## Why
The 2026-06-04 billing incident: the Stripe claim used `.update().or(status…)`. **PostgREST cannot build an `or` filter on a MUTATION** — it throws `42703 "column … does not exist"` even though the column exists (the same `or` works on a SELECT). It passed unit tests + typecheck + deployed clean, yet stranded **every** checkout. Fixed in #957 by moving the claim to the `claim_stripe_event` RPC.

This is the cheap, always-on prevention: a CI gate that makes the anti-pattern impossible to reintroduce.

## What
- `scripts/check-no-mutation-or.mjs` — dependency-free; scans `app/lib/workers`, strips comments, and fails on any `.update/.delete/.upsert(...)…or(...)` chain. Points at the fix (RPC).
- new `ci.yml` job **`Supabase mutation guard`** (fast, no `npm ci`).
- `npm run lint:mutations` for local use.

## Tested
- ✓ passes on current `main`
- ✓ fails on an injected `.update().or()` (nested, multi-line) **and** `.delete().or()` (top-level `lib/`)
- ✓ does **not** flag the doc-comment in `route.ts` that describes the anti-pattern (comment-stripping)

This is the verifiable slice of the release-testing plan (Layer 2). The fuller ephemeral-PostgREST integration job is a follow-up (needs Docker/Supabase CI infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)