### PR TITLE
feat(device-capture): privacy-preserving device-identity, fingerprint + brand foundations

### DIFF
--- a/__tests__/device-brand-classifier.test.ts
+++ b/__tests__/device-brand-classifier.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { classifyBrand, type FileRef } from '@/lib/device-brand-classifier';
+
+const refs = (paths: string[]): FileRef[] =>
+  paths.map((p) => ({ name: p.split('/').pop() || p, path: p }));
+
+describe('classifyBrand', () => {
+  it('detects ResMed from DATALOG + BRP', () => {
+    const r = classifyBrand(refs([
+      'DATALOG/20260111/20260111_210649_BRP.edf',
+      'STR.edf',
+      'Identification.tgt',
+    ]));
+    expect(r.brand).toBe('resmed');
+  });
+
+  it('detects ResMed from STR.edf alone', () => {
+    expect(classifyBrand(refs(['STR.edf'])).brand).toBe('resmed');
+  });
+
+  it('detects BMC from the numeric SERIAL.idx + SERIAL.000 triad', () => {
+    const r = classifyBrand(refs(['12345678.idx', '12345678.000', '12345678.usr']));
+    expect(r.brand).toBe('bmc');
+  });
+
+  it('returns unknown for an unrecognised brand and logs the signature', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const r = classifyBrand(refs(['P1/001.001', 'P1/002.002', 'SETTINGS.BIN']));
+    expect(r.brand).toBe('unknown');
+    expect(warn).toHaveBeenCalledWith(
+      '[brand-classifier] unmatched device signature',
+      expect.objectContaining({ fileCount: 3 }),
+    );
+    warn.mockRestore();
+  });
+
+  it('always returns an auditable signature (extensions, folders, count)', () => {
+    const r = classifyBrand(refs(['DATALOG/x/y_BRP.edf', 'STR.edf']));
+    expect(r.signature.fileCount).toBe(2);
+    expect(r.signature.extensions.edf).toBe(2);
+    expect(r.signature.folders).toContain('DATALOG/X');
+  });
+
+  it('does not crash and stays quiet on an empty upload', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const r = classifyBrand([]);
+    expect(r.brand).toBe('unknown');
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/__tests__/device-fingerprint.test.ts
+++ b/__tests__/device-fingerprint.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { extractDeviceFingerprint } from '@/lib/device-fingerprint';
+
+// Synthetic identifiers only — never real device serials/GUIDs in fixtures.
+const SERIAL = '22200000001';
+const GUID = '14ec73e2-0000-4000-8000-000000000000';
+
+const RESMED10 =
+  '\r\n#PNA AirCurve_10_VAuto\n\r\n#SRN ' +
+  SERIAL +
+  '\n\r\n#CID CX036-009-013-026-101-100-101\n\r\n#VID 0009\n\r\n#RID 000D';
+
+const RESMED11 = JSON.stringify({
+  FlowGenerator: {
+    IdentificationProfiles: {
+      Product: {
+        UniversalIdentifier: GUID,
+        SerialNumber: SERIAL,
+        ProductName: 'AirCurve 11 VAuto',
+        ModelNumber: '39000',
+      },
+    },
+  },
+});
+
+describe('extractDeviceFingerprint', () => {
+  it('parses ResMed 10 # code text: model + markers, serial isolated, no guid', () => {
+    const fp = extractDeviceFingerprint(RESMED10);
+    expect(fp.model).toBe('AirCurve_10_VAuto');
+    expect(fp.serial).toBe(SERIAL);
+    expect(fp.guid).toBeNull();
+    expect(fp.firmwareMarkers.CID).toBe('CX036-009-013-026-101-100-101');
+    expect(fp.firmwareMarkers.VID).toBe('0009');
+  });
+
+  it('parses ResMed 11 JSON: model + markers, serial + guid isolated', () => {
+    const fp = extractDeviceFingerprint(RESMED11);
+    expect(fp.model).toBe('AirCurve 11 VAuto');
+    expect(fp.serial).toBe(SERIAL);
+    expect(fp.guid).toBe(GUID);
+    expect(fp.firmwareMarkers.ModelNumber).toBe('39000');
+  });
+
+  it('NEVER leaks the serial or guid into firmwareMarkers (privacy invariant)', () => {
+    for (const sample of [RESMED10, RESMED11]) {
+      const fp = extractDeviceFingerprint(sample);
+      const markerBlob = JSON.stringify(fp.firmwareMarkers);
+      expect(markerBlob).not.toContain(SERIAL);
+      expect(markerBlob).not.toContain(GUID);
+    }
+  });
+
+  it('recovers serial + guid from truncated JSON (stored text is capped at 2000 chars)', () => {
+    // Cut a later field so JSON.parse fails but the serial/guid values stay intact —
+    // mirrors the real 2000-char cap, which only ever clips trailing fields.
+    const truncated = RESMED11.slice(0, RESMED11.indexOf('ModelNumber'));
+    const fp = extractDeviceFingerprint(truncated);
+    expect(fp.serial).toBe(SERIAL);
+    expect(fp.guid).toBe(GUID);
+  });
+
+  it('returns safe defaults for empty/absent input', () => {
+    for (const v of [null, undefined, '', '   ']) {
+      const fp = extractDeviceFingerprint(v);
+      expect(fp).toEqual({ model: 'Unknown', firmwareMarkers: {}, serial: null, guid: null });
+    }
+  });
+
+  it('falls back to a model hint from free text', () => {
+    const fp = extractDeviceFingerprint('garbage AirSense garbage');
+    expect(fp.model).toBe('AirSense');
+    expect(fp.serial).toBeNull();
+  });
+});

--- a/__tests__/device-id.test.ts
+++ b/__tests__/device-id.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const PEPPER = 'test-pepper-do-not-use-in-prod';
+
+describe('hashDeviceSerial', () => {
+  beforeEach(() => {
+    process.env.DEVICE_ID_PEPPER = PEPPER;
+  });
+  afterEach(() => {
+    delete process.env.DEVICE_ID_PEPPER;
+  });
+
+  async function load() {
+    const mod = await import('@/lib/device-id');
+    return mod.hashDeviceSerial;
+  }
+
+  it('is stable: same serial -> same key', async () => {
+    const hash = await load();
+    expect(hash('22200000001')).toBe(hash('22200000001'));
+  });
+
+  it('distinguishes different serials', async () => {
+    const hash = await load();
+    expect(hash('22200000001')).not.toBe(hash('23100000002'));
+  });
+
+  it('returns null for absent or blank serials (never hashes nothing)', async () => {
+    const hash = await load();
+    expect(hash(null)).toBeNull();
+    expect(hash(undefined)).toBeNull();
+    expect(hash('')).toBeNull();
+    expect(hash('   ')).toBeNull();
+  });
+
+  it('trims surrounding whitespace so formatting variance maps to one key', async () => {
+    const hash = await load();
+    expect(hash('  22200000001 ')).toBe(hash('22200000001'));
+  });
+
+  it('does not return the raw serial', async () => {
+    const hash = await load();
+    const out = hash('22200000001');
+    expect(out).not.toBeNull();
+    expect(out).not.toContain('22200000001');
+  });
+
+  it('changes with the pepper (so a leaked DB without the pepper cannot be re-linked)', async () => {
+    const hash1 = await load();
+    const a = hash1('22200000001');
+
+    process.env.DEVICE_ID_PEPPER = 'a-different-pepper';
+    const { hashDeviceSerial: hash2 } = await import('@/lib/device-id');
+    const b = hash2('22200000001');
+
+    expect(a).not.toBe(b);
+  });
+
+  it('throws (fails loud) when the pepper is not configured', async () => {
+    delete process.env.DEVICE_ID_PEPPER;
+    const hash = await load();
+    expect(() => hash('22200000001')).toThrow(/DEVICE_ID_PEPPER/);
+  });
+});

--- a/lib/device-brand-classifier.ts
+++ b/lib/device-brand-classifier.ts
@@ -1,0 +1,92 @@
+/**
+ * Device brand classification from the upload's file list (non-clinical).
+ *
+ * Classifies the PAP brand from file/folder NAMES only — no binary/EDF parsing — so it can
+ * run in an API route / orchestrator without touching the clinical-gated lib/parsers. The
+ * ResMed and BMC signatures are ported from lib/parsers/device-detector.ts (verified). We
+ * deliberately do NOT guess Philips / Löwenstein / Fisher & Paykel yet: a confident
+ * misclassification would poison the device-support roadmap. Instead every unmatched upload
+ * returns `unknown` PLUS a `signature` (extension histogram + folders) and is logged, so we
+ * can cluster real-world unknowns and learn their signatures before claiming detection.
+ */
+
+export type DeviceBrand =
+  | 'resmed'
+  | 'bmc'
+  | 'philips'
+  | 'lowenstein'
+  | 'fisher_paykel'
+  | 'unknown';
+
+export interface FileRef {
+  name: string;
+  path?: string;
+}
+
+export interface BrandSignature {
+  fileCount: number;
+  extensions: Record<string, number>;
+  folders: string[];
+}
+
+export interface BrandClassification {
+  brand: DeviceBrand;
+  label: string;
+  /** Always present — the auditable evidence, and the clustering input for unknown brands. */
+  signature: BrandSignature;
+}
+
+export function classifyBrand(files: FileRef[]): BrandClassification {
+  const signature = buildSignature(files);
+  const names = files.map((f) => f.name.toLowerCase());
+  const paths = files.map((f) => (f.path || f.name).toUpperCase());
+
+  // ResMed: DATALOG/ folder or BRP.edf or STR.edf or Identification.tgt
+  const isResMed =
+    paths.some((p) => p.includes('DATALOG')) ||
+    names.some((n) => n.endsWith('brp.edf') || n.endsWith('_brp.edf')) ||
+    names.some((n) => n === 'str.edf' || n.endsWith('/str.edf')) ||
+    names.some((n) => n.startsWith('identification.'));
+  if (isResMed) return { brand: 'resmed', label: 'ResMed', signature };
+
+  // BMC (Luna / RESmart): numeric SERIAL.idx/.usr with a companion SERIAL.000
+  if (hasBmcTriad(files)) return { brand: 'bmc', label: 'BMC / Luna', signature };
+
+  // Unknown — capture the signature so this brand can be learned, do not guess.
+  if (files.length > 0) {
+    console.warn('[brand-classifier] unmatched device signature', signature);
+  }
+  return { brand: 'unknown', label: 'Unknown device', signature };
+}
+
+function hasBmcTriad(files: FileRef[]): boolean {
+  const lower = files.map((f) => f.name.toLowerCase());
+  const has = (n: string) => lower.includes(n);
+  for (const name of lower) {
+    const dot = name.lastIndexOf('.');
+    if (dot < 0) continue;
+    const base = name.slice(0, dot);
+    const ext = name.slice(dot + 1);
+    if ((ext === 'idx' || ext === 'usr') && /^\d+$/.test(base) && has(`${base}.000`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function buildSignature(files: FileRef[]): BrandSignature {
+  const extensions: Record<string, number> = {};
+  const folders = new Set<string>();
+  for (const f of files) {
+    const ext = f.name.includes('.') ? f.name.split('.').pop()!.toLowerCase() : '(none)';
+    extensions[ext] = (extensions[ext] ?? 0) + 1;
+    const rel = f.path || f.name;
+    const parts = rel.split('/');
+    if (parts.length > 1) folders.add(parts.slice(0, -1).join('/').toUpperCase());
+  }
+  return {
+    fileCount: files.length,
+    extensions,
+    folders: Array.from(folders).sort().slice(0, 50),
+  };
+}

--- a/lib/device-fingerprint.ts
+++ b/lib/device-fingerprint.ts
@@ -1,0 +1,118 @@
+/**
+ * Device fingerprint extraction (non-clinical).
+ *
+ * Pulls the device-TYPE fingerprint (model + firmware/config markers) and isolates the
+ * device-IDENTITY values (serial, GUID) from a ResMed Identification file. This is string
+ * and JSON work only — it does NOT parse EDF signals or compute anything clinical, so it
+ * intentionally lives outside lib/parsers (which is clinical-gated). It deliberately
+ * re-implements the small bit of identification parsing it needs rather than importing
+ * lib/parsers/settings-extractor.
+ *
+ * Two real formats:
+ *   - ResMed 10  Identification.tgt text:  "#PNA AirCurve_10_VAuto", "#SRN <serial>",
+ *                "#CID CX036-...", "#VID", "#RID", ...   (# codes; #SRN is the serial)
+ *   - ResMed 11  JSON: {"FlowGenerator":{"IdentificationProfiles":{"Product":{
+ *                "UniversalIdentifier":"<guid>","SerialNumber":"<serial>",
+ *                "ProductName":"...","ModelNumber":"..."}}}}
+ *
+ * The markers map NEVER contains the serial or GUID. Serial/GUID are returned separately,
+ * for the caller to hash via lib/device-id and then discard — they are never persisted raw.
+ */
+
+export interface DeviceFingerprint {
+  /** Model/product name, e.g. "AirCurve_10_VAuto" or "AirCurve 11 VAuto". "Unknown" if absent. */
+  model: string;
+  /** Non-identifying firmware/config markers (ResMed # codes, JSON model/firmware fields). */
+  firmwareMarkers: Record<string, string>;
+  /** Identifying — for hashing ONLY, never persist. */
+  serial: string | null;
+  /** Identifying — for hashing ONLY, never persist. */
+  guid: string | null;
+}
+
+/** Keys whose VALUES identify an individual device and must never land in markers. */
+const IDENTIFYING_KEY = /serial|identifier|uuid|guid|\bsn\b/i;
+
+function emptyFingerprint(): DeviceFingerprint {
+  return { model: 'Unknown', firmwareMarkers: {}, serial: null, guid: null };
+}
+
+export function extractDeviceFingerprint(
+  identificationText: string | null | undefined,
+): DeviceFingerprint {
+  if (!identificationText || !identificationText.trim()) return emptyFingerprint();
+  const text = identificationText;
+
+  // Serial + GUID via regex first — robust even if the JSON is truncated (the stored
+  // identification_text is capped at 2000 chars) or in # code form.
+  const serial =
+    match(text, /"SerialNumber"\s*:\s*"([^"]+)"/i) ??
+    match(text, /#SRN\s+(\S+)/i) ??
+    null;
+  const guid = match(text, /"UniversalIdentifier"\s*:\s*"([0-9a-fA-F-]{8,})"/i) ?? null;
+
+  const fingerprint: DeviceFingerprint = { model: 'Unknown', firmwareMarkers: {}, serial, guid };
+
+  // Try JSON (ResMed 11) for model + markers.
+  const product = tryParseProduct(text);
+  if (product) {
+    for (const [key, value] of Object.entries(product)) {
+      if (typeof value !== 'string' && typeof value !== 'number') continue;
+      if (IDENTIFYING_KEY.test(key)) continue; // drop serial / UniversalIdentifier
+      fingerprint.firmwareMarkers[key] = String(value);
+    }
+    fingerprint.model =
+      str(product.ProductName) ?? str(product.ModelNumber) ?? fingerprint.model;
+  } else {
+    // ResMed 10 # code text: "#PNA value", "#CID value", ...
+    for (const m of text.matchAll(/#(\w+)\s+(\S+)/g)) {
+      const code = m[1]!.toUpperCase();
+      const value = m[2]!;
+      if (code === 'SRN') continue; // serial — already captured, never a marker
+      if (code === 'PNA') {
+        fingerprint.model = value;
+        continue;
+      }
+      fingerprint.firmwareMarkers[code] = value;
+    }
+  }
+
+  // Last-resort model hint from free text.
+  if (fingerprint.model === 'Unknown') {
+    const lc = text.toLowerCase();
+    if (lc.includes('aircurve')) fingerprint.model = 'AirCurve';
+    else if (lc.includes('airsense')) fingerprint.model = 'AirSense';
+  }
+
+  return fingerprint;
+}
+
+function match(text: string, re: RegExp): string | null {
+  const m = text.match(re);
+  return m && m[1] ? m[1] : null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v.trim() ? v : null;
+}
+
+/** Returns the ResMed-11 Product object if the text is parseable JSON containing one. */
+function tryParseProduct(text: string): Record<string, unknown> | null {
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!json || typeof json !== 'object') return null;
+  const fg = (json as Record<string, unknown>).FlowGenerator as Record<string, unknown> | undefined;
+  const profiles = (fg?.IdentificationProfiles ?? (json as Record<string, unknown>).IdentificationProfiles) as
+    | Record<string, unknown>
+    | Record<string, unknown>[]
+    | undefined;
+  if (!profiles) return null;
+  const product = Array.isArray(profiles)
+    ? (profiles[0]?.Product ?? profiles[0])
+    : (profiles.Product ?? profiles);
+  return product && typeof product === 'object' ? (product as Record<string, unknown>) : null;
+}

--- a/lib/device-id.ts
+++ b/lib/device-id.ts
@@ -1,0 +1,38 @@
+/**
+ * Device pseudonymisation.
+ *
+ * A device serial (ResMed #SRN / SerialNumber, or a per-device GUID) uniquely and
+ * permanently identifies one physical machine, and via the machine a person. We never
+ * persist it raw. Instead we store a keyed hash so we can still group uploads by device
+ * (distinct-device counts, per-device longitudinal ML, dedup) without holding the
+ * re-identifiable value.
+ *
+ * HMAC-SHA256 keyed by DEVICE_ID_PEPPER (mirrors lib/email/unsubscribe-token.ts). The
+ * pepper is a server-side secret so the hash cannot be brute-forced from the small,
+ * structured ResMed serial space. It is LONG-LIVED: rotating it changes every device key
+ * and breaks longitudinal grouping, so it must not share a rotating secret like CRON_SECRET.
+ *
+ * Note: a keyed hash is pseudonymous personal data under GDPR (Recital 26), not anonymous.
+ * It lowers exposure, it does not remove the data from scope. Keep device keys service-role
+ * only — they are a strong cross-record linkage key.
+ */
+
+import { createHmac } from 'crypto';
+
+function getPepper(): string {
+  const pepper = process.env.DEVICE_ID_PEPPER;
+  if (!pepper) throw new Error('DEVICE_ID_PEPPER not configured');
+  return pepper;
+}
+
+/**
+ * Stable pseudonymous key for a device serial/GUID.
+ * Same serial -> same key (under a fixed pepper). Returns null for an absent or blank
+ * serial — never hash nothing, and never fabricate a key.
+ */
+export function hashDeviceSerial(serial: string | null | undefined): string | null {
+  if (!serial) return null;
+  const normalised = serial.trim();
+  if (!normalised) return null;
+  return createHmac('sha256', getPepper()).update(normalised).digest('base64url');
+}


### PR DESCRIPTION
## What

First, dependency-free increment of the approved every-upload device-capture plan: three pure-lib modules + unit tests. **No callers yet**, so this is safe to merge ahead of the route/migration wiring, and it touches nothing under `lib/parsers`/`lib/analyzers`/`workers` (no clinical gate).

- **`lib/device-id.ts`** — `hashDeviceSerial()` = HMAC-SHA256(serial, `DEVICE_ID_PEPPER`). A stable pseudonymous **device key** so uploads can be grouped by physical device (distinct-device counts, per-device longitudinal ML, dedup) without persisting the raw serial/GUID. Keyed (not plain SHA-256) because ResMed serials are low-entropy and brute-forceable. Fails loud if the pepper is unset; returns `null` for absent serials.
- **`lib/device-fingerprint.ts`** — `extractDeviceFingerprint()` keeps the device-**type** fingerprint (model + `#CID/#VID/#RID` markers) and isolates the device-**identity** values (serial, GUID) for hashing only. String/JSON parsing only (no EDF), so it lives outside the clinical-gated parsers. **Privacy invariant (tested): markers never contain the serial or GUID.**
- **`lib/device-brand-classifier.ts`** — `classifyBrand()` from file-list names only. Confident ResMed/BMC (ported from `device-detector`); everything else → `unknown` **plus an auditable signature** (extension histogram + folders), logged, so unknown brands get learned rather than mis-guessed.

## Why this shape

Device identity is a first-class entity: people switch PAP devices (and oximeters) over time, so `user:device` is many-to-many and the hashed key is how each upload is attributed to the right machine. The pepper is **long-lived** (do NOT reuse `CRON_SECRET` — rotation breaks device grouping) and must be provisioned before the consumer PRs call `hashDeviceSerial`.

## Tests

19 unit tests: HMAC stability, null-handling, pepper isolation, fail-loud, truncated-JSON serial/GUID recovery, the serial/GUID-never-in-markers invariant, brand detection + unknown-signature logging. `typecheck` + `lint` clean.

Note: the full local suite has 2 **pre-existing** failures unrelated to this PR (a cross-platform float-ULP golden test and a flaky PostHog race); they fail identically on untouched `main`. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
