### PR TITLE
fix(oximetry): usable uploaded CSV overrides empty device SA2 (#988 root cause)

### DIFF
--- a/__tests__/oximetry-engine.test.ts
+++ b/__tests__/oximetry-engine.test.ts
@@ -167,5 +167,24 @@ describe('Oximetry Engine', () => {
       expect(result.spo2Mean).toBeGreaterThan(0);
       expect(hasUsableOximetry(result)).toBe(true);
     });
+
+    it('judges an empty/placeholder SA2 (all-invalid samples) as not usable', () => {
+      // parseSA2 emits spo2=-1, valid=false for out-of-range placeholder data.
+      // This is the empty-SA2 signature that was masking the real uploaded CSV
+      // (#988): a full night of these still has 0 retained samples, so a usable
+      // uploaded CSV must win over it.
+      const start = new Date('2026-06-06T22:00:00Z');
+      const emptySA2: OximetrySample[] = Array.from({ length: 5000 }, (_, i) => ({
+        time: new Date(start.getTime() + i * 1000),
+        spo2: -1,
+        hr: -1,
+        motion: 0,
+        valid: false,
+      }));
+
+      const result = computeOximetry(emptySA2, 1);
+      expect(result.retainedSamples).toBe(0);
+      expect(hasUsableOximetry(result)).toBe(false);
+    });
   });
 });

--- a/workers/analysis-worker.ts
+++ b/workers/analysis-worker.ts
@@ -491,13 +491,25 @@ async function processFiles(
     }
   }
 
-  // Step 5: Parse oximetry CSVs (SA2 takes priority — skip CSV if SA2 already present)
+  // Step 5: Parse oximetry CSVs. A device SA2 file is normally preferred, but some
+  // machines emit empty/placeholder SA2.edf files that parse to all-invalid samples
+  // (issue #988). Those must not mask an explicitly-uploaded CSV. So a *usable*
+  // uploaded CSV overrides an existing SA2 entry for the same night — the user
+  // deliberately uploaded it, and this survives empty SA2 regardless of its
+  // internal structure. computeNightOximetry later drops anything still unusable.
   if (oximetryCSVs) {
     for (const csv of oximetryCSVs) {
       try {
         const parsed = parseOximetryCSV(csv);
-        if (oximetryByDate.has(parsed.dateStr)) {
-          console.debug(`[oximetry] SA2 data available for night ${parsed.dateStr}, skipping CSV`);
+        const existing = oximetryByDate.get(parsed.dateStr);
+        if (existing) {
+          const csvUsable = hasUsableOximetry(computeOximetry(parsed.samples, parsed.intervalSeconds));
+          if (csvUsable) {
+            oximetryByDate.set(parsed.dateStr, parsed);
+            console.debug(`[oximetry] uploaded CSV overrides device SA2 for night ${parsed.dateStr}`);
+          } else {
+            console.debug(`[oximetry] keeping device SA2 for night ${parsed.dateStr} (uploaded CSV not usable)`);
+          }
         } else {
           oximetryByDate.set(parsed.dateStr, parsed);
         }


### PR DESCRIPTION
## Confirmed root cause of airwaylab-app/airwaylab-app#106

The reporter found it and confirmed by experiment. Some ResMed machines write `SA2.edf` files that contain **no real pulse-ox data**. `parseSA2` does not throw on these (out-of-range SpO2 → `spo2=-1`, `valid=false`), so the placeholder SA2 still lands in `oximetryByDate`. In the **combined CPAP+oximetry upload** path, SA2 took priority and the user's real uploaded CSV was skipped (`SA2 data available for night X, skipping CSV` — visible in his console). Deleting the SA2 files from the folder made his oximetry appear.

This is the *actual* cause of the all-0.0 report — not the parser, and not the `<60` path fixed in airwaylab-app/airwaylab#998 (that was a separate latent bug). The reporter's files parse cleanly to a full usable night.

## Change

In `processFiles` (ResMed combined path), a **usable uploaded CSV now overrides an existing SA2 entry** for the same night:

```
existing SA2 for this night + uploaded CSV is usable  -> CSV wins (user intent)
existing SA2 + uploaded CSV NOT usable                -> keep device SA2
no SA2                                                -> use the CSV (unchanged)
```

Why this rule (the reporter's option B, refined): it fixes his case **regardless of the SA2's internal structure** — his CSV is known usable, so it wins over whatever the placeholder SA2 contains. The conservative alternative (detect "empty SA2" and fall back) would depend on the exact placeholder shape, which varies. A non-usable CSV never displaces device SA2, so users with working integrated oximeters are unaffected unless they deliberately upload a good CSV.

Behavior note for review: a user who has **good** device SA2 **and** uploads a usable CSV will now get the CSV. That matches "they wouldn't upload it if they didn't want it used," but it is a deliberate behavior change worth a conscious sign-off.

## Verification
- `vitest` oximetry suites: 39/39 pass, including a new test locking that the empty-SA2 signature (all-invalid samples) is judged **not usable**, so the usable CSV wins.
- `tsc --noEmit` clean, `eslint` clean.

## NOT done / needs confirmation
- **Real SA2 fixture:** the reporter attached an example `SA2.edf`. I have not received it locally yet — a sanitized integration fixture from it should follow to lock `parseSA2` behavior on a real empty file.
- **Residual "0.0 with graphs after deleting SA2":** the reporter also saw stats stay 0.0 while the trace rendered, after removing SA2. In current code trace + stats attach together, so this is likely deploy-lag (pre-#998 build) or stale persisted stats from earlier uploads. Needs his fresh re-test on a build that includes airwaylab-app/airwaylab#998 + this PR.
- Touches `workers/` → **scanner + human `clinical-signoff` required before merge. Do not auto-merge.**

Refs airwaylab-app/airwaylab-app#106
