### PR TITLE
fix(billing): cancel Stripe subscription on account deletion (fail-safe)

### DIFF
--- a/__tests__/delete-user-data.test.ts
+++ b/__tests__/delete-user-data.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { NextRequest } from 'next/server';
 
 // ── Mocks ─────────────────────────────────────────────────────────────
@@ -14,7 +14,22 @@ vi.mock('@/lib/rate-limit', () => ({
 }));
 
 const mockCaptureException = vi.fn();
-vi.mock('@sentry/nextjs', () => ({ captureException: (...args: unknown[]) => mockCaptureException(...args) }));
+const mockCaptureMessage = vi.fn();
+vi.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+}));
+
+const mockSubscriptionsCancel = vi.fn();
+const mockSubscriptionsList = vi.fn();
+vi.mock('stripe', () => ({
+  default: class MockStripe {
+    subscriptions = {
+      cancel: (...a: unknown[]) => mockSubscriptionsCancel(...a),
+      list: (...a: unknown[]) => mockSubscriptionsList(...a),
+    };
+  },
+}));
 
 const mockDeleteUser = vi.fn();
 const mockStorageFrom = vi.fn();
@@ -46,11 +61,14 @@ function makeRequest(): NextRequest {
 function mockSuccessfulDeletion() {
   mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123', email: 'test@example.com' } }, error: null });
   mockStorageFrom.mockReturnValue({ list: vi.fn().mockResolvedValue({ data: [], error: null }) });
-  const mockTable = {
-    delete: vi.fn().mockReturnThis(),
-    eq: vi.fn().mockResolvedValue({ error: null }),
+  const deleteTable = { delete: vi.fn().mockReturnThis(), eq: vi.fn().mockResolvedValue({ error: null }) };
+  // Step 0 always looks up profiles.stripe_customer_id; null => no billing => skip Stripe.
+  const profilesBuilder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: { stripe_customer_id: null }, error: null }),
   };
-  mockFrom.mockReturnValue(mockTable);
+  mockFrom.mockImplementation((table: string) => (table === 'profiles' ? profilesBuilder : deleteTable));
   mockDeleteUser.mockResolvedValue({ error: null });
 }
 
@@ -60,6 +78,11 @@ describe('POST /api/delete-user-data', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsLimited.mockReturnValue(false);
+    // These tests cover the no-Stripe path: STRIPE_SECRET_KEY unset → getStripe()
+    // returns null → the cancel step is skipped. resetModules so the route module
+    // re-reads the env each test.
+    delete process.env.STRIPE_SECRET_KEY;
+    vi.resetModules();
   });
 
   it('returns 200 and deletes all user data including auth user', async () => {
@@ -116,7 +139,12 @@ describe('POST /api/delete-user-data', () => {
       delete: vi.fn().mockReturnThis(),
       eq: vi.fn().mockResolvedValue({ error: { message: 'DB error', code: '500' } }),
     };
-    mockFrom.mockReturnValue(failingTable);
+    const profilesBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { stripe_customer_id: null }, error: null }),
+    };
+    mockFrom.mockImplementation((table: string) => (table === 'profiles' ? profilesBuilder : failingTable));
     mockDeleteUser.mockResolvedValue({ error: null });
 
     const { POST } = await import('@/app/api/delete-user-data/route');
