### PR TITLE
feat(oximetry): decouple oximetry cache version from the global engine version

### DIFF
--- a/__tests__/oximetry-trace-idb.test.ts
+++ b/__tests__/oximetry-trace-idb.test.ts
@@ -63,11 +63,12 @@ describe('oximetry-trace-idb load non-existent', () => {
 // ── Test 3: Engine version check exists ──────────────────────
 
 describe('oximetry-trace-idb engine version check', () => {
-  it('Test 3: loadOximetryTrace checks ENGINE_VERSION', async () => {
+  it('Test 3: loadOximetryTrace checks OXIMETRY_ENGINE_VERSION', async () => {
     const { readFileSync } = await import('fs');
     const { resolve } = await import('path');
     const source = readFileSync(resolve(__dirname, '../lib/oximetry-trace-idb.ts'), 'utf-8');
-    expect(source).toContain('result.engineVersion !== ENGINE_VERSION');
+    // Oximetry traces version independently of the global ENGINE_VERSION (#988 follow-up).
+    expect(source).toContain('result.engineVersion !== OXIMETRY_ENGINE_VERSION');
   });
 });
 

--- a/__tests__/persistence.test.ts
+++ b/__tests__/persistence.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { persistResults, loadPersistedResults, clearPersistedResults, clearPersistedNights, persistNightsIncremental, mergeNightsByDate } from '@/lib/persistence';
 import { filterNightsToTierWindow } from '@/lib/analysis-orchestrator';
 import { SAMPLE_NIGHTS } from '@/lib/sample-data';
+import { OXIMETRY_ENGINE_VERSION } from '@/lib/engine-version';
 import type { NightResult } from '@/lib/types';
 
 vi.mock('@sentry/nextjs', () => ({
@@ -440,6 +441,59 @@ describe('persistence', () => {
       localStorage.setItem('airwaylab_file_manifest', '{"manifests":[],"savedAt":1}');
       clearPersistedNights();
       expect(localStorage.getItem('airwaylab_file_manifest')).toBeNull();
+    });
+  });
+
+  // Oximetry-scoped cache invalidation (decoupled from the global ENGINE_VERSION).
+  // A future OXIMETRY_ENGINE_VERSION bump must refresh ONLY oximetry — drop the stale
+  // oximetry, keep CPAP, prompt re-upload — and only for users who have oximetry and a
+  // PRESENT-but-mismatched tag (existing caches without the tag must not be disturbed).
+  describe('loadPersistedResults — oximetry-scoped invalidation', () => {
+    beforeEach(() => {
+      storage.clear();
+      vi.clearAllMocks();
+    });
+
+    function seed(opts: { oximetryEngineVersion?: string | null; withOximetry?: boolean }): void {
+      persistResults(SAMPLE_NIGHTS, null);
+      const parsed = JSON.parse(storage.get('airwaylab_results')!);
+      for (const n of parsed.nights) {
+        n.oximetry = opts.withOximetry === false ? null : { spo2Mean: 95, odi3: 5, retainedSamples: 1000 };
+      }
+      if (opts.oximetryEngineVersion === null) delete parsed.oximetryEngineVersion;
+      else if (opts.oximetryEngineVersion !== undefined) parsed.oximetryEngineVersion = opts.oximetryEngineVersion;
+      storage.set('airwaylab_results', JSON.stringify(parsed));
+    }
+
+    it('drops stale oximetry, keeps CPAP, and flags oximetryUpgraded on a tag mismatch', () => {
+      seed({ oximetryEngineVersion: 'stale-0.0.0' });
+
+      const result = loadPersistedResults();
+      expect(result).not.toBeNull();
+      expect(result!.oximetryUpgraded).toBe(true);
+      expect(result!.nights).toHaveLength(SAMPLE_NIGHTS.length); // CPAP preserved
+      expect(result!.nights.every((n) => n.oximetry === null)).toBe(true);
+
+      // Re-persisted with the current oximetry tag → does not re-fire next load.
+      const reparsed = JSON.parse(storage.get('airwaylab_results')!);
+      expect(reparsed.oximetryEngineVersion).toBe(OXIMETRY_ENGINE_VERSION);
+      const second = loadPersistedResults();
+      expect(second!.oximetryUpgraded).toBeUndefined();
+    });
+
+    it('does NOT prompt when the oximetry tag is missing (existing caches; no extra prompt now)', () => {
+      seed({ oximetryEngineVersion: null });
+
+      const result = loadPersistedResults();
+      expect(result!.oximetryUpgraded).toBeUndefined();
+      expect(result!.nights[0]!.oximetry).not.toBeNull();
+    });
+
+    it('does NOT prompt when there is no cached oximetry, even on a tag mismatch', () => {
+      seed({ withOximetry: false, oximetryEngineVersion: 'stale-0.0.0' });
+
+      const result = loadPersistedResults();
+      expect(result!.oximetryUpgraded).toBeUndefined();
     });
   });
 });

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -132,6 +132,7 @@ function AnalyzePageInner() {
   const [_isIOS, setIsIOS] = useState(false);
   const [analyzeAuthModalOpen, setAnalyzeAuthModalOpen] = useState(false);
   const [engineUpgraded, setEngineUpgraded] = useState(false);
+  const [oximetryUpgraded, setOximetryUpgraded] = useState(false);
   const [activeTab, setActiveTab] = useState('overview');
   const tabScrollRef = useRef<HTMLDivElement>(null);
   const overviewPanelRef = useRef<HTMLDivElement>(null);
@@ -321,6 +322,10 @@ function AnalyzePageInner() {
         if (saved.engineUpgraded) {
           // Engine version changed — old results cleared, prompt re-upload (FB-22)
           setEngineUpgraded(true);
+        } else if (saved.oximetryUpgraded) {
+          // Oximetry analysis improved — CPAP nights kept, stale oximetry dropped;
+          // prompt re-upload of oximetry only (#988 follow-up).
+          setOximetryUpgraded(true);
         } else if (saved.nights.length === 0) {
           // Persisted data existed but contained 0 nights — data loss
           console.error('[persistence] Restored session has 0 nights — serving empty dashboard');
@@ -780,6 +785,22 @@ function AnalyzePageInner() {
               <p className="mt-0.5">
                 Your previous results were analyzed with an older engine version.
                 Re-upload your SD card to get improved analysis with the latest algorithms.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Oximetry upgrade banner — shown when oximetry analysis improved but CPAP results were kept */}
+      {oximetryUpgraded && status === 'idle' && !isDemo && (
+        <div className="mx-auto mb-4 max-w-lg">
+          <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/20 bg-amber-500/5 px-4 py-3">
+            <RefreshCw className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+            <div className="text-xs text-muted-foreground">
+              <p className="font-medium text-amber-400">Oximetry analysis improved</p>
+              <p className="mt-0.5">
+                We&apos;ve improved how we analyze oximetry data. Re-upload your oximetry data
+                to refresh your SpO2 and heart-rate results. Your CPAP results are unchanged.
               </p>
             </div>
           </div>

--- a/lib/contribute-oximetry-trace.ts
+++ b/lib/contribute-oximetry-trace.ts
@@ -6,7 +6,7 @@
 // ============================================================
 
 import * as Sentry from '@sentry/nextjs';
-import { ENGINE_VERSION } from './engine-version';
+import { OXIMETRY_ENGINE_VERSION } from './engine-version';
 import {
   getContributedOximetryDates,
   trackContributedOximetryDate,
@@ -123,7 +123,7 @@ export async function contributeOximetryTraceBackground(
 
   // Check engine version
   const lastEngine = getContributedOximetryEngine();
-  if (lastEngine !== null && lastEngine !== ENGINE_VERSION) {
+  if (lastEngine !== null && lastEngine !== OXIMETRY_ENGINE_VERSION) {
     clearContributedOximetryDates();
   }
 
@@ -159,7 +159,7 @@ export async function contributeOximetryTraceBackground(
           ...(isCompressed && { 'Content-Encoding': 'gzip' }),
           'x-night-date': night.dateStr,
           'x-contribution-id': contributionId,
-          'x-engine-version': ENGINE_VERSION,
+          'x-engine-version': OXIMETRY_ENGINE_VERSION,
           'x-sample-count': String(trace.trace.length),
           'x-duration-seconds': String(trace.durationSeconds),
           'x-device-model': night.settings.deviceModel || 'Unknown',
@@ -185,5 +185,5 @@ export async function contributeOximetryTraceBackground(
     }
   }
 
-  setContributedOximetryEngine(ENGINE_VERSION);
+  setContributedOximetryEngine(OXIMETRY_ENGINE_VERSION);
 }

--- a/lib/engine-version.ts
+++ b/lib/engine-version.ts
@@ -5,11 +5,27 @@
 // ============================================================
 
 /**
- * Current engine version. Bump this when any engine logic changes:
+ * Current engine version. Bump this when any non-oximetry engine logic changes:
  * - lib/analyzers/glasgow-index.ts
  * - lib/analyzers/wat-engine.ts
  * - lib/analyzers/ned-engine.ts
- * - lib/analyzers/oximetry-engine.ts
  * - lib/parsers/night-grouper.ts (affects which data goes to which night)
+ *
+ * Oximetry has its own version below so an oximetry-only change does not
+ * invalidate every user's CPAP results — see OXIMETRY_ENGINE_VERSION.
  */
 export const ENGINE_VERSION = '0.9.0';
+
+/**
+ * Oximetry analysis version, decoupled from ENGINE_VERSION. Bump ONLY when
+ * oximetry analysis changes:
+ * - lib/analyzers/oximetry-engine.ts
+ * - the oximetry attach / SA2-vs-CSV logic in workers/analysis-worker.ts
+ * - lib/oximetry-trace.ts (trace shape)
+ *
+ * Bumping this re-prompts ONLY users who have oximetry data (their CPAP results
+ * are preserved) and re-tags oximetry IDB traces + research contributions.
+ * Initialised to the current ENGINE_VERSION value so introducing it is seamless
+ * (existing oximetry traces tagged with ENGINE_VERSION still match).
+ */
+export const OXIMETRY_ENGINE_VERSION = '0.9.0';

--- a/lib/oximetry-trace-idb.ts
+++ b/lib/oximetry-trace-idb.ts
@@ -11,7 +11,7 @@
 import type { OximetryTraceData } from './types';
 import { OXIMETRY_STORE_NAME } from './waveform-idb';
 import { runTx, assertQuota, isQuotaError } from './idb-core';
-import { ENGINE_VERSION } from './engine-version';
+import { OXIMETRY_ENGINE_VERSION } from './engine-version';
 
 const STORE_NAME = OXIMETRY_STORE_NAME;
 const TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
@@ -48,7 +48,7 @@ export async function storeOximetryTrace(
       dateStr,
       ...trace,
       storedAt: Date.now(),
-      engineVersion: ENGINE_VERSION,
+      engineVersion: OXIMETRY_ENGINE_VERSION,
     };
     await runTx(STORE_NAME, 'readwrite', (tx) =>
       tx.objectStore(STORE_NAME).put(stored),
@@ -79,8 +79,8 @@ export async function loadOximetryTrace(
       return null;
     }
 
-    // Engine version mismatch → stale data
-    if (result.engineVersion !== ENGINE_VERSION) {
+    // Oximetry engine version mismatch → stale data
+    if (result.engineVersion !== OXIMETRY_ENGINE_VERSION) {
       deleteOximetryTrace(dateStr).catch(() => { /* fire-and-forget stale IDB cleanup */ });
       return null;
     }

--- a/lib/persistence.ts
+++ b/lib/persistence.ts
@@ -5,7 +5,7 @@
 
 import * as Sentry from '@sentry/nextjs';
 import type { NightResult } from './types';
-import { ENGINE_VERSION } from './engine-version';
+import { ENGINE_VERSION, OXIMETRY_ENGINE_VERSION } from './engine-version';
 
 const STORAGE_KEY = 'airwaylab_results';
 const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -23,6 +23,9 @@ interface PersistedData {
   therapyChangeDate: string | null;
   savedAt: number;
   engineVersion?: string;
+  /** Oximetry analysis version, decoupled from engineVersion. Lets an oximetry-only
+   *  change refresh just the oximetry (keeping CPAP results) — see loadPersistedResults. */
+  oximetryEngineVersion?: string;
 }
 
 /**
@@ -72,6 +75,7 @@ function trySerialise(
     therapyChangeDate,
     savedAt: Date.now(),
     engineVersion: ENGINE_VERSION,
+    oximetryEngineVersion: OXIMETRY_ENGINE_VERSION,
   };
 
   let json: string;
@@ -208,6 +212,7 @@ export function loadPersistedResults(): {
   therapyChangeDate: string | null;
   savedAt?: number;
   engineUpgraded?: boolean;
+  oximetryUpgraded?: boolean;
 } | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -309,6 +314,32 @@ export function loadPersistedResults(): {
         night.ned.amplitudeCvMedianEpoch = 0;
         night.ned.unstableEpochPct = 0;
       }
+    }
+
+    // Oximetry-scoped invalidation (separate from the global ENGINE_VERSION check above).
+    // Fires ONLY when the oximetry tag is PRESENT and mismatches, so existing caches
+    // (no tag yet) never trigger an extra prompt — only a future OXIMETRY_ENGINE_VERSION
+    // bump does. Drops just the stale oximetry, preserving CPAP/other-engine results, and
+    // re-persists with the current tag so it does not re-fire on the next load.
+    const hasOximetry = data.nights.some(
+      (n: NightResult) => n.oximetry !== null && n.oximetry !== undefined
+    );
+    if (
+      hasOximetry &&
+      data.oximetryEngineVersion &&
+      data.oximetryEngineVersion !== OXIMETRY_ENGINE_VERSION
+    ) {
+      for (const night of data.nights as NightResult[]) {
+        night.oximetry = null;
+        night.oximetryTrace = null;
+      }
+      persistResults(data.nights, data.therapyChangeDate);
+      return {
+        nights: data.nights,
+        therapyChangeDate: data.therapyChangeDate,
+        savedAt: data.savedAt,
+        oximetryUpgraded: true,
+      };
     }
 
     return {

--- a/lib/waveform-idb.ts
+++ b/lib/waveform-idb.ts
@@ -10,7 +10,7 @@
 // ============================================================
 
 import type { StoredWaveform } from './waveform-types';
-import { ENGINE_VERSION } from './engine-version';
+import { ENGINE_VERSION, OXIMETRY_ENGINE_VERSION } from './engine-version';
 import {
   getDB,
   runTx,
@@ -146,7 +146,10 @@ async function deleteWaveform(dateStr: string): Promise<void> {
  * Runs through the serialized queue, so it enqueues behind any pending write
  * for the same key (I3 — no longer deletes a freshly-written record).
  */
-async function deleteExpiredFromStore(storeName: string): Promise<void> {
+async function deleteExpiredFromStore(
+  storeName: string,
+  expectedEngineVersion: string = ENGINE_VERSION,
+): Promise<void> {
   await runTx(storeName, 'readwrite', (tx) => {
     const store = tx.objectStore(storeName);
     const request = store.openCursor();
@@ -156,7 +159,7 @@ async function deleteExpiredFromStore(storeName: string): Promise<void> {
         const entry = cursor.value as { storedAt: number; engineVersion: string };
         if (
           Date.now() - entry.storedAt > TTL_MS ||
-          entry.engineVersion !== ENGINE_VERSION
+          entry.engineVersion !== expectedEngineVersion
         ) {
           cursor.delete();
         }
@@ -175,7 +178,8 @@ async function deleteExpiredFromStore(storeName: string): Promise<void> {
 export async function deleteExpired(): Promise<void> {
   try {
     await deleteExpiredFromStore(WAVEFORM_STORE_NAME);
-    await deleteExpiredFromStore(OXIMETRY_STORE_NAME);
+    // Oximetry traces version independently (see OXIMETRY_ENGINE_VERSION).
+    await deleteExpiredFromStore(OXIMETRY_STORE_NAME, OXIMETRY_ENGINE_VERSION);
     await deleteExpiredFromStore(BREATH_DATA_STORE_NAME);
     await deleteExpiredFromStore(PLD_TRACES_STORE_NAME);
   } catch {


### PR DESCRIPTION
## Why
We just shipped oximetry analysis fixes (#998, airwaylab-app/airwaylab#1011, airwaylab-app/airwaylab#1012) and bumped the global `ENGINE_VERSION` (#1015) to force a one-time re-upload that refreshes everyone's results. That global lever is blunt: **any** future oximetry-only change invalidates **every** user's cached results, including pure-CPAP users who never used oximetry. This decouples oximetry so future oximetry changes are surgical.

## What
A separate `OXIMETRY_ENGINE_VERSION` (`lib/engine-version.ts`), initialised to the current `ENGINE_VERSION` (`0.9.0`) so introducing it is seamless and adds **no extra prompt this round**.

- **`lib/persistence.ts`** — results carry `oximetryEngineVersion`. On load, after the existing global check, if oximetry is cached **and** the tag is **present and mismatches**, the oximetry is nulled (CPAP kept), re-persisted with the current tag, and `oximetryUpgraded: true` is returned. A **missing** tag (existing caches) is not treated as stale → only a *future* bump prompts. This is what keeps the current round single-prompt.
- **`lib/oximetry-trace-idb.ts`**, **`lib/contribute-oximetry-trace.ts`**, and the oximetry branch of **`lib/waveform-idb.ts`** `deleteExpired` key off `OXIMETRY_ENGINE_VERSION`. Waveform/breath/PLD stay on the global `ENGINE_VERSION`.
- **`app/analyze/page.tsx`** — an oximetry-specific banner: "Oximetry analysis improved — re-upload your oximetry data … your CPAP results are unchanged." The user refreshes via the existing add-oximetry flow (`analyzeOximetryOnly`), no full SD re-upload.

## Behaviour
- **Pure-CPAP users:** never disturbed by oximetry changes again.
- **Oximetry users, future oximetry bump:** keep CPAP results, re-upload only oximetry.
- **This round:** unchanged — the global 0.9.0 prompt still drives the one-time re-upload; no second oximetry prompt (missing-tag rule).
- Research contributions now carry the oximetry version independently (the endpoint stores `engine_version` as a plain tag; no allow-list).

## Verification
- New persistence tests: mismatch drops oximetry + keeps CPAP + flags + re-persists (no re-fire); missing tag does not prompt; no-oximetry never prompts.
- Affected suites (persistence + IDB + contribution) 84/84. Full suite 2735/2736 — the one failure is the pre-existing `clinical-input-guards` `periodicityIndex` float-precision flake in `computeWAT`, unrelated to this change (no analysis math touched). `tsc` + `eslint` clean.
- Manual follow-up (not unit-testable here): bump `OXIMETRY_ENGINE_VERSION` in a scratch build → oximetry user sees the banner, CPAP intact, re-upload oximetry refreshes; CPAP-only user unaffected.

Non-clinical: no `lib/parsers`, `lib/analyzers`, or `workers` changes, so `clinical-gate` does not apply.

Refs airwaylab-app/airwaylab-app#106, airwaylab-app/airwaylab#1015
