### PR TITLE
feat(ci): G5 — real-PostgREST client tests on the db-contract gate

### DIFF
--- a/.github/workflows/integration-db.yml
+++ b/.github/workflows/integration-db.yml
@@ -46,8 +46,15 @@ jobs:
       # local, ephemeral container — not a real credential); it is duplicated in
       # the test step env below because the `env:` context is not available to
       # services.
+      # Pinned to the Supabase GA PostgREST line (v12.2.x). This MATTERS: the
+      # `.update().or()` → 42703 billing-incident behaviour is version-specific —
+      # upstream PostgREST fixed `or` on mutations by v13.0.x (it now applies the
+      # filter and returns 200), so a v13 image would NOT reproduce the incident.
+      # The 2026-06-04 incident hit prod (same PostgREST that runs now), so the
+      # gate must run a prod-era version to faithfully catch the 42703 class.
+      # Track Supabase's PostgREST version when bumping.
       postgrest:
-        image: postgrest/postgrest:v13.0.8
+        image: postgrest/postgrest:v12.2.12
         env:
           PGRST_DB_URI: postgres://postgres:postgres@postgres:5432/airwaylab_test
           PGRST_DB_SCHEMAS: public

--- a/.github/workflows/integration-db.yml
+++ b/.github/workflows/integration-db.yml
@@ -36,17 +36,20 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 12
-      # PostgREST connects as `authenticator` (created by ci-db-preshim.sql) and
-      # SET ROLEs into anon/service_role per the request JWT. It boots before the
-      # schema exists and retries the connection with backoff; the test runner
-      # waits for readiness and issues `NOTIFY pgrst, 'reload schema'` once the
-      # baseline is applied. The JWT secret is a throwaway CI value (a local,
-      # ephemeral container — not a real credential); it is duplicated in the test
-      # step env below because the `env:` context is not available to services.
+      # PostgREST connects as the `postgres` superuser (it exists from container
+      # init, so it connects immediately — no cold-start race with the schema
+      # apply) and SET ROLEs into anon/service_role per the request JWT
+      # (db-anon-role=anon). Every request switches role, so no query runs as the
+      # superuser and the per-role boundaries the tests assert hold. It boots
+      # against an empty DB; the test runner issues `NOTIFY pgrst, 'reload schema'`
+      # once the baseline is applied. The JWT secret is a throwaway CI value (a
+      # local, ephemeral container — not a real credential); it is duplicated in
+      # the test step env below because the `env:` context is not available to
+      # services.
       postgrest:
         image: postgrest/postgrest:v13.0.8
         env:
-          PGRST_DB_URI: postgres://authenticator:postgres@postgres:5432/airwaylab_test
+          PGRST_DB_URI: postgres://postgres:postgres@postgres:5432/airwaylab_test
           PGRST_DB_SCHEMAS: public
           PGRST_DB_ANON_ROLE: anon
           PGRST_JWT_SECRET: ci-only-not-a-real-secret-pgrst-jwt-0123456789

--- a/.github/workflows/integration-db.yml
+++ b/.github/workflows/integration-db.yml
@@ -46,12 +46,13 @@ jobs:
       # local, ephemeral container — not a real credential); it is duplicated in
       # the test step env below because the `env:` context is not available to
       # services.
-      # Pinned to the Supabase GA PostgREST line (v12.2.x). This MATTERS: the
-      # `.update().or()` → 42703 billing-incident behaviour is version-specific —
-      # upstream PostgREST fixed `or` on mutations by v13.0.x (it now applies the
-      # filter and returns 200), so a v13 image would NOT reproduce the incident.
-      # The 2026-06-04 incident hit prod (same PostgREST that runs now), so the
-      # gate must run a prod-era version to faithfully catch the 42703 class.
+      # Pinned to the Supabase GA PostgREST line (v12.2.x) for prod fidelity of the
+      # RPC / permission / schema-reload behaviour the tests assert. NOTE on the
+      # 2026-06-04 `.update().or()` → 42703 incident: upstream PostgREST has since
+      # fixed `or` on mutations (both the flat and the exact nested incident filter
+      # return 200 on v12.2.x / v13.x), so that symptom is no longer reproducible
+      # here — the test logs the live behaviour as a diagnostic, and the
+      # version-independent static check-no-mutation-or.mjs guard is the defense.
       # Track Supabase's PostgREST version when bumping.
       postgrest:
         image: postgrest/postgrest:v12.2.12

--- a/.github/workflows/integration-db.yml
+++ b/.github/workflows/integration-db.yml
@@ -1,9 +1,11 @@
 name: Integration DB
 
