### PR TITLE
fix(mdr): replace RERA detection term in dashboard upgrade banner (AIR-2519)

### DIFF
--- a/components/dashboard/post-analysis-upgrade.tsx
+++ b/components/dashboard/post-analysis-upgrade.tsx
@@ -71,7 +71,7 @@ export function PostAnalysisUpgrade({ isComplete, sequencerActive, onDismiss }: 
             </button>
           </div>
           <p className="mt-1 text-xs text-muted-foreground">
-            You just got Glasgow Index, flow limitation scores, and RERA detection — free, in your browser.
+            You just got Glasgow Index, flow limitation scores, and effort-pattern analysis — free, in your browser.
             Want to go deeper?
           </p>
           <div className="mt-3 grid gap-2 sm:grid-cols-3">


### PR DESCRIPTION
## Summary

`components/dashboard/post-analysis-upgrade.tsx:74` used "RERA detection" as a product feature claim in the upgrade banner shown to users after completing their first analysis. Presenting "RERA detection" as a delivered capability implies the software clinically detects a medical event (RERA = Respiratory Effort-Related Arousal), which risks MDR Rule 2 reclassification.

**Fix:** `RERA detection` → `effort-pattern analysis` — consistent with the batch remediation in:
- PR #963 (AIR-2481): compare pages
- PR #980 (AIR-2509): app/landing/shared/guides pages

## Changes

Single line in `components/dashboard/post-analysis-upgrade.tsx:74`.

## Closes

AIR-2519 (delegated fix from AIR-2517)

## Test plan

- [ ] Dashboard upgrade banner shows "effort-pattern analysis" instead of "RERA detection" after first analysis upload
- [ ] Lint ✅, typecheck ✅, tests pass

## MDR checklist

- [x] "RERA detection" feature claim removed from user-visible component
- [x] Replacement language is neutral descriptor consistent with prior batch fixes
- [x] No diagnostic language introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)