### PR TITLE
chore(framework): ship reworked ai-prompt-audit, fix CLAUDE.md test-count

### DIFF
--- a/.claude/skills/ai-prompt-audit/SKILL.md
+++ b/.claude/skills/ai-prompt-audit/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: ai-prompt-audit
+description: >
+  Use this skill when reviewing or auditing the AI insights system prompt for
+  hallucination risk, prompt quality, output reliability, and cost. MDR language
+  is delegated to the mdr-compliance-check skill + mdr-string-check CI.
+  Don't use for general MDR audits (use mdr-compliance-check) or code review
+  (use code-review).
+---
+
+# AI Prompt Audit
+
+Review the AI insights system prompt and pipeline for quality, hallucination risk, reliability, and cost.
+
+## What to Audit
+
+### 1. System Prompt (app/api/ai-insights/)
+- Does it describe data only? (MUST -- no action suggestions)
+- Does it include medical disclaimer instruction?
+- Does it reference the specific metrics being sent?
+- Are there guardrails against hallucination? (e.g., "only reference metrics provided")
+- Does it instruct the model to say "I don't know" when uncertain?
+
+### 2. MDR Language (delegated)
+MDR language risk in AI output is owned by the `mdr-compliance-check` skill, the `mdr-string-check` CI gate, and `.claude/rules/mdr-compliance.md`. Do not duplicate those checks here. If a prompt change touches MDR-relevant wording, run that gate. Keep one prompt-level invariant: the system prompt MUST NOT instruct the model to suggest actions.
+
+### 3. Data Sent to API
+- Only aggregated metrics sent, never raw waveforms
+- No personally identifiable information in the payload
+- User has explicitly consented to Tier 2 (server-enhanced) analysis
+
+### 4. Output Quality
+- Are responses consistent across similar inputs?
+- Does the model stay within the scope of provided data?
+- Are numerical references accurate (does it cite the actual values sent)?
+- Does it make up data points not in the input?
+
+### 5. Cost Efficiency
+- Is the model tier right? Community uses Claude Haiku, premium uses Claude Sonnet 4.6 (cost constraint; see app/api/ai-insights/route.ts)
+- Are token counts reasonable for the input size?
+- Could the prompt be shorter without losing quality?
+
+## Audit Output
+
+```
+## AI Prompt Audit -- [Date]
+
+### System Prompt
+**Version:** [hash or last-modified date]
+**Token count:** [input prompt tokens]
+
+### MDR Compliance
+**Verdict:** PASS / FAIL
+- [specific findings]
+
+### Hallucination Risk
+**Risk level:** Low / Medium / High
+- [guardrails present/missing]
+- [failure modes identified]
+
+### Data Privacy
+- Metrics only (no raw waveforms): [yes/no]
+- Consent verified before send: [yes/no]
+
+### Recommendations
+- [prioritized improvements]
+```

--- a/.claude/skills/ai-prompt-audit/SKILL.md
+++ b/.claude/skills/ai-prompt-audit/SKILL.md
@@ -49,9 +49,9 @@ MDR language risk in AI output is owned by the `mdr-compliance-check` skill, the
 **Version:** [hash or last-modified date]
 **Token count:** [input prompt tokens]
 
-### MDR Compliance
-**Verdict:** PASS / FAIL
-- [specific findings]
+### MDR (delegated)
+Ran `mdr-compliance-check` + `mdr-string-check`: [yes / no]
+- [MDR findings belong to that skill, not here]
 
 ### Hallucination Risk
 **Risk level:** Low / Medium / High

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ airwaylab/
 ├── hooks/                  → Custom React hooks (client-side only)
 ├── __tests__/              → Vitest test files
 │   ├── setup.ts            → Test setup (@testing-library/jest-dom)
-│   └── *.test.ts           → 16 test files covering engines, exports, insights, etc.
+│   └── *.test.ts           → Vitest test files covering engines, exports, insights, etc.
 ├── supabase/
 │   └── migrations/         → Database migrations (append-only, never edit existing)
 │       └── NEXT_MIGRATION  → Next available migration number (increment in same commit as new migration)


### PR DESCRIPTION
## What
Lands the last reworked piece of the recovered dev framework.

- **ai-prompt-audit skill** (reworked): removed the MDR Language section (it duplicated `mdr-compliance-check` + the `mdr-string-check` CI gate); fixed the stale single-model assumption to the two-tier reality (community Haiku / premium Sonnet 4.6).
- **CLAUDE.md**: the Directory Structure tree said "16 test files"; de-numericized it to avoid drift.

## Dropped (not shipped)
`directory-structure.md` is a near-verbatim duplicate of the CLAUDE.md Directory Structure section, so it is not shipped. Its only unique content was the stale 0-8 Glasgow range, which CLAUDE.md already has correct at 0-9.

This completes the framework rework. Held items `code-review` and `mdr-compliance-check` stay unshipped (they duplicate existing CI/built-ins); `development-workflow.md` stays unshipped (duplicate of the CLAUDE.md section). All remain on `chore/preserve-dev-framework-snapshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
