### PR TITLE
fix(oximetry): surface CSV upload failures instead of false "data added" (#988)

### DIFF
--- a/__tests__/oximetry-csv-parser.test.ts
+++ b/__tests__/oximetry-csv-parser.test.ts
@@ -281,4 +281,36 @@ describe('parseOximetryCSV → computeOximetry — silent-failure regression', (
     const csv = 'Time, Oxygen Level, Pulse Rate, Motion, O2 Reminder, PR Reminder';
     expect(() => parseOximetryCSV(csv)).toThrow();
   });
+
+  // O2 Insight Pro export: quoted 12h timestamp, unpadded day, trailing comma,
+  // 1s sampling — matching the real reported file structure.
+  function makeO2Ring1sCSV(sampleCount: number): string {
+    const header = 'Time,SpO2(%),Pulse Rate(bpm),Motion,SpO2 Reminder,PR Reminder,';
+    const lines = [header];
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const base = new Date(2026, 5, 4, 22, 48, 53); // Jun 4 2026 22:48:53
+    for (let i = 0; i < sampleCount; i++) {
+      const t = new Date(base.getTime() + i * 1000);
+      const hours = t.getHours();
+      const ampm = hours >= 12 ? 'PM' : 'AM';
+      const h12 = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
+      const hh = String(h12).padStart(2, '0');
+      const mm = String(t.getMinutes()).padStart(2, '0');
+      const ss = String(t.getSeconds()).padStart(2, '0');
+      lines.push(`"${hh}:${mm}:${ss}${ampm} ${months[t.getMonth()]} ${t.getDate()}, ${t.getFullYear()}",96,89,0,0,0,`);
+    }
+    return lines.join('\n');
+  }
+
+  it('full-night file in BOTH real formats yields usable oximetry (the reported files reproduce green)', () => {
+    // ~90 min at 1s sampling survives the 15min+5min buffer trim with thousands of samples.
+    const checkme = parseOximetryCSV(makeCheckme1sCSV(90 * 60));
+    expect(checkme.samples.length).toBe(90 * 60);
+    expect(hasUsableOximetry(computeOximetry(checkme.samples, checkme.intervalSeconds))).toBe(true);
+
+    const o2ring = parseOximetryCSV(makeO2Ring1sCSV(90 * 60));
+    expect(o2ring.samples.length).toBe(90 * 60);
+    expect(hasUsableOximetry(computeOximetry(o2ring.samples, o2ring.intervalSeconds))).toBe(true);
+  });
 });

--- a/__tests__/oximetry-csv-parser.test.ts
+++ b/__tests__/oximetry-csv-parser.test.ts
@@ -5,6 +5,7 @@ import {
   parseO2RingLine,
   parseOximetryCSV,
 } from '@/lib/parsers/oximetry-csv-parser';
+import { computeOximetry, hasUsableOximetry } from '@/lib/analyzers/oximetry-engine';
 
 // ── Format detection ──────────────────────────────────────────
 
