### PR TITLE
feat(skills): add 5 clean dev skills + engine-reference rule

### DIFF
--- a/.claude/rules/engine-reference.md
+++ b/.claude/rules/engine-reference.md
@@ -1,0 +1,19 @@
+---
+globs:
+  - "lib/analyzers/**"
+  - "workers/**"
+  - "lib/parsers/**"
+---
+# Analysis Engines Reference
+
+### Glasgow Index (`lib/analyzers/glasgow-index.ts`)
+Ported from DaveSkvn/Glasgow-Index (GPL-3.0). Scores inspiratory flow shapes on 9 components (0–1 each): skew, spike, flatTop, topHeavy, multiPeak, noPause, inspirRate, multiBreath, variableAmp. Overall score = sum of all 9 components, range 0–9. Pipeline: findMins → findInspirations → calcCycleBasedIndicators → inspirationAmplitude → prepIndices. Multi-session nights use duration-weighted averaging.
+
+### WAT — Wobble Analysis Tool (`lib/analyzers/wat-engine.ts`)
+Three metrics: FL Score (inspiratory flatness, 0–100, higher = worse), Regularity (Sample Entropy on minute ventilation, higher = more irregular), Periodicity Index (FFT power in 0.01–0.03 Hz band, detects periodic breathing at 30–100s cycles). Includes a Cooley-Tukey radix-2 FFT implementation.
+
+### NED — Negative Effort Dependence (`lib/analyzers/ned-engine.ts`)
+Per-breath analysis: NED = (Qpeak − Qmid) / Qpeak × 100, Flatness Index = mean/peak, Tpeak/Ti ratio, M-shape detection (valley < 80% Qpeak in middle 50% of inspiration). RERA detection: runs of 3–15 breaths with progressive FL features evaluated by NED slope, recovery breath, and sigh detection. Estimated Arousal Index (EAI): respiratory rate + tidal volume spikes vs 120s rolling baseline. Night summary includes H1/H2 split and combined FL percentage.
+
+### Oximetry Pipeline (`lib/analyzers/oximetry-engine.ts`)
+17-metric framework from Viatom/Checkme O2 Max CSV data. Cleaning pipeline: buffer zone trimming (15min start, 5min end), motion filter, invalid sample removal, SpO2 range validation (50–100), HR double-tracking correction. Metrics: ODI-3/ODI-4 (2min rolling baseline), HR Clinical surges (30s baseline, 8/10/12/15 bpm thresholds), HR Rolling Mean surges (5min baseline, 5s sustain), coupled events (ODI + HR within ±30s), desaturation time, summary stats, H1/H2 splits.

--- a/.claude/skills/bug-triage/SKILL.md
+++ b/.claude/skills/bug-triage/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: bug-triage
+description: >
+  Use this skill when triaging, investigating, or fixing a reported bug.
+  Covers reproduction, root cause analysis, fix implementation, and regression testing.
+  Use when assigned a bug report or when investigating unexpected behavior.
+  Don't use for new features (use backend-feature or frontend-feature) or reviews (use code-review).
+---
+
+# Bug Triage
+
+Investigate and fix bugs in AirwayLab following the triage protocol.
+
+## Triage Steps
+
+### 1. Reproduce
+- Understand the reported behavior vs expected behavior
+- Identify which component/module is affected
+- Check if it's a known issue (search existing issues/comments)
+
+### 2. Root Cause Analysis
+- Read the relevant code before proposing changes
+- Check if the bug is in a protected module (lib/analyzers/, lib/parsers/, workers/)
+  - If yes: document the bug and escalate to CTO/board. Do NOT fix.
+- Trace the data flow to find where behavior diverges
+- Check for common gotchas:
+  - Float32Array serialisation issues
+  - Null oximetry data not handled
+  - Hardcoded sampling rates
+  - EDF date parsing (2-digit years)
+  - Duration-weighted averaging edge cases
+  - localStorage 4MB cap exceeded
+
+### 3. Write a Test First
+- Write a test that catches the bug before fixing it
+- Test goes in `__tests__/<module-name>.test.ts`
+- The test should fail before the fix and pass after
+
+### 4. Fix
+- Minimal change. Fix the bug, don't refactor surrounding code.
+- One concern per PR, max 400 lines
+- Follow all coding conventions (TypeScript strict, Tailwind, etc.)
+
+### 5. Verify
+```bash
+npx tsc --noEmit && npm run lint && npm test && npm run build
+```
+
+### 6. Report
+Comment on the issue with:
+- Root cause (one sentence)
+- Fix description (what changed and why)
+- Test added (name and what it covers)
+- Regression risk (low/medium/high with reasoning)
+
+## Severity Classification
+
+| Severity | Definition | Action |
+|----------|-----------|--------|
+| Critical | Core analysis produces incorrect results | Escalate immediately. Revert if merged. |
+| High | Feature broken, no workaround | Fix in current heartbeat |
+| Medium | Feature degraded, workaround exists | Schedule for next heartbeat |
+| Low | Cosmetic, minor UX issue | Create task, prioritize normally |
+
+## Fix-on-Fix Rule
+
+If a fix introduces a new bug, STOP. This is a red flag. Escalate to CTO. Do not stack fixes.

