### PR TITLE
fix(flow-analysis): label RERA Count with a unit (#974)

### DIFF
--- a/components/dashboard/flow-analysis-tab.tsx
+++ b/components/dashboard/flow-analysis-tab.tsx
@@ -153,8 +153,9 @@ export function FlowAnalysisTab({ selectedNight, previousNight, nights = [] }: P
             label="RERA Count"
             value={n.ned.reraCount}
             format="int"
+            unit="events"
             previousValue={p?.ned.reraCount}
-            tooltip="Total number of detected RERA events during the entire session."
+            tooltip="Total number of RERA events for the whole night. This is the raw count -- the per-hour rate is shown as RERA Index above."
             onClick={clickable ? () => openMetric('RERA Count', (x) => x.ned.reraCount) : undefined}
           />
           <MetricCard


### PR DESCRIPTION
Closes #974.

**Not a calculation bug.** A user reported RERA "shows 1 on the graph but 12 in the list". Those are two correct, distinct metrics: `reraIndex` (RERA Index, ~1/hr) and `reraCount` (RERA Count, ~12 events/night), shown side by side on Flow Analysis. The Count card rendered a bare integer with no unit, so the two numbers read as a contradiction (the reporter noted limited English).

## Change
- `components/dashboard/flow-analysis-tab.tsx`: add `unit="events"` to the RERA Count card and clarify its tooltip to point at RERA Index for the per-hour rate.

No change to `lib/analyzers` or any calculation. Purely a label/clarity tweak.

> Clinical-surface copy — needs `clinical-signoff` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)