### PR TITLE
fix(oximetry): bump ENGINE_VERSION to invalidate stale cache (#988)

### DIFF
--- a/lib/engine-version.ts
+++ b/lib/engine-version.ts
@@ -12,4 +12,4 @@
  * - lib/analyzers/oximetry-engine.ts
  * - lib/parsers/night-grouper.ts (affects which data goes to which night)
  */
-export const ENGINE_VERSION = '0.8.0';
+export const ENGINE_VERSION = '0.9.0';


### PR DESCRIPTION
## Why
The reporter confirmed airwaylab-app/airwaylab#1011 works for the most recent day, but **previous days still show the oximetry graph with 0.0 stats** after a clean re-upload.

**Root cause (verified):** `lib/engine-version.ts` documents that `ENGINE_VERSION` must be bumped "when any analysis engine logic changes" (it lists `lib/analyzers/oximetry-engine.ts`). airwaylab-app/airwaylab#998 and airwaylab-app/airwaylab#1011 both changed oximetry behavior but left it at `0.8.0`. Both caches are version-gated:
- night-results (localStorage): cleared on mismatch — `lib/persistence.ts:230`
- oximetry traces (IndexedDB): cleared on mismatch — `lib/waveform-idb.ts`

Without the bump, "unchanged" nights are restored from cache and **never re-analyzed** (`lib/analysis-orchestrator.ts:155-180`), so they keep stale pre-fix 0.0 stats + stale graphs. Only changed/new nights recompute — which is why only the most recent day works.

## Change
One line: `ENGINE_VERSION` `0.8.0` → `0.9.0`. This is the routine cache-bust airwaylab-app/airwaylab#998/#1011 omitted.

## Consequence (please confirm before merge)
Bumping invalidates every user's cached results and traces. On next visit they are prompted to re-upload once, after which all nights re-analyze with the current engine (correct oximetry). This is the designed behavior of the version mechanism, but it is an all-users event.

Non-clinical (`lib/engine-version.ts` is not a gated path).

Refs airwaylab-app/airwaylab-app#106