### PR TITLE
feat(feedback): fan out every report to email + Discord, stamp feedback id

### DIFF
--- a/__tests__/api-routes.test.ts
+++ b/__tests__/api-routes.test.ts
@@ -122,7 +122,15 @@ function setupDefaultMocks() {
     limit: vi.fn().mockReturnValue({ data: [], error: null }),
     maybeSingle: vi.fn().mockReturnValue({ data: { stripe_customer_id: 'cus_existing' }, error: null }),
     single: vi.fn().mockReturnValue({ data: { stripe_customer_id: 'cus_existing' }, error: null }),
-    insert: vi.fn().mockReturnValue({ error: null }),
+    // Supports both `await insert(...)` -> { error } and the feedback path
+    // `insert(...).select('id').single()` -> { data: { id }, error }.
+    insert: vi.fn().mockReturnValue({
+      error: null,
+      then: (resolve: (v: { error: null }) => unknown) => resolve({ error: null }),
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockReturnValue({ data: { id: 'feedback-test-id' }, error: null }),
+      }),
+    }),
     update: vi.fn().mockReturnThis(),
     upsert: vi.fn().mockReturnValue({ error: null }),
   };

--- a/lib/discord-webhook.ts
+++ b/lib/discord-webhook.ts
@@ -503,6 +503,7 @@ export function formatUserSignalEmbed(opts: {
   message?: string
   email?: string
   name?: string
+  feedbackId?: string
 }): DiscordEmbed {
   const titles: Record<string, string> = {
     feedback: ':speech_balloon: User Feedback',
@@ -524,10 +525,12 @@ export function formatUserSignalEmbed(opts: {
   if (opts.category) fields.push({ name: 'Category', value: opts.category, inline: true })
   if (opts.email) fields.push({ name: 'Email', value: opts.email, inline: true })
   if (opts.name) fields.push({ name: 'Name', value: opts.name, inline: true })
+  if (opts.feedbackId) fields.push({ name: 'Ref', value: opts.feedbackId, inline: true })
 
   return {
     title: titles[opts.type] ?? opts.type,
-    description: opts.message ? opts.message.slice(0, 500) : undefined,
+    // #user-signals is admin-only, so carry the full report (Discord embed cap is 4096).
+    description: opts.message ? opts.message.slice(0, 4000) : undefined,
     color: colors[opts.type] ?? COLORS.blue,
     fields,
     footer: { text: 'airwaylab.app' },

--- a/lib/services/feedback-service.ts
+++ b/lib/services/feedback-service.ts
@@ -1,7 +1,7 @@
 import { ResultAsync, okAsync } from 'neverthrow'
 import type { AppError } from '@/lib/errors'
 import { getSupabaseAdmin } from '@/lib/supabase/server'
-import { supabaseInsert } from './supabase-helpers'
+import { supabaseQuery } from './supabase-helpers'
 import { sendEmail } from '@/lib/email/send'
 import { sendAlert, formatUserSignalEmbed } from '@/lib/discord-webhook'
 
@@ -31,9 +31,11 @@ const TYPE_LABELS: Record<string, string> = {
 /**
  * Persists feedback to Supabase and fires notifications.
  *
- * Notification routing:
- * - Bug reports → email (dev@airwaylab.app) + Discord (with @mention)
- * - All other types → Discord only
+ * Notification routing (every type fans out to all three trails):
+ * - Email (dev@airwaylab.app) + Discord (#user-signals, admin-only) for ALL types
+ * - Bug reports additionally @mention the admin in Discord
+ * The feedback row id is stamped into both trails so triage can reconcile the
+ * GitHub issue it opens against the Supabase source of truth.
  *
  * This function owns the business logic; HTTP concerns (auth, CSRF,
  * rate limiting, Zod validation) stay in the API route.
@@ -52,7 +54,7 @@ export function submitFeedback(
     return okAsync({ ok: true as const })
   }
 
-  return supabaseInsert(
+  return supabaseQuery<{ id: string }>(
     supabase.from('feedback').insert({
       message: `[${input.type}] ${input.message.trim()}`,
       email: input.email?.trim() || null,
@@ -61,41 +63,41 @@ export function submitFeedback(
       contact_ok: input.contact_ok ?? false,
       type: input.type,
       metadata: input.metadata ?? null,
-    }),
+    }).select('id').single(),
     'feedback',
-  ).map((result) => {
+  ).map((row) => {
+    const feedbackId = row.id
     const label = TYPE_LABELS[input.type] ?? 'Feedback'
     const meta = (input.metadata ?? {}) as Record<string, unknown>
 
-    // Admin email only for bug reports (feature requests / ideas → Discord only)
-    if (input.type === 'bug') {
-      void sendEmail({
-        to: 'dev@airwaylab.app',
-        subject: `${label}: ${input.message.slice(0, 60)}${input.message.length > 60 ? '...' : ''}`,
-        text: [
-          `New ${label.toLowerCase()} on airwaylab.app`,
-          '',
-          `Type: ${label}`,
-          `Page: ${input.page ?? '\u2014'}`,
-          `Email: ${input.email?.trim() ?? '\u2014'}`,
-          `Contact OK: ${input.contact_ok ? 'Yes' : 'No'}`,
-          `User ID: ${input.user_id ?? '\u2014'}`,
-          `Tier: ${meta.user_tier ?? '\u2014'}`,
-          `Display name: ${meta.display_name ?? '\u2014'}`,
-          '',
-          'Message:',
-          input.message.trim(),
-          '',
-          '\u2500\u2500 Context \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500',
-          `App version: ${meta.app_version ?? '\u2014'}`,
-          `Browser: ${typeof meta.user_agent === 'string' ? meta.user_agent.slice(0, 120) : '\u2014'}`,
-          `Screen: ${meta.screen_width ?? '?'}x${meta.screen_height ?? '?'} (viewport: ${meta.viewport_width ?? '?'}x${meta.viewport_height ?? '?'})`,
-          `Timezone: ${meta.timezone ?? '\u2014'}`,
-          `Has analysis: ${meta.has_analysis_results === true ? 'Yes' : meta.has_analysis_results === false ? 'No' : '\u2014'}`,
-        ].join('\n'),
-        metadata: { emailType: 'admin_feedback' },
-      })
-    }
+    // Admin email for EVERY feedback type (internal inbox, full context incl. PHI)
+    void sendEmail({
+      to: 'dev@airwaylab.app',
+      subject: `${label}: ${input.message.slice(0, 60)}${input.message.length > 60 ? '...' : ''}`,
+      text: [
+        `New ${label.toLowerCase()} on airwaylab.app`,
+        '',
+        `Feedback ID: ${feedbackId}`,
+        `Type: ${label}`,
+        `Page: ${input.page ?? '\u2014'}`,
+        `Email: ${input.email?.trim() ?? '\u2014'}`,
+        `Contact OK: ${input.contact_ok ? 'Yes' : 'No'}`,
+        `User ID: ${input.user_id ?? '\u2014'}`,
+        `Tier: ${meta.user_tier ?? '\u2014'}`,
+        `Display name: ${meta.display_name ?? '\u2014'}`,
+        '',
+        'Message:',
+        input.message.trim(),
+        '',
+        '\u2500\u2500 Context \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500',
+        `App version: ${meta.app_version ?? '\u2014'}`,
+        `Browser: ${typeof meta.user_agent === 'string' ? meta.user_agent.slice(0, 120) : '\u2014'}`,
+        `Screen: ${meta.screen_width ?? '?'}x${meta.screen_height ?? '?'} (viewport: ${meta.viewport_width ?? '?'}x${meta.viewport_height ?? '?'})`,
+        `Timezone: ${meta.timezone ?? '\u2014'}`,
+        `Has analysis: ${meta.has_analysis_results === true ? 'Yes' : meta.has_analysis_results === false ? 'No' : '\u2014'}`,
+      ].join('\n'),
+      metadata: { emailType: 'admin_feedback' },
+    })
 
     // Discord notification for all feedback types
     // Personal mention for bugs so admin gets pinged
@@ -109,8 +111,9 @@ export function submitFeedback(
       category: label,
       message: input.message.trim(),
       email: input.email?.trim() ?? undefined,
+      feedbackId,
     })])
 
-    return result
+    return { ok: true as const }
   })
 }


### PR DESCRIPTION
## What
Every feedback type (bug / feature / "other") now fans out to all three trails, not just bugs:
- **Email** to `dev@airwaylab.app` for ALL types (was bug-only) with full context + `Feedback ID`
- **Discord `#user-signals`** (admin-only) carries the **full report** — embed truncation raised 500 → 4000 chars — plus a `Ref` field with the feedback id
- The Supabase `feedback.id` is stamped into both trails so the new `awl-triage` pipeline can reconcile the GitHub issue it opens against the source of truth

## Why
User feedback had no GitHub trail and no investigation path. This is the product half of the feedback-triage work: a complete, reconcilable paper trail. The agent half (the `awl-triage` skill + helper) lives in the ops repo and reads Supabase as the source of truth.

## Notes
- Insert now returns the id via `.select('id').single()` (`supabaseQuery` instead of `supabaseInsert`). No new route, no migration, no schema change.
- **PHI:** email + Discord are internal/admin-only, so full text is fine there. Public GitHub issues stay structured-only (handled by the triage skill, not this PR).
- Test mock updated for the `insert().select().single()` chain.

## Verification (local, against fresh origin/main)
- `vitest` api-routes 28/28, feedback + discord suites 61/61
- `tsc --noEmit` 0 errors, `eslint` clean on changed files, mutation guard clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)