-# Replays the full migration history into a throwaway Postgres and runs the SQL
-# contract tests. NON-REQUIRED for now (see ruleset) — promote to a required
-# check once it is reliably green. Runs on PRs + manual dispatch (not in the
-# merge queue, to avoid slowing it while this is being stabilised).
+# Builds a throwaway Postgres from the prod schema baseline (GATE mode) and runs
+# the SQL contract tests, then stands up a real PostgREST in front of it and runs
+# the G5 client tests (per-role permission boundaries, the claim_stripe_event RPC,
+# schema-cache reload, and the `.update().or()` 42703 billing-incident pattern).
+# NON-REQUIRED for now (see ruleset) — promote to a required check once it is
+# reliably green. Runs on PRs + manual dispatch (not in the merge queue).
 on:
   pull_request:
     branches: [main]
@@ -34,11 +36,37 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 12
+      # PostgREST connects as `authenticator` (created by ci-db-preshim.sql) and
+      # SET ROLEs into anon/service_role per the request JWT. It boots before the
+      # schema exists and retries the connection with backoff; the test runner
+      # waits for readiness and issues `NOTIFY pgrst, 'reload schema'` once the
+      # baseline is applied. The JWT secret is a throwaway CI value (a local,
+      # ephemeral container — not a real credential); it is duplicated in the test
+      # step env below because the `env:` context is not available to services.
+      postgrest:
+        image: postgrest/postgrest:v13.0.8
+        env:
+          PGRST_DB_URI: postgres://authenticator:postgres@postgres:5432/airwaylab_test
+          PGRST_DB_SCHEMAS: public
+          PGRST_DB_ANON_ROLE: anon
+          PGRST_JWT_SECRET: ci-only-not-a-real-secret-pgrst-jwt-0123456789
+          PGRST_DB_CHANNEL_ENABLED: "true"
+          PGRST_LOG_LEVEL: info
+        ports:
+          - 3000:3000
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/airwaylab_test
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
       - name: Install psql client
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
-      - name: Replay migrations + SQL contract tests
+      - name: Replay baseline + migrations + grants + SQL contract tests
         run: bash scripts/db-replay.sh
+      - name: PostgREST client tests (G5)
+        env:
+          PGRST_URL: http://localhost:3000
+          PGRST_JWT_SECRET: ci-only-not-a-real-secret-pgrst-jwt-0123456789
+        run: node scripts/ci-postgrest-tests.mjs

--- a/scripts/ci-db-preshim.sql
+++ b/scripts/ci-db-preshim.sql
@@ -23,7 +23,11 @@ create or replace function auth.role() returns text language sql stable as $$
   select coalesce(nullif(current_setting('request.jwt.claim.role', true), ''), 'anon');
 $$;
 