@@ -234,5 +235,50 @@ describe('parseOximetryCSV — Checkme format regression', () => {
     const result = parseOximetryCSV(csv);
     // 11:45 PM → hour >= 18 → nightDate = startTime → 2025-01-15
     expect(result.dateStr).toBe('2025-01-15');
+  });
+});
+
+// ── Regression: silent-failure path (issue #988) ──────────────
+// A real-format CSV can parse cleanly yet produce no usable analysis. The bug
+// was that this still showed "Oximetry data added" with every stat 0.0. These
+// lock the boundary the worker now gates on (parse OK → computeOximetry →
+// hasUsableOximetry) and confirm a broken file throws so the worker can surface it.
+
+describe('parseOximetryCSV → computeOximetry — silent-failure regression', () => {
+  // ViHealth/Checkme 1s export, matching the format in the user report.
+  function makeCheckme1sCSV(sampleCount: number): string {
+    const header = 'Time, Oxygen Level, Pulse Rate, Motion, O2 Reminder, PR Reminder';
+    const lines = [header];
+    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const base = new Date(2026, 5, 3, 22, 50, 7); // Jun 3 2026 22:50:07
+    for (let i = 0; i < sampleCount; i++) {
+      const t = new Date(base.getTime() + i * 1000); // 1s sampling (O2Ring S)
+      const hh = String(t.getHours()).padStart(2, '0');
+      const mm = String(t.getMinutes()).padStart(2, '0');
+      const ss = String(t.getSeconds()).padStart(2, '0');
+      const mon = months[t.getMonth()];
+      const day = String(t.getDate()).padStart(2, '0');
+      lines.push(`${hh}:${mm}:${ss} ${mon} ${day} ${t.getFullYear()}, 96, 89, 0, 0, 0`);
+    }
+    return lines.join('\n');
+  }
+
+  it('parses a short recording but yields NO usable oximetry', () => {
+    // 90 seconds of data → wiped by the 15min+5min buffer trim.
+    const csv = makeCheckme1sCSV(90);
+    const parsed = parseOximetryCSV(csv);
+
+    // Parse genuinely succeeds — this is the trap.
+    expect(parsed.samples.length).toBe(90);
+
+    const result = computeOximetry(parsed.samples, parsed.intervalSeconds);
+    expect(hasUsableOximetry(result)).toBe(false);
+    expect(result.spo2Mean).toBe(0);
+  });
+
+  it('throws on a header-only file so the worker can surface it', () => {
+    const csv = 'Time, Oxygen Level, Pulse Rate, Motion, O2 Reminder, PR Reminder';
+    expect(() => parseOximetryCSV(csv)).toThrow();
   });
 });

--- a/__tests__/oximetry-engine.test.ts
+++ b/__tests__/oximetry-engine.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { computeOximetry } from '@/lib/analyzers/oximetry-engine';
+import {
+  computeOximetry,
+  hasUsableOximetry,
+  MIN_USABLE_OXIMETRY_SAMPLES,
+} from '@/lib/analyzers/oximetry-engine';
 import type { OximetrySample } from '@/lib/parsers/oximetry-csv-parser';
 
 // Helper: generate normal SpO2/HR samples over a period
@@ -127,6 +131,41 @@ describe('Oximetry Engine', () => {
       expect(result.tBelow90).toBeLessThanOrEqual(100);
       expect(result.tBelow94).toBeGreaterThanOrEqual(0);
       expect(result.tBelow94).toBeLessThanOrEqual(100);
+    });
+  });
+
+  // Regression guard for the silent-failure bug: a CSV that parses but yields
+  // too little usable data collapses to an all-zero emptyResults() object. That
+  // object is truthy, so the old `!!night.oximetry` gate showed "Oximetry data
+  // added" with every stat 0.0. hasUsableOximetry() must reject it.
+  describe('hasUsableOximetry — silent-failure guard', () => {
+    it('threshold mirrors the engine guard (60)', () => {
+      expect(MIN_USABLE_OXIMETRY_SAMPLES).toBe(60);
+    });
+
+    it('rejects null / undefined', () => {
+      expect(hasUsableOximetry(null)).toBe(false);
+      expect(hasUsableOximetry(undefined)).toBe(false);
+    });
+
+    it('rejects the all-zero result from an insufficient recording', () => {
+      // 1 minute → wiped out by the 15min+5min buffer trim → emptyResults()
+      const result = computeOximetry(makeNormalSamples(1));
+
+      // The object is truthy (the trap the old gate fell into) ...
+      expect(result).toBeTruthy();
+      expect(result.retainedSamples).toBeLessThan(MIN_USABLE_OXIMETRY_SAMPLES);
+      expect(result.spo2Mean).toBe(0);
+      // ... but it must NOT be treated as usable oximetry.
+      expect(hasUsableOximetry(result)).toBe(false);
+    });
+
+    it('accepts a full night with real metrics', () => {
+      const result = computeOximetry(makeNormalSamples(120));
+
+      expect(result.retainedSamples).toBeGreaterThanOrEqual(MIN_USABLE_OXIMETRY_SAMPLES);
+      expect(result.spo2Mean).toBeGreaterThan(0);
+      expect(hasUsableOximetry(result)).toBe(true);
     });
   });
 });

--- a/lib/analyzers/oximetry-engine.ts
+++ b/lib/analyzers/oximetry-engine.ts
@@ -7,6 +7,24 @@
 import type { OximetryResults } from '../types';
 import type { OximetrySample } from '../parsers/oximetry-csv-parser';
 
