### PR TITLE
fix(ai-insights): pin temperature to 0 for stable output (#976)

### DIFF
--- a/app/api/ai-insights/route.ts
+++ b/app/api/ai-insights/route.ts
@@ -666,6 +666,10 @@ export async function POST(request: NextRequest) {
     const message = await client.messages.create({
       model,
       max_tokens: maxTokens,
+      // Deterministic output: the same night must yield the same insights on
+      // refresh. Without this, temperature defaults to 1.0 and the insight count
+      // drifts between calls (reported bug #976).
+      temperature: 0,
       system: systemPrompt,
       messages: [
         {


### PR DESCRIPTION
Closes #976.

User reported AI Insights returns a different number of insights for the same night on refresh.

**Root cause:** `client.messages.create` in `app/api/ai-insights/route.ts` set no `temperature`, so it defaulted to 1.0 and the model re-rolled different output (and counts) each call. Insights are also not cached, so every refresh regenerates.

## Change
- Set `temperature: 0` on the insights model call.

This makes output stable across refreshes for the same input. Full byte-identical determinism would additionally need per-(user, night) caching so a refresh returns the stored set without re-calling the model — noted as a follow-up (table + migration).

> Clinical-surface (insights interpret therapy data) — `clinical-review-required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)