--- standard Supabase roles (the baseline's policies/grants reference these)
+-- standard Supabase roles (the baseline's policies/grants reference these).
+-- `authenticator` is the role PostgREST logs in as; it is NOINHERIT and member
+-- of the three API roles so PostgREST can SET ROLE into them per the JWT `role`
+-- claim (anon when unauthenticated). This mirrors the Supabase platform setup
+-- and is what lets the G5 client tests hit real per-role permission boundaries.
 do $$
 begin
   if not exists (select from pg_roles where rolname = 'anon') then
@@ -35,4 +39,10 @@ begin
   if not exists (select from pg_roles where rolname = 'service_role') then
     create role service_role nologin noinherit bypassrls;
   end if;
+  if not exists (select from pg_roles where rolname = 'authenticator') then
+    -- password matches the PGRST_DB_URI in .github/workflows/integration-db.yml
+    create role authenticator login noinherit password 'postgres';
+  end if;
 end $$;
+
+grant anon, authenticated, service_role to authenticator;

--- a/scripts/ci-db-preshim.sql
+++ b/scripts/ci-db-preshim.sql
@@ -24,10 +24,11 @@ create or replace function auth.role() returns text language sql stable as $$
 $$;
 
 -- standard Supabase roles (the baseline's policies/grants reference these).
--- `authenticator` is the role PostgREST logs in as; it is NOINHERIT and member
--- of the three API roles so PostgREST can SET ROLE into them per the JWT `role`
--- claim (anon when unauthenticated). This mirrors the Supabase platform setup
--- and is what lets the G5 client tests hit real per-role permission boundaries.
+-- PostgREST connects as the `postgres` superuser in CI (it exists from container
+-- init, so there is no cold-start race while this shim runs) and SET ROLEs into
+-- anon / service_role per the request JWT (PGRST_DB_ANON_ROLE=anon). Role
+-- switching, not the login identity, is what the G5 client tests exercise, so the
+-- per-role permission boundaries are faithful regardless of the login role.
 do $$
 begin
   if not exists (select from pg_roles where rolname = 'anon') then
@@ -39,10 +40,4 @@ begin
   if not exists (select from pg_roles where rolname = 'service_role') then
     create role service_role nologin noinherit bypassrls;
   end if;
-  if not exists (select from pg_roles where rolname = 'authenticator') then
-    -- password matches the PGRST_DB_URI in .github/workflows/integration-db.yml
-    create role authenticator login noinherit password 'postgres';
-  end if;
 end $$;
-
-grant anon, authenticated, service_role to authenticator;

--- a/scripts/ci-postgrest-tests.mjs
+++ b/scripts/ci-postgrest-tests.mjs
@@ -172,12 +172,18 @@ async function run() {
   await reloadSchema();
 
   // 5) the billing incident: `.update().or()` → PostgREST 42703 (undefined_column).
-  //    Mirrors the supabase-js wire format exactly: .eq('event_id',…).or('status…')
-  //    serialises to ?event_id=eq.…&or=(status…). The same `or` on a SELECT works;
-  //    on a MUTATION PostgREST reports "column stripe_events.status does not exist".
+  //    This is the EXACT claim filter from the 057/#945 webhook (see migration
+  //    063): .eq('event_id',…).or('status.in.(pending,failed),and(status.eq.processing,updated_at.lt.<cutoff>)')
+  //    which serialises to the URL below. Upstream PostgREST has since fixed a
+  //    FLAT `or` on a mutation, but this NESTED logic tree (an `and(...)` inside
+  //    the `or(...)`) is what stranded every checkout — PostgREST reports
+  //    "column stripe_events.status does not exist" (42703). The same filter on a
+  //    SELECT works fine. Defense-in-depth to the static check-no-mutation-or.mjs.
+  const incidentOr =
+    `or=(status.in.(pending,failed),and(status.eq.processing,updated_at.lt.${encodeURIComponent(cutoff)}))`;
   const orUpdate = await req(
     'PATCH',
-    `/stripe_events?event_id=eq.${EV}&or=(status.eq.pending,status.eq.failed)`,
+    `/stripe_events?event_id=eq.${EV}&${incidentOr}`,
     { jwt: SERVICE, prefer: 'return=representation', body: { attempts: 99 } },
   );
   check('.update().or() is rejected, not a silent success', orUpdate.status >= 400,
@@ -187,6 +193,13 @@ async function run() {
   console.log(
     `     .update().or() → status=${orUpdate.status}, code=${orUpdate.body?.code}, message=${JSON.stringify(orUpdate.body?.message)}`,
   );
+  // Diagnostic only (not asserted): how a FLAT `or` on the same mutation behaves
+  // on this PostgREST version — fixed upstream, so this is expected to be 200.
+  const flatOr = await req(
+    'PATCH', `/stripe_events?event_id=eq.${EV}&or=(status.eq.pending,status.eq.failed)`,
+    { jwt: SERVICE, prefer: 'return=representation', body: { attempts: 98 } },
+  );
+  console.log(`     (flat .or() → status=${flatOr.status}, code=${flatOr.body?.code ?? 'n/a'})`);
 
   psql(`delete from public.stripe_events where event_id like '__g5_pgrst%'`);
 

--- a/scripts/ci-postgrest-tests.mjs
+++ b/scripts/ci-postgrest-tests.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * G5 — end-to-end PostgREST client tests for the `db-contract` CI job.
+ *
+ * Runs after scripts/db-replay.sh has built the GATE-mode DB (pre-shim + prod
+ * schema baseline + post-baseline migrations + supabase/baseline.grants.sql) and
+ * a PostgREST service container is up. Exercises the REAL request path — a live
+ * PostgREST speaking to a real Postgres over HTTP, switching roles by JWT — so we
+ * catch what unit tests + a green build cannot:
+ *
+ *   1. claim_stripe_event RPC happy path (service-role JWT).
+ *   2. claim_stripe_event idempotency (a fresh `processing` row is not re-claimed).
+ *   3. permission boundary: anon is denied, service_role is allowed (prod revokes
+ *      EXECUTE on the RPC from PUBLIC — replicated in baseline.grants.sql).
+ *   4. schema-cache reload semantics (a new function is invisible until
+ *      `NOTIFY pgrst, 'reload schema'`).
+ *   5. the 2026-06-04 billing incident: `.update().or()` is rejected by PostgREST
+ *      with PG 42703, proven observable end-to-end. Defense-in-depth to the
+ *      static `scripts/check-no-mutation-or.mjs` guard.
+ *
+ * No npm dependencies: built-in fetch + crypto for the (HS256) JWT, and psql
+ * (already installed in the job) for the DDL/NOTIFY a PostgREST client can't do.
+ */
+import crypto from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+
+const PGRST = process.env.PGRST_URL || 'http://localhost:3000';
+const SECRET = process.env.PGRST_JWT_SECRET;
+const DB = process.env.DATABASE_URL;
+if (!SECRET || !DB) {
+  console.error('PGRST_JWT_SECRET and DATABASE_URL are required');
+  process.exit(2);
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+const b64url = (s) => Buffer.from(s).toString('base64url');
+function mintJwt(role) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = b64url(JSON.stringify({ role, iat: now, exp: now + 3600 }));
+  const data = `${header}.${payload}`;
+  const sig = crypto.createHmac('sha256', SECRET).update(data).digest('base64url');
+  return `${data}.${sig}`;
+}
+const SERVICE = mintJwt('service_role');
+
+const psql = (sql) =>
+  execFileSync('psql', [DB, '-v', 'ON_ERROR_STOP=1', '-tAc', sql], { encoding: 'utf8' }).trim();
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function req(method, path, { jwt, body, prefer } = {}) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (jwt) headers.Authorization = `Bearer ${jwt}`;
+  if (prefer) headers.Prefer = prefer;
+  const res = await fetch(`${PGRST}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let parsed = null;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    parsed = text;
+  }
+  return { status: res.status, body: parsed };
+}
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) console.log(`  ok   ${name}`);
+  else {
+    failures++;
+    console.error(`  FAIL ${name}${detail ? ` — ${detail}` : ''}`);
+  }
+}
+
+async function waitForPostgrest() {
+  for (let i = 0; i < 90; i++) {
+    try {
+      const res = await fetch(`${PGRST}/`);
+      if (res.status === 200) return;
+    } catch {
+      /* not up yet */
+    }
+    await sleep(1000);
+  }
+  throw new Error('PostgREST did not become ready within 90s');
+}
+
+async function reloadSchema() {
+  psql(`notify pgrst, 'reload schema'`);
+  await sleep(1500);
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+async function run() {
+  console.log('> waiting for PostgREST to connect + load schema cache');
+  await waitForPostgrest();
+  // PostgREST may have connected mid-apply (authenticator appears before the
+  // baseline finishes), so force one fresh cache before asserting anything.
+  await reloadSchema();
+
+  const cutoff = new Date(Date.now() - 15 * 60 * 1000).toISOString();
+  const EV = '__g5_pgrst_happy__';
+  psql(`delete from public.stripe_events where event_id like '__g5_pgrst%'`);
+
+  // 1) happy path — seed via PostgREST as service_role, then claim.
+  const seed = await req('POST', '/stripe_events', {
+    jwt: SERVICE,
+    prefer: 'return=representation',
+    body: { event_id: EV, event_type: 'test.g5', status: 'pending', attempts: 0 },
+  });
+  check('seed stripe_events as service_role → 201', seed.status === 201,
+    `status=${seed.status} body=${JSON.stringify(seed.body)}`);
+
+  const claim1 = await req('POST', '/rpc/claim_stripe_event', {
+    jwt: SERVICE,
+    body: { p_event_id: EV, p_attempts: 1, p_stale_cutoff: cutoff },
+  });
+  check('claim_stripe_event (service_role) → 200', claim1.status === 200, `status=${claim1.status}`);
+  check('claim returns the pending event once',
+    Array.isArray(claim1.body) && claim1.body.length === 1 && claim1.body[0].event_id === EV,
+    JSON.stringify(claim1.body));
+
+  // 2) idempotency — the row is now `processing` + fresh, so a second claim is a no-op.
+  const claim2 = await req('POST', '/rpc/claim_stripe_event', {
+    jwt: SERVICE,
+    body: { p_event_id: EV, p_attempts: 2, p_stale_cutoff: cutoff },
+  });
+  check('claim is idempotent (fresh processing not re-claimed)',
+    Array.isArray(claim2.body) && claim2.body.length === 0,
+    `status=${claim2.status} body=${JSON.stringify(claim2.body)}`);
+  const attempts = psql(`select attempts from public.stripe_events where event_id = '${EV}'`);
+  check('claimed row left untouched by the no-op (attempts still 1)', attempts === '1',
+    `attempts=${attempts}`);
+
+  // 3) permission boundary — anon denied, service_role allowed.
+  const anonCall = await req('POST', '/rpc/claim_stripe_event', {
+    body: { p_event_id: EV, p_attempts: 9, p_stale_cutoff: cutoff }, // no JWT → anon
+  });
+  check('anon cannot execute claim_stripe_event (denied)',
+    [401, 403, 404].includes(anonCall.status),
+    `status=${anonCall.status} body=${JSON.stringify(anonCall.body)}`);
+  console.log(`     anon → status=${anonCall.status}, code=${anonCall.body?.code ?? 'n/a'}`);
+  const svcCall = await req('POST', '/rpc/claim_stripe_event', {
+    jwt: SERVICE,
+    body: { p_event_id: '__g5_pgrst_perm__', p_attempts: 1, p_stale_cutoff: cutoff },
+  });
+  check('service_role can execute claim_stripe_event → 200', svcCall.status === 200,
+    `status=${svcCall.status} body=${JSON.stringify(svcCall.body)}`);
+
+  // 4) schema-cache reload semantics.
+  psql(`drop function if exists public.__g5_reload_probe()`);
+  psql(`create function public.__g5_reload_probe() returns int language sql as 'select 42'`);
+  psql(`grant execute on function public.__g5_reload_probe() to service_role`);
+  const before = await req('POST', '/rpc/__g5_reload_probe', { jwt: SERVICE });
+  check('new function absent from stale schema cache (404)', before.status === 404,
+    `status=${before.status} body=${JSON.stringify(before.body)}`);
+  await reloadSchema();
+  let after = { status: 0, body: null };
+  for (let i = 0; i < 10; i++) {
+    after = await req('POST', '/rpc/__g5_reload_probe', { jwt: SERVICE });
+    if (after.status === 200) break;
+    await sleep(1000);
+  }
+  check('function visible after NOTIFY pgrst reload (200 → 42)',
+    after.status === 200 && after.body === 42,
+    `status=${after.status} body=${JSON.stringify(after.body)}`);
+  psql(`drop function if exists public.__g5_reload_probe()`);
+  await reloadSchema();
+
+  // 5) the billing incident: `.update().or()` → PostgREST 42703 (undefined_column).
+  //    Mirrors the supabase-js wire format exactly: .eq('event_id',…).or('status…')
+  //    serialises to ?event_id=eq.…&or=(status…). The same `or` on a SELECT works;
+  //    on a MUTATION PostgREST reports "column stripe_events.status does not exist".
+  const orUpdate = await req(
+    'PATCH',
+    `/stripe_events?event_id=eq.${EV}&or=(status.eq.pending,status.eq.failed)`,
+    { jwt: SERVICE, prefer: 'return=representation', body: { attempts: 99 } },
+  );
+  check('.update().or() is rejected, not a silent success', orUpdate.status >= 400,
+    `status=${orUpdate.status} body=${JSON.stringify(orUpdate.body)}`);
+  check('.update().or() fails with PG 42703 (undefined_column)', orUpdate.body?.code === '42703',
+    `status=${orUpdate.status} code=${orUpdate.body?.code} body=${JSON.stringify(orUpdate.body)}`);
+  console.log(
+    `     .update().or() → status=${orUpdate.status}, code=${orUpdate.body?.code}, message=${JSON.stringify(orUpdate.body?.message)}`,
+  );
+
+  psql(`delete from public.stripe_events where event_id like '__g5_pgrst%'`);
+
+  console.log(
+    failures === 0
+      ? '\n>> ci-postgrest-tests: all assertions passed'
+      : `\n>> ci-postgrest-tests: ${failures} assertion(s) FAILED`,
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+run().catch((e) => {
+  console.error('FATAL', e);
+  process.exit(1);
+});

--- a/scripts/ci-postgrest-tests.mjs
+++ b/scripts/ci-postgrest-tests.mjs
@@ -14,9 +14,11 @@
  *      EXECUTE on the RPC from PUBLIC — replicated in baseline.grants.sql).
  *   4. schema-cache reload semantics (a new function is invisible until
  *      `NOTIFY pgrst, 'reload schema'`).
- *   5. the 2026-06-04 billing incident: `.update().or()` is rejected by PostgREST
- *      with PG 42703, proven observable end-to-end. Defense-in-depth to the
- *      static `scripts/check-no-mutation-or.mjs` guard.
+ *   5. DIAGNOSTIC — the 2026-06-04 `.update().or()` billing incident. Logs the
+ *      live or-on-mutation behaviour (not asserted): upstream PostgREST has since
+ *      fixed it, so the 42703 symptom no longer reproduces on v12.2.x / v13.x. The
+ *      version-independent static `scripts/check-no-mutation-or.mjs` guard is the
+ *      real defense; this records what the live stack actually does.
  *
  * No npm dependencies: built-in fetch + crypto for the (HS256) JWT, and psql
  * (already installed in the job) for the DDL/NOTIFY a PostgREST client can't do.
@@ -171,35 +173,34 @@ async function run() {
   psql(`drop function if exists public.__g5_reload_probe()`);
   await reloadSchema();
 
-  // 5) the billing incident: `.update().or()` → PostgREST 42703 (undefined_column).
-  //    This is the EXACT claim filter from the 057/#945 webhook (see migration
-  //    063): .eq('event_id',…).or('status.in.(pending,failed),and(status.eq.processing,updated_at.lt.<cutoff>)')
-  //    which serialises to the URL below. Upstream PostgREST has since fixed a
-  //    FLAT `or` on a mutation, but this NESTED logic tree (an `and(...)` inside
-  //    the `or(...)`) is what stranded every checkout — PostgREST reports
-  //    "column stripe_events.status does not exist" (42703). The same filter on a
-  //    SELECT works fine. Defense-in-depth to the static check-no-mutation-or.mjs.
+  // 5) DIAGNOSTIC (not asserted): `.update().or()` — the 2026-06-04 billing
+  //    incident pattern. The 057/#945 webhook claimed events with
+  //    .eq('event_id',…).or('status.in.(pending,failed),and(status.eq.processing,updated_at.lt.<cutoff>)')
+  //    and PostgREST rejected it with PG 42703 "column stripe_events.status does
+  //    not exist", stranding every checkout (fix: the claim_stripe_event RPC,
+  //    migration 063). VERIFIED HERE: upstream PostgREST has since fixed `or` on a
+  //    mutation — BOTH the flat and the exact nested incident filter return 200 on
+  //    v12.2.x / v13.x (they apply the filter correctly). So the 42703 symptom is
+  //    no longer reproducible on these versions; we log the live behavior for the
+  //    record rather than assert it. The version-INDEPENDENT defense is the static
+  //    scripts/check-no-mutation-or.mjs guard, which blocks the pattern in code —
+  //    important because the failure mode is now SILENT (a wrong filter would
+  //    mis-update quietly) rather than a loud 42703.
   const incidentOr =
     `or=(status.in.(pending,failed),and(status.eq.processing,updated_at.lt.${encodeURIComponent(cutoff)}))`;
-  const orUpdate = await req(
-    'PATCH',
-    `/stripe_events?event_id=eq.${EV}&${incidentOr}`,
+  const nestedOr = await req(
+    'PATCH', `/stripe_events?event_id=eq.${EV}&${incidentOr}`,
     { jwt: SERVICE, prefer: 'return=representation', body: { attempts: 99 } },
   );
-  check('.update().or() is rejected, not a silent success', orUpdate.status >= 400,
-    `status=${orUpdate.status} body=${JSON.stringify(orUpdate.body)}`);
-  check('.update().or() fails with PG 42703 (undefined_column)', orUpdate.body?.code === '42703',
-    `status=${orUpdate.status} code=${orUpdate.body?.code} body=${JSON.stringify(orUpdate.body)}`);
-  console.log(
-    `     .update().or() → status=${orUpdate.status}, code=${orUpdate.body?.code}, message=${JSON.stringify(orUpdate.body?.message)}`,
-  );
-  // Diagnostic only (not asserted): how a FLAT `or` on the same mutation behaves
-  // on this PostgREST version — fixed upstream, so this is expected to be 200.
   const flatOr = await req(
     'PATCH', `/stripe_events?event_id=eq.${EV}&or=(status.eq.pending,status.eq.failed)`,
     { jwt: SERVICE, prefer: 'return=representation', body: { attempts: 98 } },
   );
-  console.log(`     (flat .or() → status=${flatOr.status}, code=${flatOr.body?.code ?? 'n/a'})`);
+  console.log(
+    `  diag .update().or() incident(nested) → status=${nestedOr.status}, code=${nestedOr.body?.code ?? 'n/a'}` +
+    `; flat → status=${flatOr.status}, code=${flatOr.body?.code ?? 'n/a'} ` +
+    `(42703 here = incident reproduced; 200 = or-on-mutation fixed upstream — static guard remains the defense)`,
+  );
 
   psql(`delete from public.stripe_events where event_id like '__g5_pgrst%'`);
 

--- a/scripts/db-replay.sh
+++ b/scripts/db-replay.sh
@@ -32,6 +32,13 @@ if [ -f supabase/baseline.sql ]; then
     n="$(basename "$f" | grep -oE '^[0-9]+' || echo 000)"
     if [ "$n" \> "$cut" ]; then echo "   apply $(basename "$f")"; run -f "$f"; fi
   done
+  # Role GRANTs (the structure-only baseline excludes them). Applied last so they
+  # cover whatever the migrations left in place; required for the PostgREST tests
+  # to hit real per-role permission boundaries (anon vs service_role).
+  if [ -f supabase/baseline.grants.sql ]; then
+    echo ">> applying role grants (supabase/baseline.grants.sql)"
+    run -f supabase/baseline.grants.sql
+  fi
 else
   echo ">> AUDIT mode: no baseline; shim + full replay (expects history defects, see PR #984)"
   run -f scripts/ci-db-bootstrap.sql

--- a/supabase/baseline.grants.sql
+++ b/supabase/baseline.grants.sql
@@ -1,0 +1,116 @@
+-- supabase/baseline.grants.sql
+-- Role GRANTs for the GATE-mode db-contract harness (G5).
+--
+-- supabase/baseline.sql is a STRUCTURE-ONLY dump and excludes role privileges,
+-- so a fresh CI database has no anon/authenticated/service_role grants and
+-- PostgREST cannot reach any table or RPC. This file restores the exact prod
+-- grant picture so the PostgREST client tests exercise real permission
+-- boundaries (anon vs service_role). Applied by scripts/db-replay.sh AFTER the
+-- baseline + post-baseline migrations, BEFORE the contract tests.
+--
+-- EXTRACTED FROM PROD (project kcrdpikxbhhmhbgcayiy, 2026-06-06) via the
+-- Supabase MCP. Regenerate alongside supabase/baseline.sql with:
+--   table grants:    information_schema.role_table_grants  (schema=public, grantee in the 3 roles)
+--   function grants:  pg_proc + aclexplode(proacl)         (EXECUTE; PUBLIC = grantee oid 0)
+--
+-- NOT replicated (absent from the structure-only baseline, and untouched by the
+-- current tests): the share_analytics VIEW, and the serial sequences
+-- ai_insights_log_id_seq / symptom_contributions_id_seq (the dump rendered those
+-- id columns as bare bigint, dropping the owned sequences). Flagged as a baseline
+-- gap on the G5 PR; add their grants here if/when the baseline regains them.
+
+set search_path to public, auth, storage, extensions;
+
+-- Schema usage (Supabase grants this to every API role).
+grant usage on schema public to anon, authenticated, service_role;
+
+-- ── Table / view privileges ────────────────────────────────────────────────
+-- Supabase default: full privileges to all three API roles; RLS does the actual
+-- row-level protection. Two prod exceptions are encoded below.
+
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.account_deletion_requests to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.ai_insights_log to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.ai_usage to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.analysis_data to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.analysis_sessions to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.consent_audit to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.daily_usage_snapshots to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.data_contributions to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.device_diagnostics to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.discord_digest_events to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.discord_pending_roles to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.discord_role_events to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.email_log to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.email_sequences to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.error_submissions to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.feedback to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.kv_alert_dedup to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.oximetry_trace_contributions to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.premium_interest to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.provider_interest to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.remind_requests to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.signal_daily_counts to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.stripe_events to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.subscribers to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.subscription_events to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.subscriptions to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.symptom_contributions to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.unsupported_device_submissions to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.user_files to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.user_nights to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.user_storage_usage to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.waitlist to anon, authenticated, service_role;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.waveform_contributions to anon, authenticated, service_role;
+
+-- Exception: profiles — anon/authenticated have everything EXCEPT UPDATE.
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE on table public.profiles to anon, authenticated;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.profiles to service_role;
+
+-- Exception: shared_analyses — anon/authenticated get only REFERENCES/TRIGGER/TRUNCATE
+-- (no read/write through the API; reads go via the share token path / service_role).
+grant REFERENCES, TRIGGER, TRUNCATE on table public.shared_analyses to anon, authenticated;
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.shared_analyses to service_role;
+
+-- ── Function EXECUTE privileges ─────────────────────────────────────────────
+-- Prod locks these RPCs down: EXECUTE revoked from PUBLIC, granted to specific
+-- roles. A freshly-created function defaults to EXECUTE for PUBLIC, so without
+-- the REVOKEs anon could call service-only RPCs (e.g. claim_stripe_event) and
+-- the anon-vs-service_role permission test would not hold.
+
+revoke execute on function public.claim_stripe_event(p_event_id text, p_attempts integer, p_stale_cutoff timestamp with time zone) from public;
+grant execute on function public.claim_stripe_event(p_event_id text, p_attempts integer, p_stale_cutoff timestamp with time zone) to service_role;
+revoke execute on function public.cleanup_ai_insights_log() from public;
+grant execute on function public.cleanup_ai_insights_log() to service_role;
+revoke execute on function public.cleanup_expired_shared_analyses() from public;
+grant execute on function public.cleanup_expired_shared_analyses() to service_role;
+revoke execute on function public.cleanup_old_analysis_sessions() from public;
+grant execute on function public.cleanup_old_analysis_sessions() to service_role;
+revoke execute on function public.export_ml_training_data() from public;
+grant execute on function public.export_ml_training_data() to service_role;
+revoke execute on function public.get_community_benchmarks() from public;
+grant execute on function public.get_community_benchmarks() to service_role;
+revoke execute on function public.get_community_symptom_stats(p_ifl_risk numeric, p_pressure_bucket text) from public;
+grant execute on function public.get_community_symptom_stats(p_ifl_risk numeric, p_pressure_bucket text) to service_role;
+revoke execute on function public.get_extended_stats() from public;
+grant execute on function public.get_extended_stats() to service_role;
+revoke execute on function public.get_latest_usage_snapshot() from public;
+grant execute on function public.get_latest_usage_snapshot() to service_role;
+revoke execute on function public.get_monthly_ai_token_usage(p_month text) from public;
+grant execute on function public.get_monthly_ai_token_usage(p_month text) to service_role;
+revoke execute on function public.get_storage_stats() from public;
+grant execute on function public.get_storage_stats() to service_role;
+revoke execute on function public.get_symptom_aggregate_stats() from public;
+grant execute on function public.get_symptom_aggregate_stats() to service_role;
+revoke execute on function public.increment_ai_usage(p_user_id uuid, p_month text, p_input_tokens bigint, p_output_tokens bigint) from public;
+grant execute on function public.increment_ai_usage(p_user_id uuid, p_month text, p_input_tokens bigint, p_output_tokens bigint) to service_role;
+revoke execute on function public.increment_signal_count(p_signal_type text, p_signal_name text) from public;
+grant execute on function public.increment_signal_count(p_signal_type text, p_signal_name text) to service_role;
+revoke execute on function public.ml_dataset_stats() from public;
+grant execute on function public.ml_dataset_stats() to service_role;
+grant execute on function public.run_db_integrity_checks() to service_role;
+grant execute on function public.handle_new_user() to anon, authenticated, service_role;
+grant execute on function public.rls_auto_enable() to anon, authenticated, service_role;
+grant execute on function public.update_storage_usage() to anon, authenticated, service_role;
+grant execute on function public.update_symptom_contributions_updated_at() to anon, authenticated, service_role;
+grant execute on function public.update_updated_at() to anon, authenticated, service_role;
+


### PR DESCRIPTION
## G5 — real-PostgREST client tests (builds on #984)

Stands a **PostgREST service container** in front of the GATE-mode baseline DB from #984 and runs end-to-end client tests over the real request path — a live PostgREST speaking to a real Postgres over HTTP, switching roles by JWT.

### What the `db-contract` job now does
1. Builds the GATE-mode DB (pre-shim + `baseline.sql` + post-baseline migrations + **new** `baseline.grants.sql`) and runs the SQL contract tests.
2. Brings up `postgrest/postgrest:v12.2.12` (the Supabase GA line). It connects as the `postgres` superuser — which exists from container init, so there's no cold-start race — and `SET ROLE`s into `anon`/`service_role` per request (`db-anon-role=anon`). Every request switches role, so no query runs as superuser and the per-role boundaries are faithful.
3. Runs `scripts/ci-postgrest-tests.mjs` (built-in `fetch`/`crypto`, no npm deps) — **9 asserted + 1 diagnostic**, all green:
   - **claim_stripe_event happy path + idempotency** (service-role JWT) — a fresh `processing` row is not re-claimed.
   - **permission boundary** — `anon` is denied (401 / PG `42501`), `service_role` is allowed (200). Prod revokes `EXECUTE` on the RPC from `PUBLIC`; replicated in the grants file (a freshly-created function defaults to `PUBLIC` execute, so without the REVOKE the boundary would not hold).
   - **schema-cache reload** — a new function is invisible until `NOTIFY pgrst, 'reload schema'`.
   - **`.update().or()` (diagnostic, logged not asserted)** — see finding below.

### Finding: the 42703 `.update().or()` symptom is fixed upstream
The 2026-06-04 billing incident was `.update().or()` → PostgREST `42703 "column stripe_events.status does not exist"` (migration 063). **Verified across 4 CI runs that this no longer reproduces** on PostgREST v12.2.12 or v13.0.8 — *both* the flat `or` and the **exact nested incident filter** (`or=(status.in.(pending,failed),and(status.eq.processing,updated_at.lt.<cutoff>))`) return **200** (the filter is applied correctly). Upstream PostgREST fixed `or` on mutations.

So G5 logs the live `or`-on-mutation behaviour as a **diagnostic** rather than asserting 42703. The version-independent defense remains the static `scripts/check-no-mutation-or.mjs` guard — arguably *more* important now, because the failure mode is **silent** (a wrong filter mis-updates quietly) rather than a loud 42703. (Couldn't fingerprint prod's exact PostgREST version — Cloudflare strips the `Server` header and the OpenAPI root needs the `service_role` key.)

### Why a separate grants file
`supabase/baseline.sql` is structure-only and **excludes role privileges**, so a fresh CI DB has no grants and PostgREST can reach nothing. `supabase/baseline.grants.sql` restores the **exact prod grant picture** (extracted via the Supabase MCP). Kept separate so a `supabase db dump` regen of the baseline doesn't clobber it.

### Baseline gap surfaced (follow-up, not blocking)
The structure-only baseline **omits** the `share_analytics` VIEW and the `ai_insights_log` / `symptom_contributions` serial sequences (id columns dumped as bare `bigint`). Their grants are excluded here — none are touched by these tests — but the baseline should regain them on the next regen.

### Status
**NON-REQUIRED**, same as #984. Promote once reliably green across a few runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)