### PR TITLE
fix(mdr): replace RERA detection clinical term in compare pages (AIR-2481)

### DIFF
--- a/app/compare/myair/page.tsx
+++ b/app/compare/myair/page.tsx
@@ -16,11 +16,11 @@ import { FAQItem } from '@/components/common/faq-item';
 export const metadata: Metadata = {
   title: 'AirwayLab vs myAir: Beyond Basic CPAP Metrics',
   description:
-    'Compare AirwayLab and ResMed myAir for CPAP analysis. Go beyond AHI, mask fit, and usage hours with flow limitation scoring, RERA detection, Glasgow Index, and privacy-first browser analysis.',
+    'Compare AirwayLab and ResMed myAir for CPAP analysis. Go beyond AHI, mask fit, and usage hours with flow limitation scoring, effort-pattern analysis, Glasgow Index, and privacy-first browser analysis.',
   openGraph: {
     title: 'AirwayLab vs myAir: Beyond Basic CPAP Metrics',
     description:
-      'Compare AirwayLab and ResMed myAir for CPAP analysis. Go beyond AHI with flow limitation scoring, RERA detection, and the Glasgow Index.',
+      'Compare AirwayLab and ResMed myAir for CPAP analysis. Go beyond AHI with flow limitation scoring, effort-pattern analysis, and the Glasgow Index.',
   },
   alternates: {
     canonical: 'https://airwaylab.app/compare/myair',
@@ -71,7 +71,7 @@ const faqData = [
   {
     question: 'What does AirwayLab see that myAir does not?',
     answer:
-      'myAir receives a simplified summary: AHI, usage hours, mask fit, and leak data. The SD card contains the full flow waveform -- every breath, sampled 25 times per second. AirwayLab analyses these raw waveforms to compute flow limitation scores, detect RERAs, calculate the Glasgow Index, and identify breathing pattern abnormalities that the simplified summary hides.',
+      'myAir receives a simplified summary: AHI, usage hours, mask fit, and leak data. The SD card contains the full flow waveform -- every breath, sampled 25 times per second. AirwayLab analyses these raw waveforms to compute flow limitation scores, analyse effort-related breathing patterns, calculate the Glasgow Index, and identify breathing pattern abnormalities that the simplified summary hides.',
   },
   {
     question: 'Does myAir share my data with my insurance company?',
@@ -234,11 +234,11 @@ export default function CompareMyAirPage() {
               </p>
             </div>
             <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
-              <p className="text-sm font-semibold text-emerald-400">RERA Detection</p>
+              <p className="text-sm font-semibold text-emerald-400">Progressive Effort Patterns</p>
               <p className="mt-1 text-xs text-muted-foreground">
                 AirwayLab identifies sequences of flow-limited breaths ending in arousals --
-                Respiratory Effort-Related Arousals (RERAs) that fragment sleep but never appear in
-                your AHI or myAir score.
+                effort-related events that fragment sleep but never appear in your AHI or myAir
+                score.
               </p>
             </div>
             <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
@@ -297,7 +297,7 @@ export default function CompareMyAirPage() {
                 <td className="px-4 py-2.5 text-center text-emerald-400">4 engines</td>
               </tr>
               <tr className="border-b border-border/30">
-                <td className="py-2.5 pr-4">RERA detection</td>
+                <td className="py-2.5 pr-4">Effort-pattern analysis</td>
                 <td className="px-4 py-2.5 text-center text-muted-foreground/60">No</td>
                 <td className="px-4 py-2.5 text-center text-emerald-400">Yes (NED)</td>
               </tr>
@@ -470,8 +470,8 @@ export default function CompareMyAirPage() {
         <h3 className="text-lg font-bold">See What myAir Does Not Show You</h3>
         <p className="mt-2 text-sm text-muted-foreground">
           Upload your ResMed SD card and discover the flow limitation patterns hiding behind your
-          myAir score. Four research-grade engines, composite metrics, RERA detection, and trend
-          tracking. No installation, no account required, 100% private.
+          myAir score. Four research-grade engines, composite metrics, progressive effort-pattern
+          analysis, and trend tracking. No installation, no account required, 100% private.
         </p>
         <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">
           <Link

--- a/app/compare/oscar/page.tsx
+++ b/app/compare/oscar/page.tsx
@@ -56,7 +56,7 @@ const faqData = [
   {
     question: 'Should I switch from OSCAR to AirwayLab?',
     answer:
-      'No -- use both. OSCAR excels at interactive waveform inspection and supports many devices. AirwayLab adds automated flow limitation scoring, RERA detection, and composite metrics that OSCAR does not compute. They solve different problems and work best together.',
+      'No -- use both. OSCAR excels at interactive waveform inspection and supports many devices. AirwayLab adds automated flow limitation scoring, progressive effort-pattern analysis, and composite metrics that OSCAR does not compute. They solve different problems and work best together.',
   },
   {
     question: 'Does AirwayLab support all the same devices as OSCAR?',
@@ -200,7 +200,7 @@ export default function CompareOscarPage() {
               </p>
             </div>
             <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4">
-              <p className="text-sm font-semibold text-emerald-400">RERA Detection</p>
+              <p className="text-sm font-semibold text-emerald-400">Progressive Effort Patterns</p>
               <p className="mt-1 text-xs text-muted-foreground">
                 AirwayLab&apos;s NED engine identifies sequences of flow-limited breaths that end in
                 arousals, estimating a RERA index and Respiratory Disturbance Index that OSCAR cannot
@@ -263,7 +263,7 @@ export default function CompareOscarPage() {
                 <td className="px-4 py-2.5 text-center text-emerald-400">4 engines</td>
               </tr>
               <tr className="border-b border-border/30">
-                <td className="py-2.5 pr-4">RERA detection</td>
+                <td className="py-2.5 pr-4">Effort-pattern analysis</td>
                 <td className="px-4 py-2.5 text-center text-muted-foreground/60">No</td>
                 <td className="px-4 py-2.5 text-center text-emerald-400">Yes (NED)</td>
               </tr>

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -56,7 +56,7 @@ interface ComparisonRow {
 
 const comparisonData: ComparisonRow[] = [
   { feature: 'Flow limitation scoring', oscar: 'no', sleephq: 'no', myair: 'no', airwaylab: '4 engines' },
-  { feature: 'RERA detection', oscar: 'no', sleephq: 'no', myair: 'no', airwaylab: 'yes' },
+  { feature: 'Effort-pattern analysis', oscar: 'no', sleephq: 'no', myair: 'no', airwaylab: 'yes' },
   { feature: 'Glasgow Index', oscar: 'no', sleephq: 'no', myair: 'no', airwaylab: 'yes' },
   { feature: 'AI-powered insights', oscar: 'no', sleephq: 'no', myair: 'no', airwaylab: 'opt-in' },
   { feature: 'Interactive waveform zoom', oscar: 'yes', sleephq: 'basic', myair: 'no', airwaylab: 'Viewer' },
@@ -135,7 +135,7 @@ const tools = [
     bgColor: 'bg-emerald-500/5',
     strengths: [
       'Four independent flow limitation engines',
-      'RERA detection and Glasgow Index',
+      'Effort-pattern analysis and Glasgow Index',
       'Browser-only -- data never leaves your device',
       'Open source (GPL-3.0)',
     ],
@@ -288,7 +288,7 @@ export default function ComparePage() {
         <h3 className="text-lg font-bold">Try AirwayLab Free</h3>
         <p className="mt-2 text-sm text-muted-foreground">
           Upload your ResMed SD card and get flow limitation analysis in minutes. Four research-grade
-          engines, composite metrics, RERA detection, and trend tracking. No installation, no account
+          engines, composite metrics, progressive effort-pattern analysis, and trend tracking. No installation, no account
           required, 100% private.
         </p>
         <div className="mt-4 flex flex-col items-center gap-2 sm:flex-row sm:justify-center">


### PR DESCRIPTION
## Summary

Replaces 10 MDR MUST Rule 2 violations across three compare pages.

- 'RERA detection', 'detect RERAs', 'RERA Detection' → 'effort-pattern analysis' / 'progressive effort patterns'
- Violations were in SEO-indexed meta descriptions, OG tags, section headers, feature tables, FAQ answers, and CTA copy
- Follows precedent from PR #951 (about page) and the sleephq compare page (already uses 'RERA estimation')

## Files

- app/compare/page.tsx — 3 fixes (feature row, strengths bullet, CTA)
- app/compare/myair/page.tsx — 5 fixes (meta, OG, FAQ, header, table, CTA)
- app/compare/oscar/page.tsx — 2 fixes (FAQ, header, table)

## MDR self-review

- [x] No therapeutic recommendations
- [x] No diagnostic claims — 'RERA detection'/'detect RERAs' removed
- [x] No predictive claims
- [x] No clinical effectiveness judgments
- [x] Disclaimers intact
- [x] No AI prompt changes

## Pre-merge checklist

- [x] lint / typecheck / 2689 tests all pass
- [ ] Vercel preview verified by Demian
- [x] One concern only

Per AIR-2139: author != reviewer. CTO must review before merge.