--- a/.claude/skills/frontend-feature/SKILL.md
+++ b/.claude/skills/frontend-feature/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: frontend-feature
+description: >
+  Use this skill when implementing UI components, dashboard features,
+  landing page changes, chart visualizations, or client-side functionality.
+  Don't use for API routes or backend work (use backend-feature),
+  bug fixes (use bug-triage), or code review (use code-review).
+---
+
+# Frontend Feature Development
+
+Implement client-side features following AirwayLab conventions.
+
+## Scope
+
+Your domain:
+- `app/` pages and layouts (NOT app/api/)
+- `components/` all UI components
+- `hooks/` custom React hooks
+- `lib/` client-side utilities (export.ts, persistence.ts, insights.ts, thresholds.ts, analytics.ts, metric-explanations.ts)
+
+NOT your domain:
+- `app/api/` (Backend Engineer)
+- `lib/analyzers/`, `lib/parsers/`, `workers/` (PROTECTED -- never modify)
+
+## Pre-Implementation
+
+1. Check if a spec exists in `specs/` for this feature
+2. Glob + Grep for existing implementations -- build only the delta
+3. Check `components/ui/` for available shadcn/ui primitives
+
+## Code Standards
+
+- Server Components by default. `'use client'` only for state/effects/browser APIs.
+- shadcn/ui with @base-ui/react (NOT Radix)
+- Recharts 3.8 for charts (include "airwaylab.app" watermark)
+- Tailwind only for styling
+- `airwaylab_` prefix for localStorage keys
+- Named exports (default only for page/layout)
+- Medical disclaimer on health-related output
+- Check lib/analytics.ts for Plausible helpers when adding user-facing features
+
+## Privacy Architecture
+
+- Tier 1 (browser-only, default): no network requests for health data
+- Tier 2 (opt-in): requires explicit consent
+- If the feature touches health data without consent, it MUST stay Tier 1
+
+## Build Checks (MANDATORY)
+
+```bash
+npx tsc --noEmit && npm run lint && npm test && npm run build
+```
+
+## Common Gotchas
+
+- No src/ directory -- flat structure at root
+- Float32Array not JSON-serialisable -- strip before persisting
+- `NightResult.oximetry` can be null -- always check
+- 4MB localStorage cap -- strip bulk data before saving
+- Feature gate: `canAccess('ai_insights', tier)` for premium features

