### PR TITLE
fix(gdpr): split Discord processor entry — document admin webhook separately (AIR-2524)

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -354,7 +354,13 @@ export default function PrivacyPolicyPage() {
                   <td className="py-2 pr-4 font-medium text-foreground">Discord</td>
                   <td className="py-2 pr-4">Community (opt-in, paid subscribers only)</td>
                   <td className="py-2 pr-4">US</td>
-                  <td className="py-2">Discord user ID and username only. No health data is sent to Discord.</td>
+                  <td className="py-2">Discord user ID and username only. No health data is sent to Discord via this channel.</td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4 font-medium text-foreground">Discord (admin webhook)</td>
+                  <td className="py-2 pr-4">Internal feedback triage &amp; operational alerts (admin-only channel)</td>
+                  <td className="py-2 pr-4">US</td>
+                  <td className="py-2">Feedback message text, submitter email (if provided), app metadata (page, tier, browser). No raw therapy data. Message text may contain health context provided voluntarily by the user.</td>
                 </tr>
                 <tr>
                   <td className="py-2 pr-4 font-medium text-foreground">Google (Gmail API)</td>


### PR DESCRIPTION
## Summary

The Privacy Policy processor table had a single Discord entry that claimed "No health data is sent to Discord." This was inaccurate — there are two distinct Discord integrations:

1. **Community Discord** (opt-in, paid subscribers only): correctly described, user credentials only
2. **Admin feedback webhook** (#user-signals, admin-only channel): undocumented as a separate entry. Sends feedback message text, submitter email, and app metadata. Feedback messages can contain health context provided voluntarily by users.

This PR splits the entry into two rows so both integrations are accurately documented.

**Trigger:** PR #969 (`feat(feedback): fan out every report to email + Discord`) expanded the admin webhook from bug-reports-only to all feedback types, making the inaccuracy more significant. Tracked in AIR-2524.

## Changes

- `app/privacy/page.tsx`: Discord community entry updated with clarifying qualifier; new "Discord (admin webhook)" row added below it

## Test plan

- [ ] Privacy page `/privacy` loads without errors; processor table shows both Discord rows
- [ ] Community row: "Discord user ID and username only. No health data is sent to Discord via this channel."
- [ ] Admin webhook row: documents feedback text, email, app metadata, and health context note
- [ ] Full pipeline: lint ✅, typecheck ✅, tests pass

## GDPR checklist

- [x] Privacy Policy now accurately reflects both Discord integrations (GDPR Art. 13/14 transparency)
- [x] No health data flows changed — documentation fix only
- [x] No MDR-regulated content modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)