### PR TITLE
fix(parsers): AirCurve 11 uses the same 0-4 sensitivity scale (#975)

### DIFF
--- a/__tests__/settings-extractor.test.ts
+++ b/__tests__/settings-extractor.test.ts
@@ -194,8 +194,8 @@ describe('parseIdentification — AirCurve 11 nested JSON', () => {
   });
 });
 
-describe('sensitivityLabel — AirCurve 11 scale', () => {
-  it('maps old scale (0-4) correctly by default', () => {
+describe('sensitivityLabel — shared 0-4 scale (AirCurve 10 and 11)', () => {
+  it('maps the 0-4 scale', () => {
     expect(sensitivityLabel(0)).toBe('very low');
     expect(sensitivityLabel(1)).toBe('low');
     expect(sensitivityLabel(2)).toBe('medium');
@@ -203,27 +203,18 @@ describe('sensitivityLabel — AirCurve 11 scale', () => {
     expect(sensitivityLabel(4)).toBe('very high');
   });
 
-  it('maps AirCurve 11 scale (1-5) when isAirCurve11 is true', () => {
-    expect(sensitivityLabel(1, true)).toBe('very low');
-    expect(sensitivityLabel(2, true)).toBe('low');
-    expect(sensitivityLabel(3, true)).toBe('medium');
-    expect(sensitivityLabel(4, true)).toBe('high');
-    expect(sensitivityLabel(5, true)).toBe('very high');
-  });
-
-  it('old scale value 3 = "high" but AC11 scale value 3 = "medium"', () => {
-    expect(sensitivityLabel(3, false)).toBe('high');
-    expect(sensitivityLabel(3, true)).toBe('medium');
+  it('AirCurve 11 uses the same 0-4 scale: raw 3 = "high" (#975)', () => {
+    // Regression: a real AirCurve 11 VAuto set to High stores raw 3. The old
+    // AC11-specific 1-5 remap mislabelled it "medium".
+    expect(sensitivityLabel(3)).toBe('high');
   });
 
   it('returns N/A for undefined', () => {
     expect(sensitivityLabel(undefined)).toBe('N/A');
-    expect(sensitivityLabel(undefined, true)).toBe('N/A');
   });
 
-  it('returns raw number for unmapped values', () => {
+  it('returns the raw number for unmapped values', () => {
     expect(sensitivityLabel(7)).toBe('7');
-    expect(sensitivityLabel(0, true)).toBe('0');
   });
 });
 
@@ -563,7 +554,7 @@ describe('extractSettings — AirSense 11 CPAP', () => {
 // ============================================================
 
 describe('extractSettings — AirCurve 11 VAuto', () => {
-  it('uses S.VA.Trigger for trigger signal and AC11 1-5 sensitivity scale', () => {
+  it('uses S.VA.Trigger for trigger signal, shared 0-4 sensitivity scale', () => {
     const buf = buildSTRBuffer([
       { label: 'Date',         values: [0],  physMin: 0,  physMax: 36500 },
       { label: 'TgtIPAP.50',   values: [14], physMin: 4,  physMax: 25 },
@@ -577,10 +568,10 @@ describe('extractSettings — AirCurve 11 VAuto', () => {
     const result = extractSettings(buf, 'AirCurve11VAuto');
     const day = result[Object.keys(result)[0]!]!;
     expect(day.papMode).toBe('BiPAP Auto');
-    // AC11 scale: 3 = medium (not "high" as in old scale)
-    expect(day.trigger).toBe('medium');
-    // AC11 scale: 2 = low
-    expect(day.cycle).toBe('low');
+    // 0-4 scale (AirCurve 10 and 11 alike): raw 3 = high (#975)
+    expect(day.trigger).toBe('high');
+    // raw 2 = medium
+    expect(day.cycle).toBe('medium');
   });
 
   it('remaps mode 8 to VAuto for AirCurve 11', () => {
@@ -612,9 +603,9 @@ describe('extractSettings — AirCurve 11 VAuto', () => {
     ]);
     const result = extractSettings(buf, 'AirCurve11VAuto');
     const day = result[Object.keys(result)[0]!]!;
-    // AC11 scale: 4 = high
-    expect(day.trigger).toBe('high');
-    // AC11 scale: 1 = very low
-    expect(day.cycle).toBe('very low');
+    // 0-4 scale: raw 4 = very high
+    expect(day.trigger).toBe('very high');
+    // raw 1 = low
+    expect(day.cycle).toBe('low');
   });
 });

--- a/lib/parsers/settings-extractor.ts
+++ b/lib/parsers/settings-extractor.ts
@@ -30,25 +30,18 @@ const SENSITIVITY_MAP: Record<number, string> = {
   0: 'very low',
 };
 
-/** AirCurve 11 (BiPAP) uses a 1-5 sensitivity scale instead of 0-4. AirSense 11 (CPAP) does not have trigger/cycle settings. */
-const SENSITIVITY_MAP_AIRCURVE11: Record<number, string> = {
-  5: 'very high',
-  4: 'high',
-  3: 'medium',
-  2: 'low',
-  1: 'very low',
-};
-
 const MASK_MAP: Record<number, string> = {
   0: 'Pillows',
   1: 'Full Face',
   2: 'Nasal',
 };
 
-export function sensitivityLabel(value: number | undefined, isAirCurve11 = false): string {
+// Trigger/Cycle sensitivity uses the same 0-4 scale on AirCurve 10 and 11.
+// A prior AirCurve-11-specific 1-5 remap shifted every label down one step:
+// a real AirCurve 11 VAuto set to High stores raw 3 and was shown as "medium" (#975).
+export function sensitivityLabel(value: number | undefined): string {
   if (value === undefined || value === null) return 'N/A';
-  const map = isAirCurve11 ? SENSITIVITY_MAP_AIRCURVE11 : SENSITIVITY_MAP;
-  return map[value] ?? String(value);
+  return SENSITIVITY_MAP[value] ?? String(value);
 }
 
 /** Signals already handled by typed fields — excluded from extendedSettings */
@@ -79,7 +72,6 @@ export function extractSettings(strBuffer: ArrayBuffer, deviceModel: string): Da
   const allLabels = signals.map((s) => s.label);
   console.error(`[settings] STR.edf signals (${allLabels.length}): ${allLabels.join(', ')}`);
 
-  const isAirCurve11 = deviceModel.replace(/\s/g, '').toLowerCase().includes('aircurve11');
   // AirCurve devices (10 and 11) share VAuto signal names; used for S.VA.* signal selection
   const isAirCurveDevice = deviceModel.replace(/\s/g, '').toLowerCase().includes('aircurve');
   // VAuto devices use mode 8 for VAuto; AirCurve 10 ST-A uses mode 8 for iVAPS (different firmware)
@@ -249,8 +241,8 @@ export function extractSettings(strBuffer: ArrayBuffer, deviceModel: string): Da
       pressureSupport: Math.round((ipap - epap) * 10) / 10,
       papMode,
       riseTime: easyBreatheOn ? null : (riseTimeRaw !== undefined ? Math.round(riseTimeRaw) : null),
-      trigger: sensitivityLabel(triggerRaw !== undefined ? Math.round(triggerRaw) : undefined, isAirCurve11),
-      cycle: sensitivityLabel(cycleRaw !== undefined ? Math.round(cycleRaw) : undefined, isAirCurve11),
+      trigger: sensitivityLabel(triggerRaw !== undefined ? Math.round(triggerRaw) : undefined),
+      cycle: sensitivityLabel(cycleRaw !== undefined ? Math.round(cycleRaw) : undefined),
       easyBreathe: easyBreatheOn,
       rampEnabled: rampEnableRaw !== undefined ? Math.round(rampEnableRaw) !== 0 : null,
       rampTime: rampTimeRaw !== undefined ? Math.round(rampTimeRaw) : null,


### PR DESCRIPTION
Closes #975.

A user set Trigger/Cycle to **High** but the Settings Timeline showed **Medium**.

## Root cause (confirmed against a real device)
Trigger/Cycle sensitivity was read off an **AirCurve-11-specific 1–5 map** (`SENSITIVITY_MAP_AIRCURVE11`) selected by a `deviceModel.includes('aircurve11')` check. That map is shifted one step from the standard 0–4 scale.

Evidence from a real **AirCurve 11 VAuto** account: every night stored a raw sensitivity of **3**. On the standard ResMed **0–4** scale `3 = high` (matches what the user set on the device); the 1–5 remap turned `3` into **"medium"** — exactly the reported off-by-one.

## Change
- Remove `SENSITIVITY_MAP_AIRCURVE11` and the `isAirCurve11` branch — AirCurve 10 and 11 both use the standard 0–4 `SENSITIVITY_MAP`.
- `sensitivityLabel(value)` loses its now-unused `isAirCurve11` param (no external callers).
- Tests updated to the corrected scale (53/53 pass).

> ⚠ Clinical module (`lib/parsers/`) — needs `clinical-signoff`. Please confirm against a ResMed source that AirCurve 11 uses the 0–4 scale (the real-device evidence above strongly indicates it does, contradicting the prior 1–5 assumption which had no cited source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)