### PR TITLE
docs(ops): update Gmail OAuth scope to gmail.modify + gmail.labels (AIR-2543)

### DIFF
--- a/docs/ops/credentials.md
+++ b/docs/ops/credentials.md
@@ -64,9 +64,13 @@ Used by: feedback-processor cron (`/api/cron/feedback-processor`, 07:00 UTC dail
 **Re-issue refresh token** (required if token is revoked or after secret rotation):
 
 1. Re-run the OAuth consent flow for `dev@airwaylab.app` in Google OAuth Playground or equivalent
-2. Exchange auth code for a new refresh token (scope: `https://www.googleapis.com/auth/gmail.compose`)
+2. Exchange auth code for a new refresh token with **only these two scopes**:
+   - `https://www.googleapis.com/auth/gmail.modify`
+   - `https://www.googleapis.com/auth/gmail.labels`
+   - Do NOT include `gmail.compose` (prohibited by AIR-742) or `gmail.settings.basic` (no use case)
 3. File a board approval before updating Vercel
 4. After approval: update `GMAIL_REFRESH_TOKEN` in Vercel (Production + Preview + Development)
+5. Also update Cortis gmail-mcp token: `~/tools/gmail-mcp/instances/airwaylab/accounts/airwaylab/token.json`
 
 **Verify** by triggering `GET /api/cron/feedback-processor` (with `CRON_SECRET` header) and confirming the response is `{ ok: true }`, not `{ skipped: true }`.
 


### PR DESCRIPTION
## Summary

- Updates `credentials.md` rotation instructions to remove `gmail.compose` (prohibited by AIR-742) and `gmail.settings.basic` (no documented use case)
- Correct approved scopes: `gmail.modify` + `gmail.labels` only
- Adds step 5 to the re-issue instructions: also update the Cortis gmail-mcp token

This is a docs-only change. The actual token re-authorization is a manual board action tracked in AIR-2543 / AIR-2545.

## Test plan

- [x] No code logic changed — docs only
- [x] All 2689 tests pass
- [ ] Demian completes OAuth re-auth with reduced scopes (external action, tracked in AIR-2543)

🤖 Generated with [Claude Code](https://claude.com/claude-code)