+// ── Usability gate ───────────────────────────────────────────
+
+/**
+ * Minimum cleaned samples for the engine to produce real metrics. Mirrors the
+ * guard in computeOximetry: below this, computeOximetry returns an all-zero
+ * emptyResults() placeholder that must never be presented as a successful analysis.
+ */
+export const MIN_USABLE_OXIMETRY_SAMPLES = 60;
+
+/**
+ * True when an oximetry result is backed by enough cleaned data to be meaningful.
+ * A result below the threshold is an emptyResults() placeholder (all metrics 0) —
+ * callers must treat it as "not analysed", not as oximetry data that attached.
+ */
+export function hasUsableOximetry(result: OximetryResults | null | undefined): boolean {
+  return !!result && result.retainedSamples >= MIN_USABLE_OXIMETRY_SAMPLES;
+}
+
 // ── Cleaning ─────────────────────────────────────────────────
 
 interface CleanedData {
@@ -349,7 +367,7 @@ export function computeOximetry(rawSamples: OximetrySample[], intervalSeconds: n
 
   const iv = intervalSeconds;
 
-  if (samples.length < 60) {
+  if (samples.length < MIN_USABLE_OXIMETRY_SAMPLES) {
     // Not enough data for meaningful analysis
     return emptyResults(totalSamples, retainedSamples, doubleTrackingCorrected);
   }

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -17,7 +17,7 @@ import { parseBMCFiles, bmcSessionNightDate } from '../lib/parsers/bmc-parser';
 import { computeNightGlasgow } from '../lib/analyzers/glasgow-index';
 import { computeWAT } from '../lib/analyzers/wat-engine';
 import { computeNED } from '../lib/analyzers/ned-engine';
-import { computeOximetry } from '../lib/analyzers/oximetry-engine';
+import { computeOximetry, hasUsableOximetry, MIN_USABLE_OXIMETRY_SAMPLES } from '../lib/analyzers/oximetry-engine';
 import { computeSettingsMetrics } from '../lib/analyzers/settings-engine';
 import { computeCrossDevice } from '../lib/analyzers/cross-device-engine';
 import { buildOximetryTrace } from '../lib/oximetry-trace';
@@ -90,6 +90,56 @@ self.onmessage = async (e: MessageEvent<WorkerMessage>) => {
 function postProgress(current: number, total: number, stage: string): void {
   const msg: WorkerProgress = { type: 'PROGRESS', current, total, stage };
   self.postMessage(msg);
+}
+
+/**
+ * Surface an oximetry CSV that could not be read. Sanitized: no filename or raw
+ * parser message (either may carry PII) — only a generic, actionable reason.
+ * The orchestrator routes WARNING to Sentry + the UI warnings list.
+ */
+function postOximetryParseFailedWarning(): void {
+  const warning: WorkerWarning = {
+    type: 'WARNING',
+    checkpoint: 'oximetry_parse_failed',
+    detail:
+      'An oximetry file could not be read and was skipped. Check it is a valid pulse-oximeter CSV export (e.g. ViHealth or O2 Insight Pro) and try uploading it again.',
+    tags: {},
+  };
+  self.postMessage(warning);
+}
+
+/**
+ * Compute oximetry for one night and gate it on usability. A CSV that parsed but
+ * yielded too little usable data after cleaning collapses to an all-zero
+ * emptyResults() — attaching that produced the silent "data added but every stat
+ * 0.0" bug. Here it is dropped (oximetry stays null) and a sanitized WARNING is
+ * emitted instead. Returns null/null when there is no oximetry for the night.
+ */
+function computeNightOximetry(
+  oxData: ReturnType<typeof parseOximetryCSV> | undefined,
+  nightDate: string
+): { oximetry: OximetryResults | null; oximetryTrace: OximetryTraceData | null } {
+  if (!oxData) return { oximetry: null, oximetryTrace: null };
+
+  const result = computeOximetry(oxData.samples, oxData.intervalSeconds ?? 2);
+  if (!hasUsableOximetry(result)) {
+    const warning: WorkerWarning = {
+      type: 'WARNING',
+      checkpoint: 'oximetry_insufficient_samples',
+      detail:
+        `An oximetry file for night ${nightDate} was read but had too little usable data after cleaning to analyse ` +
+        `(under ${MIN_USABLE_OXIMETRY_SAMPLES} samples). It may be truncated, mostly motion-flagged, or have unreadable timestamps.`,
+      tags: {
+        night_date: nightDate,
+        retained_samples: result.retainedSamples,
+        total_samples: result.totalSamples,
+      },
+    };
+    self.postMessage(warning);
+    return { oximetry: null, oximetryTrace: null };
+  }
+
+  return { oximetry: result, oximetryTrace: buildOximetryTrace(oxData.samples) };
 }
 
 /**
@@ -451,9 +501,9 @@ async function processFiles(
         } else {
           oximetryByDate.set(parsed.dateStr, parsed);
         }
-      // eslint-disable-next-line airwaylab/no-silent-catch -- Individual CSV parse failures are non-fatal; worker continues processing remaining files and reports results via postMessage.
       } catch (err) {
         console.error('[oximetry] Failed to parse CSV:', err instanceof Error ? err.message : String(err));
+        postOximetryParseFailedWarning();
       }
     }
   }
@@ -582,11 +632,11 @@ async function processFiles(
       ? computeSettingsMetrics(combinedFlow, combinedPressure, avgSamplingRate)
       : null;
 
-    // Oximetry: match by night date
+    // Oximetry: match by night date. computeNightOximetry drops unusable data
+    // (and warns) instead of attaching an all-zero result as if it succeeded.
     const oxData = oximetryByDate.get(group.nightDate);
     const oxInterval = oxData?.intervalSeconds ?? 2;
-    const oximetry = oxData ? computeOximetry(oxData.samples, oxInterval) : null;
-    const oximetryTrace = oxData ? buildOximetryTrace(oxData.samples) : null;
+    const { oximetry, oximetryTrace } = computeNightOximetry(oxData, group.nightDate);
 
     // Cross-device RERA-arousal matching
     let crossDevice: CrossDeviceResults | null = null;
@@ -700,9 +750,9 @@ async function processBMCFiles(
       try {
         const parsed = parseOximetryCSV(csv);
         oximetryByDate.set(parsed.dateStr, parsed);
-      // eslint-disable-next-line airwaylab/no-silent-catch -- Individual CSV parse failures are non-fatal; loop continues. Results reported via postMessage.
       } catch (err) {
         console.error('[oximetry] Failed to parse CSV:', err instanceof Error ? err.message : String(err));
+        postOximetryParseFailedWarning();
       }
     }
   }
@@ -784,11 +834,11 @@ async function processBMCFiles(
       ? computeSettingsMetrics(combinedFlow, combinedPressure, avgSamplingRate)
       : null;
 
-    // Oximetry
+    // Oximetry. computeNightOximetry drops unusable data (and warns) instead of
+    // attaching an all-zero result as if it succeeded.
     const oxData = oximetryByDate.get(nightDate);
     const oxInterval = oxData?.intervalSeconds ?? 2;
-    const oximetry = oxData ? computeOximetry(oxData.samples, oxInterval) : null;
-    const oximetryTrace = oxData ? buildOximetryTrace(oxData.samples) : null;
+    const { oximetry, oximetryTrace } = computeNightOximetry(oxData, nightDate);
 
     // Cross-device matching
     let crossDevice: CrossDeviceResults | null = null;
@@ -847,14 +897,16 @@ function processOximetryOnly(oximetryCSVs: string[]): {
   for (const csv of oximetryCSVs) {
     try {
       const parsed = parseOximetryCSV(csv);
-      metrics[parsed.dateStr] = computeOximetry(parsed.samples, parsed.intervalSeconds);
-      const trace = buildOximetryTrace(parsed.samples);
-      if (trace) {
-        traces[parsed.dateStr] = trace;
+      const { oximetry, oximetryTrace } = computeNightOximetry(parsed, parsed.dateStr);
+      if (oximetry) {
+        metrics[parsed.dateStr] = oximetry;
+        if (oximetryTrace) {
+          traces[parsed.dateStr] = oximetryTrace;
+        }
       }
-    // eslint-disable-next-line airwaylab/no-silent-catch -- Individual CSV parse failures are non-fatal; loop continues. Caller aggregates results.
     } catch (err) {
       console.error('[oximetry] Failed to parse CSV:', err instanceof Error ? err.message : String(err));
+      postOximetryParseFailedWarning();
     }
   }
 

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -515,6 +515,17 @@ async function processFiles(
     const matched = oxDates.filter((d) => nightDates.includes(d));
     if (matched.length === 0) {
       console.error(`[oximetry] No date matches. Oximetry dates: [${oxDates.join(', ')}], Night dates: [${nightDates.slice(0, 5).join(', ')}${nightDates.length > 5 ? '...' : ''}]`);
+      // Surface the no-match case to the user. The oximetry-only re-upload path
+      // already warns here; the combined upload path previously only console.logged,
+      // so a date-mismatched oximetry file was silently ignored (issue #988).
+      const warning: WorkerWarning = {
+        type: 'WARNING',
+        checkpoint: 'oximetry_no_night_match',
+        detail:
+          'Oximetry data was uploaded but could not be matched to any analysed night. Check that the recording date in your oximetry export lines up with one of your therapy nights.',
+        tags: { oximetry_dates: oxDates.length, night_count: nightDates.length },
+      };
+      self.postMessage(warning);
     } else {
       console.debug(`[oximetry] Matched ${matched.length}/${oxDates.length} oximetry files to nights`);
     }


### PR DESCRIPTION
## What and why

Fixes the user-visible half of airwaylab-app/airwaylab-app#106: oximetry CSV uploads showed "Oximetry data added" but every stat read 0.0, and the file was dropped with no signal.

Root cause of the **silent failure** (verified): when a CSV parses but too few samples survive cleaning (`<60`), `computeOximetry` returns an all-zero `emptyResults()` object. That object is truthy, so the night attached it and the banner gate `!!night.oximetry` fired "success". Separately, the three oximetry parse `catch` blocks only `console.error`-ed, so a broken file produced no Sentry event and no user signal.

> This does **not** claim to fix why a given file collapses to `<60` samples (the actual parse-collapse cause is still unknown, pending the reporter's file). It fixes the silent-failure behaviour: stop reporting success when no usable data attached, and surface the reason.

## Change

- **`lib/analyzers/oximetry-engine.ts`** — export `MIN_USABLE_OXIMETRY_SAMPLES` (60, the existing guard value) and `hasUsableOximetry()`. No clinical math changed; the `<60` guard now references the constant.
- **`workers/analysis-worker.ts`** — `computeNightOximetry()` gates all three attach points (ResMed, BMC, oximetry-only). Unusable data is dropped (`oximetry` stays `null`, so the existing UI banner gate is now correct) and a sanitized `oximetry_insufficient_samples` WARNING is emitted. The three parse `catch` blocks now emit a sanitized `oximetry_parse_failed` WARNING (no filename or raw parser text, both may carry PII) instead of swallowing the error. The orchestrator already routes WARNING to Sentry + the UI warnings list, so no orchestrator/UI change was needed.
- **Tests** — reproduce the all-zero / insufficient case end-to-end in both device formats (ViHealth/Checkme + O2 Insight Pro/O2Ring) and lock `hasUsableOximetry`.

## Verification

- `vitest run` oximetry suites: 37/37 pass (incl. new regression).
- Full suite: 2694/2695. The one failure (`clinical-input-guards.test.ts`, a 14th-digit `periodicityIndex` float diff in `computeWAT`) is **pre-existing** and reproduces on pristine `origin/main` with these edits stashed. Untouched by this PR.
- `tsc --noEmit`: clean. `eslint`: clean (the `no-silent-catch` disables were removed because the catches are no longer silent).

## NOT done in this PR (need gates / inputs)

- **Browser E2E** of the WARNING surfacing + banner behaviour. The unit layer is covered; the worker→orchestrator→UI path needs a manual run.
- **Clinical sign-off**: touches `workers/` and `lib/analyzers/` (regulated surfaces). Please run the scanner + human clinical review before merge. **Do not auto-merge.**
- **Durable persistence**, the per-upload `{uploadId, csv}` contract, and **parser hardening for the real root cause** (needs the reporter's failing file). Tracked in airwaylab-app/airwaylab-app#106.

Refs airwaylab-app/airwaylab-app#106
