### PR TITLE
fix(gdpr): update privacy portability section + add bulk-download audit log (AIR-2512)

### DIFF
--- a/app/api/files/bulk-download/route.ts
+++ b/app/api/files/bulk-download/route.ts
@@ -80,6 +80,14 @@ export async function GET(request: NextRequest) {
       .order('night_date', { ascending: true });
     if (nightsError) throw nightsError;
 
+    // Audit log: GDPR Art 20 portability export (flows to Vercel logs + Sentry)
+    console.error('[AUDIT] bulk-download', {
+      action: 'gdpr_data_export',
+      userId: user.id,
+      fileCount: files.length,
+      nightCount: nightRows?.length ?? 0,
+    });
+
     return NextResponse.json({
       generatedAt: new Date().toISOString(),
       urlTtlSeconds: SIGNED_URL_TTL,

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -405,7 +405,10 @@ export default function PrivacyPolicyPage() {
             </li>
             <li>
               <strong>Portability:</strong> Export your analysis data as CSV, JSON, or PDF at any
-              time from the dashboard — no request needed.
+              time from the dashboard — no request needed. You can also download all of your raw
+              device files (EDF) and full analysis history as a structured JSON package via
+              Account Settings &rsquo; Download My Data. This covers all data held under GDPR
+              Art. 20.
             </li>
             <li>
               <strong>Rectification:</strong> Update your account details via your profile settings.


### PR DESCRIPTION
## Summary

- **`app/privacy/page.tsx`**: Extends the Portability bullet in §8 "Your Rights" to document the new raw EDF + analysis JSON export capability added by PR airwaylab-app/airwaylab-app#104. Previously the privacy policy was silent about `GET /api/files/bulk-download`, leaving GDPR Art. 20 coverage incomplete.
- **`app/api/files/bulk-download/route.ts`**: Adds a structured success-path audit log (`[AUDIT] bulk-download`) on every completed data export, per the CLAUDE.md convention that every API route must log action type + user ID.

## Fixes

Closes AIR-2512

## Test plan

- [ ] Privacy page `/privacy` loads without errors; §8 "Your Rights" Portability bullet mentions raw device files and Account Settings
- [ ] `GET /api/files/bulk-download` (authenticated) completes successfully; Vercel log stream shows `[AUDIT] bulk-download` entry with correct `userId`, `fileCount`, `nightCount`
- [ ] Unauthenticated request to bulk-download still returns 401 (no audit log emitted)
- [ ] Full pipeline: lint, typecheck, test (2689/2689 ✅), build

## MDR / GDPR checklist

- [x] Privacy policy accurately reflects all data flows (GDPR Art. 13/14 transparency)
- [x] GDPR Art. 20 portability right now fully documented (raw files + processed analysis)
- [x] Audit log provides evidence trail for regulatory inquiry or DSAR
- [x] No health data added to external processors
- [x] No clinical language changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)