### PR TITLE
feat(skills): add backend-feature + dependency-audit skills

### DIFF
--- a/.claude/skills/backend-feature/SKILL.md
+++ b/.claude/skills/backend-feature/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: backend-feature
+description: >
+  Use this skill when implementing API routes, Supabase integration,
+  authentication, webhooks, database migrations, or server-side functionality.
+  Don't use for UI components (use frontend-feature), bug fixes (use bug-triage),
+  or code review (use code-review).
+---
+
+# Backend Feature Development
+
+Implement server-side features following AirwayLab conventions.
+
+## Scope
+
+Your domain:
+- `app/api/` all API routes
+- `lib/auth/` authentication context, feature gating
+- `lib/ai-insights-client.ts` AI insights fetcher
+- `supabase/migrations/` database migrations (append-only)
+
+NOT your domain:
+- `app/` pages (Frontend Engineer)
+- `components/` (Frontend Engineer)
+- `lib/analyzers/`, `lib/parsers/`, `workers/` (PROTECTED -- never modify)
+
+## Critical Security Rules
+
+- EVERY API route MUST have auth middleware
+- EVERY new Supabase table MUST have RLS enabled
+- NEVER hardcode secrets -- use process.env with Zod validation
+- NEVER send health data without explicit user consent
+- NEVER store health data server-side without documenting retention + deletion path
+- Migrations are append-only -- NEVER edit existing files
+- All new env vars MUST be added to .env.example
+
+## AI Insights Rules
+
+- AI system prompts describe data only
+- NEVER suggest actions, adjustments, or investigations
+- Always include medical disclaimer in AI output
+- Two-tier model: Claude Haiku for community, Claude Sonnet 4.6 for premium (see app/api/ai-insights/route.ts). Do not change models without discussion (cost constraint)
+
+## Build Checks (MANDATORY)
+
+```bash
+npx tsc --noEmit && npm run lint && npm test && npm run build
+```
+
+## Testing
+
+- Vitest for unit tests
+- Test API validation, auth middleware, edge cases
+- Tests in __tests__/*.test.ts
+- Tests ship with the code
+
+## Database Conventions
+
+- Supabase EU region (GDPR)
+- RLS on every table
+- Document retention period for health-related data
+- Ensure deletion path for DSAR requests
+- New third-party integrations must be added to Privacy Policy processor list

--- a/.claude/skills/dependency-audit/SKILL.md
+++ b/.claude/skills/dependency-audit/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: dependency-audit
+description: >
+  Use this skill when auditing project dependencies for security vulnerabilities,
+  outdated packages, or unnecessary bloat. Use on a monthly cadence or when
+  a security advisory is reported. Complements the dependency-review CI gate
+  (which only blocks high-severity new deps on PRs) with a proactive audit.
+  Don't use for feature development or bug fixes.
+---
+
+# Dependency Audit
+
+Audit AirwayLab's npm dependencies for security, freshness, and bundle impact.
+
+## Audit Steps
+
+### 1. Security Check
+```bash
+npm audit
+```
+Review all findings. Critical and high severity issues require immediate action.
+
+### 2. Outdated Packages
+```bash
+npm outdated
+```
+Identify packages with available updates. Prioritize:
+- Security patches (always update)
+- Minor versions of core dependencies (Next.js, React, TypeScript)
+- Major versions (evaluate breaking changes first)
+
+### 3. Bundle Size Impact
+Check current bundle size:
+```bash
+npm run build
+```
+Review the build output for any package contributing >50KB to the client bundle.
+
+### 4. Unused Dependencies
+Cross-reference `package.json` dependencies against actual imports in the codebase. Flag any dependency that has zero imports.
+
+## Key Constraints
+
+- **NEVER install new dependencies without CTO/board discussion.** Each dependency is maintenance cost against the 2hr/week budget.
+- **NEVER update a major version without testing.** Run the full check suite after any update.
+- **Bundle size budget:** Flag any change increasing bundle >10KB.
+
+## Core Dependencies to Watch
+
+| Package | Role | Update Risk |
+|---------|------|-------------|
+| next | Framework | High -- test thoroughly |
+| react / react-dom | UI | High -- test thoroughly |
+| typescript | Type system | Medium |
+| tailwindcss | Styling | Medium |
+| recharts | Charts | Medium -- visual regression |
+| @supabase/supabase-js | Auth + DB | Medium |
+| zod | Validation | Low |
+| vitest | Testing | Low |
+
+## Output Format
+
+```
+## Dependency Audit — [Date]
+
+### Security
+- [Critical/High/Medium findings with package names]
+
+### Outdated
+| Package | Current | Latest | Priority |
+|---------|---------|--------|----------|
+| ... | ... | ... | update/skip/evaluate |
+
+### Bundle Impact
+- Total client bundle: [size]
+- Largest contributors: [list]
+
+### Recommendation
+[Single recommended action]
+```


### PR DESCRIPTION
## What
Adds two more skills from the recovered local framework (preserved on chore/preserve-dev-framework-snapshot):
- backend-feature: API routes, Supabase, auth, migration conventions
- dependency-audit: proactive periodic dependency sweep

## Fixes vs the original
- backend-feature: the original said "use Claude Haiku"; the shipped route is two-tier (Haiku community / Sonnet 4.6 premium, app/api/ai-insights/route.ts). Corrected so an agent does not flag Sonnet as a violation.
- dependency-audit: scoped its description to complement the dependency-review CI gate (which only blocks high-severity new deps on PRs), not duplicate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
