### PR TITLE
fix(mdr): replace RERA detection clinical term in app pages (AIR-2509)

### DIFF
--- a/app/about/flow-limitation/page.tsx
+++ b/app/about/flow-limitation/page.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
     'PAP partial obstruction', 'UARS', 'RERA', 'ResMed flow data',
     'PAP pressure too low', 'flow limitation treatment',
     'OSCAR flow limitation', 'PAP therapy optimisation',
-    'WAT analysis', 'NED analysis', 'RERA detection', 'flow limitation PAP',
+    'WAT analysis', 'NED analysis', 'effort-pattern analysis', 'flow limitation PAP',
   ],
   alternates: {
     canonical: 'https://airwaylab.app/about/flow-limitation',
@@ -101,7 +101,7 @@ const detectionMethods = [
     borderColor: 'border-amber-500/20',
     bgColor: 'bg-amber-500/5',
     approach:
-      'Measures the ratio of peak-to-mid inspiratory flow (Negative Effort Dependence) to quantify airway narrowing. Also detects M-shaped breaths and automated RERA event sequences.',
+      'Measures the ratio of peak-to-mid inspiratory flow (Negative Effort Dependence) to quantify airway narrowing. Also identifies M-shaped breaths and progressive effort-related breathing patterns.',
     link: '/about',
   },
 ];

--- a/app/guides/[device]/page.tsx
+++ b/app/guides/[device]/page.tsx
@@ -295,7 +295,7 @@ export default async function DeviceGuidePage({ params }: PageProps) {
           </h2>
           <p className="mb-4 text-sm text-muted-foreground">
             Upload your SD card and see flow limitation scores, breath shape
-            analysis, and RERA detection in seconds. Free and private.
+            analysis, and effort-pattern analysis in seconds. Free and private.
           </p>
           <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
             <Link href="/analyze">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -157,7 +157,7 @@ const landingFaqData = [
   {
     question: 'What is AirwayLab?',
     answer:
-      'AirwayLab is a free, open-source web tool that analyses ResMed CPAP and BiPAP SD card data using four research-grade engines: Glasgow Index (breath shape scoring), WAT (flow limitation and periodicity), NED (negative effort dependence and RERA detection), and Oximetry (SpO2 and heart rate analysis). All analysis runs entirely in your browser. No data is uploaded to any server unless you choose to share it.',
+      'AirwayLab is a free, open-source web tool that analyses ResMed CPAP and BiPAP SD card data using four research-grade engines: Glasgow Index (breath shape scoring), WAT (flow limitation and periodicity), NED (negative effort dependence and effort-pattern analysis), and Oximetry (SpO2 and heart rate analysis). All analysis runs entirely in your browser. No data is uploaded to any server unless you choose to share it.',
   },
   {
     question: 'Is AirwayLab free?',

--- a/app/providers/page.tsx
+++ b/app/providers/page.tsx
@@ -376,7 +376,7 @@ export default function ProvidersPage() {
               <h3 className="text-sm font-semibold text-foreground">How does this compare to OSCAR?</h3>
               <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
                 OSCAR is a desktop application for interactive waveform browsing. AirwayLab adds
-                automated flow limitation scoring (Glasgow Index, NED, WAT), RERA detection, and
+                automated flow limitation scoring (Glasgow Index, NED, WAT), effort-pattern analysis, and
                 composite metrics that OSCAR doesn&apos;t compute. Many providers use both. See our{' '}
                 <Link href="/blog" className="text-primary hover:text-primary/80">
                   comparison article

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'For Researchers — AirwayLab',
     description:
-      'Large-scale anonymised PAP therapy dataset for sleep science research. Collaborate with us on flow limitation, RERA detection, and breathing pattern analysis.',
+      'Large-scale anonymised PAP therapy dataset for sleep science research. Collaborate with us on flow limitation, effort-pattern analysis, and breathing pattern analysis.',
   },
   alternates: {
     canonical: 'https://airwaylab.app/research',
@@ -168,7 +168,7 @@ const pipelineSteps = [
 const collaborationItems = [
   'Access to anonymised, aggregate breathing metrics from thousands of real-world therapy nights',
   'Validation partnerships for our analysis engines (Glasgow Index, WAT, NED) against clinical gold-standard measurements',
-  'Joint research on flow limitation patterns, RERA detection, and the relationship between breathing metrics and patient outcomes',
+  'Joint research on flow limitation patterns, effort-pattern analysis, and the relationship between breathing metrics and patient outcomes',
   'Open-source codebase (GPL-3.0) \u2014 adapt our algorithms for your research, contribute improvements back',
 ];
 

--- a/app/shared/[id]/page.tsx
+++ b/app/shared/[id]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   const { id } = await params;
   const fallback: Metadata = {
     title: 'Shared Analysis | AirwayLab',
-    description: 'View a shared PAP therapy analysis with flow limitation scores, Glasgow Index, and RERA detection.',
+    description: 'View a shared PAP therapy analysis with flow limitation scores, Glasgow Index, and effort-pattern analysis.',
     robots: { index: false, follow: false },
   };
 


### PR DESCRIPTION
## Summary

Proactive MDR scan found 8 additional violations beyond the compare pages (AIR-2481 / PR #963).

Replaces 'RERA detection' / 'detects...RERA event sequences' with 'effort-pattern analysis' / 'progressive effort-related breathing patterns' — consistent with PR #963 precedent.

## Files changed

- `app/page.tsx` — landing page FAQ / JSON-LD answer
- `app/shared/[id]/page.tsx` — shared analysis meta description
- `app/guides/[device]/page.tsx` — guide CTA copy
- `app/providers/page.tsx` — providers FAQ answer
- `app/research/page.tsx` — OG description (x1) and collaboration list (x1)
- `app/about/flow-limitation/page.tsx` — SEO keywords (x1) and engine card (x1)

## MDR self-review (AIR-2509)

- [x] No therapeutic recommendations
- [x] No diagnostic claims — 'RERA detection'/'detects RERA sequences' removed
- [x] No predictive claims
- [x] No clinical effectiveness judgments
- [x] Disclaimers intact on all changed pages
- [x] No AI prompt changes

## Pre-merge checklist

- [x] lint / typecheck / 2689 tests all pass
- [ ] Vercel preview verified by Demian
- [x] One concern only (MDR text fixes, no logic changes)

> Per AIR-2139: author != reviewer. CTO must review before merge.

Generated with [Claude Code](https://claude.com/claude-code)