--- a/.claude/skills/privacy-audit/SKILL.md
+++ b/.claude/skills/privacy-audit/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: privacy-audit
+description: >
+  Use this skill when auditing code changes for GDPR compliance, privacy
+  policy accuracy, data flow verification, or consent mechanism review.
+  Don't use for MDR SaMD compliance (use mdr-compliance-check) or
+  general code review (use code-review).
+---
+
+# Privacy Audit
+
+Verify that code changes comply with GDPR and AirwayLab's privacy architecture.
+
+## Privacy Architecture
+
+### Tier 1 -- Browser-only (default)
+All core analysis runs client-side in a Web Worker. No data leaves the browser. No network requests for health data. Results persist in localStorage (airwaylab_ prefix, 30-day expiry, 4MB cap).
+
+### Tier 2 -- Server-enhanced (opt-in)
+Users explicitly opt in to: AI-powered insights (sends metrics, never raw waveforms), data contribution (anonymised aggregate metrics to Supabase), premium features behind `ailab-beta-2026` gate. Every server interaction requires informed, affirmative consent.
+
+## Audit Checklist
+
+### 1. Data Flow Verification
+- Does any new feature send health data to a server?
+- If yes, is there an explicit consent step?
+- Is the consent informed (user knows what data, where it goes, how long it's kept)?
+
+### 2. Storage Compliance
+- New server-side health data storage must document:
+  - Retention period
+  - Deletion mechanism (for DSAR requests)
+  - Who has access
+- Account deletion must be fulfillable within 30 days
+
+### 3. Third-Party Integrations
+- New integrations must be added to Privacy Policy processor list BEFORE deployment
+- Verify data processing agreements are in place
+
+### 4. Consent Mechanisms
+- Automated processing of health data requires GDPR Article 22 informed consent
+- Use the existing consent component (e.g. components/share/share-consent-modal.tsx or components/dashboard/ai-insights-gate.tsx) or equivalent
+- Consent must be: freely given, specific, informed, unambiguous
+
+### 5. Privacy Policy Accuracy
+- Verify /privacy page reflects all current data flows
+- Check processor table is complete
+- Verify retention periods are documented
+
+## Output Format
+
+```
+## Privacy Audit
+
+**Verdict:** PASS / FAIL / NEEDS_REVIEW
+
+### Data Flow
+- [New data flows identified: yes/no]
+- [Consent mechanism present: yes/no]
+
+### Storage
+- [New data stores: list with retention + deletion path]
+
+### Third-Party
+- [New integrations: list with privacy policy status]
+
+### Recommendations
+- [prioritized fixes]
+```

--- a/.claude/skills/release-management/SKILL.md
+++ b/.claude/skills/release-management/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: release-management
+description: >
+  Use this skill when preparing a release, updating the changelog, or managing
+  the deployment pipeline. Use after a set of features have been merged and
+  are ready for production.
+  Don't use for individual feature PRs or bug fixes.
+---
+
+# Release Management
+
+Manage AirwayLab releases, changelogs, and post-deploy verification.
+
+## Release Checklist
+
+### Pre-Release
+1. All PRs for this release are merged to main
+2. Full pipeline passes on main:
+   ```bash
+   npx tsc --noEmit && npm run lint && npm test && npm run build
+   ```
+3. Changelog updated at `app/changelog/page.tsx`
+4. Version bumped if applicable
+
+### Changelog Entry Format
+```
+## v0.X.Y — [Date]
+
+### Added
+- [Feature description with user-facing impact]
+
+### Fixed
+- [Bug description and resolution]
+
+### Changed
+- [Modification and why]
+```
+
+Keep entries user-focused. "Added oximetry H1/H2 split comparison" not "Refactored OximetryResult interface to include half-split arrays."
+
+### Deployment
+AirwayLab deploys via Vercel on push to main. After merge:
+
+1. Wait for Vercel build to complete
+2. Check Vercel deployment logs for errors
+3. Run post-deploy verification
+
+### Post-Deploy Verification
+
+Create a verification checklist issue assigned to the board (human) with these items:
+1. **Smoke test** -- Upload SD card data on airwaylab.app. Full pipeline: upload -> parse -> analyze -> all dashboard tabs.
+2. **Feature check** -- The specific feature from the release works on production.
+3. **Regression spot-check** -- 2-3 adjacent features that share components or state.
+4. **Console check** -- DevTools shows no new errors or warnings.
+5. **Mobile check** -- Changed area renders correctly on mobile viewport.
+
+Agent-verifiable checks (do these directly):
+6. **Build logs** -- Verify Vercel build completed without errors.
+7. **API health** -- Check /api/health endpoint responds 200.
+
+### Rollback Protocol
+If something breaks:
+1. Assess severity: core analysis broken = revert immediately. Cosmetic = hotfix.
+2. Revert first, investigate second: `git revert <commit> && git push`
+3. Hotfix via normal PR process (don't skip checks)
+4. Post-incident note on the PR
+
+## Cross-Team Announcement
+
+After a successful release, create an announcement task for the Head of Growth:
+- Feature name and version
+- User-facing impact (one sentence)
+- Suggested messaging angle for community/blog/email
+
+This ensures the growth team can announce new features promptly.
+
+## Output Format
+
+Comment on the release task with:
+- Version number
+- Changelog entry (for review)
+- Post-deploy verification results (pass/fail per check)
+- Announcement task created for Head of Growth (yes/no)
+- Any issues found

--- a/.claude/skills/test-coverage-audit/SKILL.md
+++ b/.claude/skills/test-coverage-audit/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: test-coverage-audit
+description: >
+  Use this skill when auditing test coverage, identifying untested code paths,
+  or planning test writing priorities. Use periodically or after significant
+  code changes.
+  Don't use for implementing individual bug fix tests (use bug-triage) or
+  build verification (run checks directly).
+---
+
+# Test Coverage Audit
+
+Identify gaps in test coverage and prioritize test writing.
+
+## Audit Process
+
+### 1. Scan for Untested Code
+- Cross-reference source files against __tests__/*.test.ts
+- Identify modules with no corresponding test file
+- Check test files for coverage of edge cases
+
+### 2. Priority Classification
+
+| Priority | What to test | Why |
+|----------|-------------|-----|
+| Critical | Analysis engines output (Glasgow, WAT, NED, Oximetry) | Wrong results = clinical harm |
+| Critical | API route validation (auth, input sanitization) | Security boundary |
+| High | Export functions (CSV, JSON, PDF, forum) | User-facing data integrity |
+| High | Persistence (save/load with schema migration) | Data loss risk |
+| Medium | UI component rendering (dashboard tabs) | User experience |
+| Medium | Insight generation (thresholds, traffic lights) | Misleading health info |
+| Low | Utility functions (cn, date formatting) | Low blast radius |
+
+### 3. Test Quality Check
+Review existing tests for:
+- Do they test behavior or implementation details?
+- Do they cover edge cases (null oximetry, multi-session nights, empty data)?
+- Do they use synthetic data helpers correctly?
+- Are assertions specific enough to catch regressions?
+
+### 4. E2E Coverage
+Map critical user flows that need Playwright tests:
+- Upload -> parse -> analyze -> dashboard (full pipeline)
+- Login -> premium feature access
+- Export (CSV, PDF, forum format)
+- Settings persistence
+
+## Testing Conventions
+
+- Vitest 4.0, jsdom, @testing-library/jest-dom
+- __tests__/*.test.ts(x) -- flat directory
+- Synthetic data via helpers (makeSineWave, etc.)
+- @/ path alias for imports
+
+## Output Format
+
+```
+## Test Coverage Audit
+
+**Overall coverage:** [assessment]
+
+### Critical Gaps
+- [module] -- [what's untested] -- [risk]
+
+### Recommended Test Plan
+1. [highest priority test to write]
+2. [next priority]
+...
+
+### Existing Test Quality
+- [issues found in current tests]
+```


### PR DESCRIPTION
## What
Adds 5 net-new Claude Code skills and the engine-reference rule, recovered from a development framework that was built locally and never committed.

- bug-triage, privacy-audit, test-coverage-audit, release-management, frontend-feature
- .claude/rules/engine-reference.md (analysis-engine summary, verified accurate)

## Why
These were sitting uncommitted in a local checkout (now preserved on branch chore/preserve-dev-framework-snapshot). Reviewed against origin/main: no overlap with the CI gates (clinical-gate, mdr-string-check, dependency-review, claude-code-review) or the built-in /code-review and /security-review skills.

## Fixes vs the original
- bug-triage: corrected a dangling skill reference (feature-development to backend-feature/frontend-feature)
- privacy-audit: corrected the consent component name to the real files

## Held for a later pass
code-review, mdr-compliance-check, ai-prompt-audit (overlap existing mechanisms), directory-structure.md (stale counts), development-workflow.md (duplicate of the CLAUDE.md section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