@@ -163,5 +191,168 @@ describe('POST /api/delete-user-data', () => {
 
     const calls = mockFrom.mock.calls.map((args: unknown[]) => args[0] as string);
     expect(calls).toContain('user_nights');
+  });
+});
+
+describe('POST /api/delete-user-data — Stripe cancellation (fail-safe, Stripe-authoritative)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLimited.mockReturnValue(false);
+    process.env.STRIPE_SECRET_KEY = 'sk_test_x';
+    vi.resetModules();
+  });
+  afterEach(() => {
+    delete process.env.STRIPE_SECRET_KEY;
+    vi.resetModules();
+  });
+
+  function setup(opts: { customerId?: string | null; stripeSubs?: Array<{ id: string; status: string }>; hasMore?: boolean } = {}) {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-123', email: 'test@example.com' } }, error: null });
+    mockStorageFrom.mockReturnValue({ list: vi.fn().mockResolvedValue({ data: [], error: null }) });
+    const deleteTable = { delete: vi.fn().mockReturnThis(), eq: vi.fn().mockResolvedValue({ error: null }) };
+    const profilesBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { stripe_customer_id: opts.customerId ?? null }, error: null }),
+    };
+    const eventsBuilder = { upsert: vi.fn().mockResolvedValue({ error: null }) };
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') return profilesBuilder;
+      if (table === 'subscription_events') return eventsBuilder;
+      return deleteTable;
+    });
+    mockSubscriptionsList.mockResolvedValue({ data: opts.stripeSubs ?? [], has_more: opts.hasMore ?? false });
+    mockDeleteUser.mockResolvedValue({ error: null });
+    return { eventsBuilder };
+  }
+
+  it('cancels the live Stripe sub BEFORE deleting the account (order enforced)', async () => {
+    setup({ customerId: 'cus_x', stripeSubs: [{ id: 'sub_active', status: 'active' }] });
+    mockSubscriptionsCancel.mockResolvedValue({});
+
+    const { POST } = await import('@/app/api/delete-user-data/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(mockSubscriptionsList).toHaveBeenCalledWith(expect.objectContaining({ customer: 'cus_x', status: 'all' }));
+    expect(mockSubscriptionsCancel).toHaveBeenCalledWith('sub_active');
+    expect(mockDeleteUser).toHaveBeenCalledWith('user-123');
+    // cancel must precede auth deletion
+    expect(mockSubscriptionsCancel.mock.invocationCallOrder[0]!).toBeLessThan(mockDeleteUser.mock.invocationCallOrder[0]!);
+  });
+
+  it('records a cancellation churn event for each cancelled sub', async () => {
+    const { eventsBuilder } = setup({ customerId: 'cus_x', stripeSubs: [{ id: 'sub_active', status: 'active' }] });
+    mockSubscriptionsCancel.mockResolvedValue({});
+
+    const { POST } = await import('@/app/api/delete-user-data/route');
+    await POST(makeRequest());
+
+    expect(eventsBuilder.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ event_type: 'cancelled', stripe_subscription_id: 'sub_active', mrr_cents: 0 }),
+      expect.objectContaining({ onConflict: 'stripe_event_id', ignoreDuplicates: true }),
+    );
+  });
+
+  it('ABORTS with 502 and deletes NOTHING when a cancellation fails', async () => {
+    setup({ customerId: 'cus_x', stripeSubs: [{ id: 'sub_active', status: 'active' }] });
+    mockSubscriptionsCancel.mockRejectedValue({ code: 'api_error', message: 'Stripe down' });
+
+    const { POST } = await import('@/app/api/delete-user-data/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(502);
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+    expect(mockStorageFrom).not.toHaveBeenCalled(); // never reached storage/table deletion
+  });
+
+  it('ABORTS with 502 and deletes NOTHING when listing subscriptions fails', async () => {
+    setup({ customerId: 'cus_x' });
+    mockSubscriptionsList.mockRejectedValue({ code: 'api_error', message: 'list failed' });
+
+    const { POST } = await import('@/app/api/delete-user-data/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(502);
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+    expect(mockStorageFrom).not.toHaveBeenCalled();
+  });
+
+  it('treats resource_missing as success and proceeds with deletion', async () => {
+    setup({ customerId: 'cus_x', stripeSubs: [{ id: 'sub_gone', status: 'active' }] });
+    mockSubscriptionsCancel.mockRejectedValue({ code: 'resource_missing', message: 'No such subscription' });
+
+    const { POST } = await import('@/app/api/delete-user-data/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(mockDeleteUser).toHaveBeenCalledWith('user-123');
+  });
+
+  it('multiple subs: a later failure aborts, but the earlier cancellation kept its churn', async () => {
+    const { eventsBuilder } = setup({ customerId: 'cus_x', stripeSubs: [{ id: 'sub_a', status: 'active' }, { id: 'sub_b', status: 'active' }] });
+    mockSubscriptionsCancel.mockResolvedValueOnce({}).mockRejectedValueOnce({ code: 'api_error', message: 'boom' });
+
+    const { POST } = await import('@/app/api/delete-user-data/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(502);
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ extra: expect.objectContaining({ failedSubscriptionId: 'sub_b', cancelledSoFar: 1 }) }),
+    );
+    // sub_a's churn was recorded BEFORE the abort (not lost)
+    expect(eventsBuilder.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ stripe_subscription_id: 'sub_a' }),
+      expect.anything(),
+    );
+  });
+
+  it('ABORTS with 502 when the customer has more than one page of subscriptions', async () => {
+    setup({ customerId: 'cus_x', stripeSubs: [{ id: 'sub_a', status: 'active' }], hasMore: true });
+
+    const { POST } = await import('@/app/api/delete-user-data/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(502);
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+    expect(mockSubscriptionsCancel).not.toHaveBeenCalled();
+  });
+
+  it('does not cancel already-canceled Stripe subs', async () => {
+    setup({ customerId: 'cus_x', stripeSubs: [{ id: 'sub_old', status: 'canceled' }] });
+
+    const { POST } = await import('@/app/api/delete-user-data/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(mockSubscriptionsCancel).not.toHaveBeenCalled();
+    expect(mockDeleteUser).toHaveBeenCalledWith('user-123');
+  });
+
+  it('ABORTS with 503 when the user has a stripe_customer_id but Stripe is not configured', async () => {
+    setup({ customerId: 'cus_x' });
+    delete process.env.STRIPE_SECRET_KEY; // simulate config regression
+    vi.resetModules();
+
+    const { POST } = await import('@/app/api/delete-user-data/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(503);
+    expect(mockDeleteUser).not.toHaveBeenCalled();
+    expect(mockSubscriptionsList).not.toHaveBeenCalled();
+  });
+
+  it('skips Stripe entirely when the user has no stripe_customer_id', async () => {
+    setup({ customerId: null });
+
+    const { POST } = await import('@/app/api/delete-user-data/route');
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(mockSubscriptionsList).not.toHaveBeenCalled();
+    expect(mockSubscriptionsCancel).not.toHaveBeenCalled();
+    expect(mockDeleteUser).toHaveBeenCalledWith('user-123');
   });
 });

--- a/app/api/delete-user-data/route.ts
+++ b/app/api/delete-user-data/route.ts
@@ -5,12 +5,21 @@ import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import { validateOrigin } from '@/lib/csrf';
 import { STORAGE_BUCKET } from '@/lib/storage/types';
+import Stripe from 'stripe';
 
 // This endpoint derives all input from the authenticated session.
 // No request body is accepted; unexpected fields are rejected.
 const BodySchema = z.object({}).strict();
 
 const rateLimiter = new RateLimiter({ windowMs: 3_600_000, max: 3 });
+
+const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+let _stripe: Stripe | null = null;
+function getStripe(): Stripe | null {
+  if (!stripeSecretKey) return null;
+  if (!_stripe) _stripe = new Stripe(stripeSecretKey, { apiVersion: '2026-02-25.clover' });
+  return _stripe;
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -44,6 +53,130 @@ export async function POST(request: NextRequest) {
     const serviceRole = getSupabaseServiceRole();
     if (!serviceRole) {
       return NextResponse.json({ error: 'Service not configured' }, { status: 503 });
+    }
+
+    // 0. Cancel any live Stripe subscription BEFORE deleting local/auth data.
+    //    STRIPE IS THE SOURCE OF TRUTH (local `subscriptions` rows can drift — the
+    //    drift cron exists precisely because Stripe subs can lack a local row).
+    //    FAIL-SAFE: if the user has a billing identity (stripe_customer_id) and we
+    //    cannot verify/cancel via Stripe, ABORT the whole deletion — never strand a
+    //    deleted account with a live subscription that keeps billing the customer.
+    const { data: profileRow, error: profileLookupError } = await serviceRole
+      .from('profiles')
+      .select('stripe_customer_id')
+      .eq('id', user.id)
+      .maybeSingle();
+    if (profileLookupError) {
+      Sentry.captureException(profileLookupError, {
+        tags: { route: 'delete-user-data', action: 'profile-lookup' },
+        extra: { userId: user.id },
+      });
+      return NextResponse.json({ error: 'Failed to delete account' }, { status: 500 });
+    }
+    const stripeCustomerId = (profileRow as { stripe_customer_id?: string } | null)?.stripe_customer_id;
+    if (stripeCustomerId) {
+      const stripe = getStripe();
+      if (!stripe) {
+        // Billing identity exists but Stripe is unavailable (config regression).
+        // Abort rather than orphan a paying customer.
+        Sentry.captureMessage('account-deletion aborted: Stripe not configured but user has a stripe_customer_id', {
+          level: 'error',
+          fingerprint: ['delete-stripe-unconfigured'],
+          tags: { route: 'delete-user-data', action: 'cancel-subscription' },
+          extra: { userId: user.id },
+        });
+        return NextResponse.json({ error: 'Account deletion is temporarily unavailable. Please try again later.' }, { status: 503 });
+      }
+      // Authoritative: list the customer's subscriptions from Stripe.
+      let subs: Stripe.Subscription[];
+      try {
+        const list = await stripe.subscriptions.list({ customer: stripeCustomerId, status: 'all', limit: 100 });
+        if (list.has_more) {
+          // >100 subscriptions cannot be enumerated in one page — fail closed
+          // rather than risk leaving a live one billing. (Not realistic for a real
+          // customer; surfaces for manual handling if it ever happens.)
+          Sentry.captureMessage('account-deletion aborted: customer has >100 subscriptions', {
+            level: 'error',
+            fingerprint: ['delete-too-many-subs'],
+            tags: { route: 'delete-user-data', action: 'cancel-subscription' },
+            extra: { userId: user.id, stripeCustomerId },
+          });
+          return NextResponse.json(
+            { error: 'Could not delete your account automatically — please contact support.' },
+            { status: 502 }
+          );
+        }
+        subs = list.data;
+      } catch (err) {
+        Sentry.captureException(err, {
+          level: 'error',
+          fingerprint: ['delete-stripe-list-failed'],
+          tags: { route: 'delete-user-data', action: 'cancel-subscription' },
+          extra: { userId: user.id, stripeCustomerId },
+        });
+        return NextResponse.json(
+          { error: 'Could not verify your subscription. Your account was NOT deleted — please retry.' },
+          { status: 502 }
+        );
+      }
+      const cancellable = subs.filter((s) => s.status !== 'canceled' && s.status !== 'incomplete_expired');
+      let cancelledCount = 0;
+      for (const sub of cancellable) {
+        try {
+          await stripe.subscriptions.cancel(sub.id);
+        } catch (err) {
+          // Only a confirmed-missing resource is idempotent success; anything else
+          // aborts. Subs cancelled earlier in this loop already recorded their churn
+          // below, so an abort here never loses an earlier cancellation.
+          if ((err as { code?: string })?.code !== 'resource_missing') {
+            Sentry.captureException(err, {
+              level: 'error',
+              fingerprint: ['delete-cancel-subscription-failed'],
+              tags: { route: 'delete-user-data', action: 'cancel-subscription' },
+              extra: { userId: user.id, stripeCustomerId, failedSubscriptionId: sub.id, cancelledSoFar: cancelledCount },
+            });
+            return NextResponse.json(
+              { error: 'Could not cancel your subscription. Your account was NOT deleted — please retry or contact support.' },
+              { status: 502 }
+            );
+          }
+          // resource_missing — already gone; still record churn (idempotent) below.
+        }
+        // Record churn for THIS sub immediately + idempotently. The
+        // customer.subscription.deleted webhook cannot record it (by the time it
+        // processes, the user is deleted → its insert hits the FK and is swallowed),
+        // and recording per-sub means a later abort never loses an earlier one.
+        const { error: auditError } = await serviceRole.from('subscription_events').upsert(
+          {
+            user_id: user.id,
+            event_type: 'cancelled',
+            tier: 'community',
+            mrr_cents: 0,
+            stripe_subscription_id: sub.id,
+            stripe_event_id: `account_deletion:${user.id}:${sub.id}`,
+          },
+          { onConflict: 'stripe_event_id', ignoreDuplicates: true }
+        );
+        if (auditError) {
+          // The subscription IS cancelled (billing stopped) — do not fail the whole
+          // deletion over an analytics write. Alert loudly for manual backfill.
+          Sentry.captureException(auditError, {
+            level: 'error',
+            fingerprint: ['delete-churn-audit-failed'],
+            tags: { route: 'delete-user-data', action: 'audit-cancellation' },
+            extra: { userId: user.id, subscriptionId: sub.id },
+          });
+        }
+        cancelledCount++;
+      }
+      if (cancelledCount > 0) {
+        Sentry.captureMessage('account-deletion: stripe subscription(s) cancelled', {
+          level: 'info',
+          fingerprint: ['account-deletion-sub-cancelled'],
+          tags: { route: 'delete-user-data', action: 'account-deletion' },
+          extra: { userId: user.id, count: cancelledCount },
+        });
+      }
     }
 
     // 1. Delete files from Supabase Storage (handles nested directories)


### PR DESCRIPTION
## Why
Account deletion (`app/api/delete-user-data/route.ts`) deleted the user + cascaded local rows but **never cancelled the Stripe subscription** — leaving orphaned paying customers billed forever with no account/access. **Hit live:** a customer deleted + re-signed up (fresh `community` profile) and is very likely still being billed.

## What (Stripe-authoritative, fail-closed)
Before any deletion:
- look up `profiles.stripe_customer_id`; absent → no billing → proceed.
- present but Stripe unconfigured → **abort 503** (never orphan a payer).
- list the customer's subscriptions **from Stripe** (local rows drift); abort 502 if listing fails or `has_more` (>100 subs → fail closed).
- cancel each non-terminal sub; **only `resource_missing` is idempotent success**, anything else aborts 502 and **deletes nothing**.
- record a `cancelled` churn event **per sub, idempotently (upsert)**, *before* any abort — the `customer.subscription.deleted` webhook can't (FK on the deleted user). Audit-write failure alerts loudly but doesn't block deletion.

Only a clean cancellation lets the existing cascade deletion run.

## Review
Codex-reviewed across two rounds — both BLOCKERs (silent-skip on unconfigured Stripe, trusting local rows) and three HIGHs (pagination, partial-cancel churn loss, swallowed audit failure) addressed. 18 tests pass; tsc/eslint/mutation-guard clean.

## Follow-up (separate PR)
Orphan-subscription reconciliation (catch any existing orphans, including the live one) + the immediate damanhoury repair are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)