### PR TITLE
fix(device-diagnostic): stop false "Unsupported Device" alarm; route by support status

### DIFF
--- a/__tests__/device-diagnostic-dedup.test.ts
+++ b/__tests__/device-diagnostic-dedup.test.ts
@@ -14,13 +14,15 @@ const kvStore = new Map<string, KvRow>()
 let _insertFn = vi.fn().mockResolvedValue({ error: null })
 // Shared sendAlert spy delegated to via wrapper — survives vi.resetModules()
 let _sendAlertFn = vi.fn().mockResolvedValue(true)
+// Shared routeAlert spy — the device-diagnostic route now routes via the AIR-1841 taxonomy
+let _routeAlertFn = vi.fn().mockResolvedValue(false)
 
 vi.mock('@/lib/discord-webhook', () => ({
   sendAlert: (...args: unknown[]) => _sendAlertFn(...args),
   formatUserSignalEmbed: vi.fn().mockReturnValue({}),
   COLORS: { green: 0x10b981, amber: 0xf59e0b, red: 0xef4444, blue: 0x3b82f6, purple: 0x8b5cf6, teal: 0x14b8a6 },
   _budget: { date: '', count: 0 },
-  routeAlert: vi.fn().mockResolvedValue(false),
+  routeAlert: (...args: unknown[]) => _routeAlertFn(...args),
   sendOpsAlert: vi.fn().mockResolvedValue(false),
   sendCriticalAlert: vi.fn().mockResolvedValue(false),
   alertCredentialExpiry: vi.fn().mockResolvedValue(false),
@@ -88,46 +90,51 @@ function makeRequest(deviceModel: string, hasStrFile = false): NextRequest {
   })
 }
 
-describe('device-diagnostic dedup', () => {
+// The loud, deduped engineering alert raised only for SUPPORTED devices that fail extraction.
+const LOUD = 'supported_device_extraction_failed'
+const countType = (t: string) => _routeAlertFn.mock.calls.filter((c) => c[0] === t).length
+
+describe('device-diagnostic dedup + routing', () => {
   beforeEach(() => {
     kvStore.clear()
     _insertFn = vi.fn().mockResolvedValue({ error: null })
     _sendAlertFn = vi.fn().mockResolvedValue(true)
+    _routeAlertFn = vi.fn().mockResolvedValue(false)
   })
 
-  it('fires 1 alert for 10 calls with the same device model', async () => {
+  it('fires 1 platform-health alert for 10 calls with the same supported model', async () => {
     for (let i = 0; i < 10; i++) {
       await POST(makeRequest('ResMed-AirSense10'))
     }
-    expect(_sendAlertFn).toHaveBeenCalledTimes(1)
+    expect(countType(LOUD)).toBe(1)
   })
 
-  it('fires 2 alerts for two distinct device models (5 calls each)', async () => {
+  it('fires 2 alerts for two distinct supported models (5 calls each)', async () => {
     for (let i = 0; i < 5; i++) {
       await POST(makeRequest('ResMed-AirSense10'))
     }
     for (let i = 0; i < 5; i++) {
-      await POST(makeRequest('Philips-DreamStation'))
+      await POST(makeRequest('ResMed-AirCurve10'))
     }
-    expect(_sendAlertFn).toHaveBeenCalledTimes(2)
+    expect(countType(LOUD)).toBe(2)
   })
 
-  it('re-fires alert for same model after 24h TTL elapses', async () => {
+  it('re-fires alert for same supported model after 24h TTL elapses', async () => {
     let fakeNow = Date.now()
     vi.spyOn(Date, 'now').mockImplementation(() => fakeNow)
 
     await POST(makeRequest('ResMed-AirSense10'))
-    expect(_sendAlertFn).toHaveBeenCalledTimes(1)
+    expect(countType(LOUD)).toBe(1)
 
     // Still within 24h — no second alert
     await POST(makeRequest('ResMed-AirSense10'))
-    expect(_sendAlertFn).toHaveBeenCalledTimes(1)
+    expect(countType(LOUD)).toBe(1)
 
     // Advance past 24h window
     fakeNow += 24 * 60 * 60 * 1000 + 1
 
     await POST(makeRequest('ResMed-AirSense10'))
-    expect(_sendAlertFn).toHaveBeenCalledTimes(2)
+    expect(countType(LOUD)).toBe(2)
 
     vi.restoreAllMocks()
   })
@@ -140,10 +147,22 @@ describe('device-diagnostic dedup', () => {
     expect(_insertFn).toHaveBeenCalledTimes(callCount)
   })
 
+  it('suppresses the live alert for Unknown/unsupported uploads but still captures the row', async () => {
+    for (let i = 0; i < 5; i++) {
+      await POST(makeRequest('Unknown'))
+    }
+    // No loud supported-device alarm for the expected unsupported tail…
+    expect(countType(LOUD)).toBe(0)
+    // …routed to the suppressed taxonomy instead…
+    expect(countType('unsupported_device_unknown')).toBe(5)
+    // …and the row is still written for the support roadmap.
+    expect(_insertFn).toHaveBeenCalledTimes(5)
+  })
+
   it('cold-start simulation: 3 cold-starts × 10 requests produce exactly 1 alert', async () => {
     // Each vi.resetModules() + re-import simulates a Vercel cold-start.
     // kvStore (shared module-level Map) persists across resets, simulating the DB.
-    // _sendAlertFn is a shared reference so calls from all module instances are counted.
+    // _routeAlertFn is a shared reference so calls from all module instances are counted.
     let totalAlerts = 0
 
     for (let coldStart = 0; coldStart < 3; coldStart++) {
@@ -151,11 +170,11 @@ describe('device-diagnostic dedup', () => {
       const { POST: freshPOST } = await import('@/app/api/device-diagnostic/route')
 
       for (let i = 0; i < 10; i++) {
-        await freshPOST(makeRequest('ResMed-ColdStart'))
+        await freshPOST(makeRequest('ResMed-ColdStart-AirSense'))
       }
 
-      totalAlerts += _sendAlertFn.mock.calls.length
-      _sendAlertFn.mockClear()
+      totalAlerts += countType(LOUD)
+      _routeAlertFn.mockClear()
     }
 
     expect(totalAlerts).toBe(1)

--- a/app/api/device-diagnostic/route.ts
+++ b/app/api/device-diagnostic/route.ts
@@ -4,9 +4,20 @@ import { z } from 'zod';
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
-import { sendAlert, formatUserSignalEmbed } from '@/lib/discord-webhook';
+import { routeAlert } from '@/lib/discord-webhook';
 import { checkAndUpdateDedup } from './_dedup';
 import { trackSignalCount } from '@/lib/signal-tracker';
+
+/**
+ * Device families whose settings we actually extract (ResMed AirSense/AirCurve, BMC).
+ * Anything else — including the `Unknown` fallback — is an unsupported or incomplete
+ * upload (non-ResMed hardware or a partial SD card), which is an expected long tail,
+ * not an error worth a live alert.
+ */
+function isSupportedModel(model: string): boolean {
+  const m = model.toLowerCase();
+  return m.includes('airsense') || m.includes('aircurve') || m.includes('bmc');
+}
 
 const limiter = new RateLimiter({ windowMs: 3_600_000, max: 5 });
 
@@ -90,19 +101,33 @@ export async function POST(request: NextRequest) {
     const now = Date.now();
 
     if (supabase) {
-      const { shouldFire, suppressedCount } = await checkAndUpdateDedup(
-        supabase,
-        deviceModel,
-        new Date(now),
-      );
-      if (shouldFire) {
-        void sendAlert('user-signals', '', [formatUserSignalEmbed({
-          type: 'unsupported_device',
-          message: `Settings extraction failed — model: ${deviceModel}, hasStr: ${hasStrFile} (${suppressedCount} hit${suppressedCount !== 1 ? 's' : ''} in last 24h)`,
-        })]);
+      if (isSupportedModel(deviceModel)) {
+        // A device we DO support produced an empty-settings diagnostic — a genuine
+        // engineering signal worth investigating. Deduped per model and routed to the
+        // quiet #platform-health channel, NOT the user-facing alarm.
+        const { shouldFire, suppressedCount } = await checkAndUpdateDedup(
+          supabase,
+          deviceModel,
+          new Date(now),
+        );
+        if (shouldFire) {
+          void routeAlert(
+            'supported_device_extraction_failed',
+            `:warning: Settings extraction failed for a SUPPORTED device — model: ${deviceModel}, hasStr: ${hasStrFile} (${suppressedCount} hit${suppressedCount !== 1 ? 's' : ''} in last 24h)`,
+          );
+        }
+        void trackSignalCount('supported_device_extraction_failed', 'Supported Device Extraction Failed');
+      } else {
+        // Unsupported or incomplete upload (non-ResMed hardware or a partial card).
+        // Expected long tail — the row is already captured above for the support
+        // roadmap; do NOT raise a live alert (routeAlert suppresses this type).
+        void routeAlert(
+          'unsupported_device_unknown',
+          `Unsupported/incomplete upload — model: ${deviceModel}, hasStr: ${hasStrFile}`,
+        );
+        void trackSignalCount('unsupported_device', 'Unsupported Device');
       }
     }
-    void trackSignalCount('unsupported_device', 'Unsupported Device');
 
     return NextResponse.json({ ok: true });
   } catch (err) {

--- a/lib/discord-webhook.ts
+++ b/lib/discord-webhook.ts
@@ -82,6 +82,7 @@ export type AlertType =
   // → #platform-health
   | 'sentry_spike'
   | 'deploy_to_prod'
+  | 'supported_device_extraction_failed' // a device we support produced an empty-settings diagnostic
   // → #audit-log
   | 'account_deletion'
   // → weekly-digest accumulator (no live Discord push)
@@ -147,6 +148,7 @@ const ALERT_ROUTING: Record<AlertType, RoutingDecision> = {
   // #platform-health
   sentry_spike: { action: 'send', channel: 'platform-health' },
   deploy_to_prod: { action: 'send', channel: 'platform-health' },
+  supported_device_extraction_failed: { action: 'send', channel: 'platform-health' },
   // #audit-log
   account_deletion: { action: 'send', channel: 'audit-log' },
   // weekly-digest accumulator — no live Discord push


### PR DESCRIPTION
## What & why

The `#user-signals` Discord alert **"Settings extraction failed — model: Unknown, hasStr: false (44 hits in last 24h)"** read like a mass upload failure. It isn't.

Investigation (prod Supabase + Sentry + code):
- **Core analysis is healthy.** 2,687 analyses in 7d; **100% of supported-device analyses carry real settings** (AirSense + AirCurve, `settingsSource=extracted`, IPAP/EPAP populated). AirCurve 10/11 (VAuto/ASV) extract 809/809.
- The alert fires on the **expected long tail** — ~46/day `Unknown`/no-STR uploads = non-ResMed hardware (a "Lowenstein 25ST" is in `unsupported_device_submissions`) or incomplete cards. Chronic, flat 21+ days. **Not a regression.**
- The blunt legacy path pushed *every* such upload to the loud user-facing channel.

## Change (route-only — no `lib/parsers`/`lib/analyzers`/`workers`, so the clinical gate is not triggered)

`app/api/device-diagnostic/route.ts` now routes by whether we actually support the model:
- **Supported family** (AirSense/AirCurve/BMC) with empty settings → genuine engineering signal: **deduped per model**, routed to the quiet **#platform-health** channel.
- **Unknown / unsupported / incomplete** → **suppressed** (no live cry); the `device_diagnostics` row is still written for the support roadmap.

`lib/discord-webhook.ts` adds the `supported_device_extraction_failed` alert type to the existing AIR-1841 `routeAlert` taxonomy.

## Deliberately deferred

The worker-side root cleanup — the AirCurve "missing ST-mode signals" **false-positive** diagnostic at `analysis-worker.ts:196` that writes an indistinguishable payload to `device_diagnostics` — is **not** in this PR. It touches `workers/` and will land with the upload-capture work under `clinical-signoff`.

## Tests / verification

- `typecheck` 0 errors, `lint` 0, **17/17** device-diagnostic tests pass (added a suppression test for the Unknown tail).
- Full suite green **except 2 pre-existing failures unrelated to this PR** (both fail identically on untouched `origin/main`): `clinical-input-guards` golden test is a 1-ULP cross-platform float diff (`periodicityIndex …215744` vs `…21575`) and `analytics-completeness` is a flaky PostHog race. Worth a separate fix (pin the golden tolerance); flagged, not addressed here.

## Post-deploy check

Re-run an AirCurve VAuto upload → confirm no loud alert; confirm an `Unknown`/no-STR upload writes its row but raises no live alert. Watch `#platform-health` only surface genuinely-supported failures (expected ~0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
