### PR TITLE
fix(waveform): show machine-off gaps in the flow graph (#1019)

### DIFF
--- a/__tests__/waveform-session-gaps.test.ts
+++ b/__tests__/waveform-session-gaps.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSessionBoundaries,
+  sessionBreaks,
+  formatGapDuration,
+  wallClockForElapsed,
+  wallClockTickShort,
+  insertBreakRows,
+  formatWallClockTime,
+  formatElapsedTimeShort,
+} from '@/lib/waveform-utils';
+import type { SessionBoundary } from '@/lib/waveform-types';
+
+// A night where the machine was turned off mid-night (bug #1019):
+//   Session 1 — 22:00 local, 1h on  → 90000 samples @ 25 Hz
+//   Machine OFF 2h 13m (7980 s)
+//   Session 2 — 01:13 local (+1d), 30m on → 45000 samples
+const RATE = 25;
+const s1Start = new Date(2026, 2, 15, 22, 0, 0);
+const s2Start = new Date(2026, 2, 16, 1, 13, 0);
+const sessions = [
+  { flowData: { length: 90000 }, recordingDate: s1Start, durationSeconds: 3600 },
+  { flowData: { length: 45000 }, recordingDate: s2Start, durationSeconds: 1800 },
+];
+const boundaries: SessionBoundary[] = buildSessionBoundaries(sessions);
+
+describe('buildSessionBoundaries', () => {
+  it('records the running sample offset + wall-clock start per session', () => {
+    expect(boundaries).toHaveLength(2);
+    expect(boundaries[0]).toEqual({
+      startSampleIndex: 0, sampleCount: 90000, startWallClockMs: s1Start.getTime(), durationSeconds: 3600,
+    });
+    expect(boundaries[1]).toEqual({
+      startSampleIndex: 90000, sampleCount: 45000, startWallClockMs: s2Start.getTime(), durationSeconds: 1800,
+    });
+  });
+});
+
+describe('sessionBreaks', () => {
+  it('returns one interior break at the session-2 start with the real off-duration', () => {
+    const breaks = sessionBreaks(boundaries, RATE);
+    expect(breaks).toHaveLength(1);
+    expect(breaks[0]!.tSec).toBeCloseTo(3600, 3);   // 90000 / 25
+    expect(breaks[0]!.offSeconds).toBeCloseTo(7980, 3); // 2h 13m off
+  });
+
+  it('is empty for a single-session night or missing boundaries', () => {
+    expect(sessionBreaks(boundaries.slice(0, 1), RATE)).toEqual([]);
+    expect(sessionBreaks(undefined, RATE)).toEqual([]);
+  });
+});
+
+describe('formatGapDuration', () => {
+  it('formats compactly', () => {
+    expect(formatGapDuration(7980)).toBe('2h 13m');
+    expect(formatGapDuration(480)).toBe('8m');
+    expect(formatGapDuration(0)).toBe('0m');
+  });
+});
+
+describe('wallClockForElapsed (the timestamp fix)', () => {
+  it('anchors a session-2 sample to session-2 wall-clock, not session-1 + elapsed', () => {
+    const t = 4200; // 10 min into session 2 (boundary at 3600)
+    const got = wallClockForElapsed(t, boundaries, RATE, s1Start);
+    // session-aware: session-2 start + 600 s local
+    expect(got).toBe(formatWallClockTime(s2Start, 600));
+    // and crucially NOT the old single-anchor result (session-1 start + 4200 s) — that was the bug
+    expect(got).not.toBe(formatWallClockTime(s1Start, t));
+  });
+
+  it('falls back to the single anchor when there are no session boundaries', () => {
+    expect(wallClockForElapsed(600, undefined, RATE, s1Start)).toBe(formatWallClockTime(s1Start, 600));
+  });
+});
+
+describe('wallClockTickShort', () => {
+  it('shows session-2 clock time for a session-2 tick', () => {
+    const expected = new Date(s2Start.getTime() + 600 * 1000)
+      .toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
+    expect(wallClockTickShort(4200, boundaries, RATE, s1Start)).toBe(expected);
+  });
+
+  it('falls back to elapsed H:MM when no anchor is available', () => {
+    expect(wallClockTickShort(1000, undefined, RATE, null)).toBe(formatElapsedTimeShort(1000));
+  });
+});
+
+describe('insertBreakRows', () => {
+  it('inserts a null break row at each boundary so the trace breaks', () => {
+    const data = [
+      { t: 0, flow: 1, pressure: 2 },
+      { t: 3600, flow: 3, pressure: 4 },
+    ];
+    const out = insertBreakRows(data, [3600]);
+    expect(out).toHaveLength(3);
+    expect(out[1]).toEqual({ t: 3600, flow: null, pressure: null });
+    expect(out[2]).toEqual({ t: 3600, flow: 3, pressure: 4 });
+  });
+
+  it('returns the data unchanged when there are no breaks', () => {
+    const data = [{ t: 0, flow: 1, pressure: 2 }];
+    expect(insertBreakRows(data, [])).toBe(data);
+  });
+});

--- a/components/charts/flow-waveform.tsx
+++ b/components/charts/flow-waveform.tsx
@@ -12,8 +12,8 @@ import {
   ReferenceArea,
   ReferenceLine,
 } from 'recharts';
-import type { FlowSample, PressurePoint, WaveformEvent } from '@/lib/waveform-types';
-import { formatElapsedTimeShort, formatWallClockTime } from '@/lib/waveform-utils';
+import type { FlowSample, PressurePoint, WaveformEvent, SessionBoundary } from '@/lib/waveform-types';
+import { wallClockForElapsed, wallClockTickShort, sessionBreaks, formatGapDuration, insertBreakRows } from '@/lib/waveform-utils';
 import { CHART_COLORS, GRID_STROKE, AXIS_TICK_FILL, AXIS_LINE_STROKE, withAlpha } from '@/lib/chart-theme';
 import { useSyncedViewport } from '@/hooks/use-synced-viewport';
 import { downsampleForChart } from '@/lib/chart-downsample';
@@ -29,8 +29,12 @@ interface Props {
   events: WaveformEvent[];
   /** Set of visible event types. If undefined, all events are shown. Empty set = no events. */
   visibleEventTypes?: Set<EventType>;
-  /** Recording start time from EDF header — enables wall-clock timestamps in tooltips. */
+  /** Recording start time from EDF header — fallback anchor for wall-clock timestamps. */
   recordingStartTime?: Date | null;
+  /** Per-session boundaries — enables gap breaks + true per-session wall-clock labels. */
+  sessions?: SessionBoundary[];
+  /** Sampling rate (Hz) — needed to map chart-space seconds to session boundaries. */
+  sampleRate?: number;
 }
 
 const EVENT_COLORS: Record<string, { fill: string; stroke: string }> = {
@@ -69,17 +73,19 @@ const ALGORITHM_LEGEND: { type: EventType; label: string; tailwindClass: string 
   { type: 'm-shape', label: 'M', tailwindClass: 'bg-chart-1/25' },
 ];
 
-function FlowTooltipContent({ active, payload, label, recordingStartTime }: {
+function FlowTooltipContent({ active, payload, label, recordingStartTime, sessions, sampleRate }: {
   active?: boolean;
   payload?: Array<{ name: string; value: number; color: string }>;
   label?: number;
   recordingStartTime?: Date | null;
+  sessions?: SessionBoundary[];
+  sampleRate?: number;
 }) {
   if (!active || !payload || payload.length === 0 || label === undefined) return null;
 
   return (
     <div className="rounded-lg border border-border bg-popover px-3 py-2 text-xs shadow-md">
-      <p className="mb-1 font-medium text-foreground">{formatWallClockTime(recordingStartTime, label)}</p>
+      <p className="mb-1 font-medium text-foreground">{wallClockForElapsed(label, sessions, sampleRate ?? 0, recordingStartTime)}</p>
       {payload.map((entry, i) => (
         <p key={i} className="text-muted-foreground">
           <span style={{ color: entry.color }}>{entry.name}:</span>{' '}
@@ -97,9 +103,15 @@ export const FlowWaveform = memo(function FlowWaveform({
   events,
   visibleEventTypes,
   recordingStartTime,
+  sessions,
+  sampleRate,
 }: Props) {
   const viewport = useSyncedViewport();
   const hasPressure = pressure.length > 0;
+  const sampleRateHz = sampleRate ?? 0;
+
+  // Interior machine-off boundaries (empty for single-session nights / old data).
+  const breaks = useMemo(() => sessionBreaks(sessions, sampleRateHz), [sessions, sampleRateHz]);
 
   // Determine which types are active
   const activeTypes: Set<EventType> | null = visibleEventTypes ?? null;
@@ -122,7 +134,21 @@ export const FlowWaveform = memo(function FlowWaveform({
   }, [flow, pressure, hasPressure]);
 
   // Apply downsampleForChart (1,500-point Recharts cap)
-  const data = useMemo(() => downsampleForChart(allData), [allData]);
+  const baseData = useMemo(() => downsampleForChart(allData), [allData]);
+
+  // Machine-off boundaries inside the visible range — drive both the null
+  // trace-break rows and the labelled dividers below.
+  const visibleBreaks = useMemo(() => {
+    if (breaks.length === 0 || baseData.length === 0) return [];
+    const lo = baseData[0]!.t;
+    const hi = baseData[baseData.length - 1]!.t;
+    return breaks.filter((b) => b.tSec > lo && b.tSec < hi);
+  }, [breaks, baseData]);
+
+  const data = useMemo(
+    () => insertBreakRows(baseData, visibleBreaks.map((b) => b.tSec)),
+    [baseData, visibleBreaks],
+  );
 
   // Filter events to visible range + active types, capped to prevent SVG OOM
   const MAX_VISIBLE_EVENTS = 100;
@@ -148,7 +174,10 @@ export const FlowWaveform = memo(function FlowWaveform({
     return types;
   }, [events]);
 
-  const tickFormatter = useCallback((value: number) => formatElapsedTimeShort(value), []);
+  const tickFormatter = useCallback(
+    (value: number) => wallClockTickShort(value, sessions, sampleRateHz, recordingStartTime),
+    [sessions, sampleRateHz, recordingStartTime],
+  );
 
   // Build legend items from types that exist in data and are visible
   const machineItems = MACHINE_LEGEND.filter((item) =>
@@ -246,7 +275,7 @@ export const FlowWaveform = memo(function FlowWaveform({
               />
             )}
             <Tooltip
-              content={<FlowTooltipContent recordingStartTime={recordingStartTime} />}
+              content={<FlowTooltipContent recordingStartTime={recordingStartTime} sessions={sessions} sampleRate={sampleRateHz} />}
               isAnimationActive={false}
             />
 
@@ -257,6 +286,24 @@ export const FlowWaveform = memo(function FlowWaveform({
               strokeDasharray="4 2"
               strokeWidth={0.5}
             />
+
+            {/* Machine-off gap dividers — the trace breaks here; this labels the off-duration */}
+            {visibleBreaks.map((b) => (
+              <ReferenceLine
+                key={`gap-${b.tSec}`}
+                yAxisId="flow"
+                x={b.tSec}
+                stroke="hsl(215 20% 50%)"
+                strokeDasharray="2 3"
+                strokeWidth={1}
+                label={{
+                  value: `Machine off ${formatGapDuration(b.offSeconds)}`,
+                  fill: 'hsl(215 20% 60%)',
+                  fontSize: 8,
+                  position: 'insideTop',
+                }}
+              />
+            ))}
 
             {/* Event overlays */}
             {visibleEvents.map((event) => {
@@ -290,6 +337,7 @@ export const FlowWaveform = memo(function FlowWaveform({
               fill={withAlpha(CHART_COLORS[0], 0.1)}
               strokeWidth={1}
               dot={false}
+              connectNulls={false}
               isAnimationActive={false}
               name="Flow"
             />
@@ -303,6 +351,7 @@ export const FlowWaveform = memo(function FlowWaveform({
                 fill={withAlpha(CHART_COLORS[1], 0.05)}
                 strokeWidth={1.5}
                 dot={false}
+                connectNulls={false}
                 isAnimationActive={false}
                 name="Pressure"
               />

--- a/components/dashboard/graphs-tab.tsx
+++ b/components/dashboard/graphs-tab.tsx
@@ -139,6 +139,8 @@ function WaveformCharts({
             events={storedWaveform.events}
             visibleEventTypes={visibleTypes}
             recordingStartTime={selectedNight.sessionStartTime}
+            sessions={storedWaveform.sessions}
+            sampleRate={storedWaveform.sampleRate}
           />
         </ErrorBoundary>
 

--- a/components/share/shared-graphs-tab.tsx
+++ b/components/share/shared-graphs-tab.tsx
@@ -285,8 +285,9 @@ function SharedWaveformCharts({
         flow={flowData}
         pressure={pressureData}
         events={waveform.events}
-
         visibleEventTypes={visibleTypes}
+        sessions={waveform.sessions}
+        sampleRate={waveform.sampleRate}
       />
     </div>
   );

--- a/lib/engine-version.ts
+++ b/lib/engine-version.ts
@@ -11,5 +11,8 @@
  * - lib/analyzers/ned-engine.ts
  * - lib/analyzers/oximetry-engine.ts
  * - lib/parsers/night-grouper.ts (affects which data goes to which night)
+ *
+ * 0.10.0 — StoredWaveform now carries per-session boundaries (gap-aware flow
+ * graph). Bumped so cached waveforms regenerate with the `sessions` field.
  */
-export const ENGINE_VERSION = '0.9.0';
+export const ENGINE_VERSION = '0.10.0';

--- a/lib/waveform-orchestrator.ts
+++ b/lib/waveform-orchestrator.ts
@@ -208,6 +208,7 @@ class WaveformOrchestrator {
           leak: result.leak,
           storedAt: Date.now(),
           engineVersion: ENGINE_VERSION,
+          sessions: result.sessions ?? [],
         };
 
         this.cache.set(targetDate, stored);

--- a/lib/waveform-types.ts
+++ b/lib/waveform-types.ts
@@ -92,6 +92,23 @@ export interface WaveformStats {
 }
 
 /**
+ * One mask-on session within a night. A night can hold several when the machine
+ * was powered off (or the mask removed) mid-night. The flow/pressure arrays are
+ * concatenated machine-on-only, so these boundaries are what lets the viewer
+ * place a sample at its true wall-clock time and break the trace across the gap.
+ */
+export interface SessionBoundary {
+  /** Offset of this session's first sample in the concatenated flow array */
+  startSampleIndex: number;
+  /** Number of flow samples in this session */
+  sampleCount: number;
+  /** Wall-clock start of this session (epoch ms, from the EDF recordingDate) */
+  startWallClockMs: number;
+  /** Machine-on duration of this session in seconds */
+  durationSeconds: number;
+}
+
+/**
  * Raw waveform data stored in IndexedDB.
  * Contains full-resolution Float32Arrays for on-demand decimation.
  */
@@ -120,6 +137,12 @@ export interface StoredWaveform {
   storedAt: number;
   /** Engine version for cache invalidation */
   engineVersion: string;
+  /**
+   * Per-session boundaries within the night (gap-aware rendering). Optional so
+   * pre-existing IDB blobs read back gracefully; the ENGINE_VERSION bump that
+   * shipped this field regenerates them on next read.
+   */
+  sessions?: SessionBoundary[];
 }
 
 /** Message sent to the waveform worker */
@@ -154,6 +177,8 @@ export interface RawWaveformResult {
   leak: LeakPoint[];
   /** Night date string */
   dateStr: string;
+  /** Per-session boundaries within the night (for gap-aware rendering) */
+  sessions?: SessionBoundary[];
   /** Error message if extraction failed */
   error?: string;
 }

--- a/lib/waveform-utils.ts
+++ b/lib/waveform-utils.ts
@@ -13,6 +13,7 @@ import type {
   TidalVolumePoint,
   RespiratoryRatePoint,
   StoredWaveform,
+  SessionBoundary,
 } from './waveform-types';
 import { ENGINE_VERSION } from './engine-version';
 
@@ -762,6 +763,146 @@ export function formatWallClockTime(recordingDate: Date | undefined | null, elap
   const elapsedLabel = h > 0 ? `${h}h ${m}m in` : `${m}m in`;
 
   return `${timeStr} (${elapsedLabel})`;
+}
+
+// ── Multi-session (machine-off gap) helpers ─────────────────
+//
+// The flow array is concatenated machine-on only, so chart-space time `t` is
+// "machine-on elapsed seconds" and has no notion of a mid-night gap. These
+// helpers use the per-session boundaries to (a) place a sample at its true
+// wall-clock time and (b) break the trace where the machine was off.
+
+/**
+ * Resolve a chart-space elapsed time to the wall-clock anchor of the session it
+ * falls in, plus the local elapsed within that session. Falls back to a single
+ * anchor (today's behaviour) when boundaries are absent.
+ */
+function resolveSessionAnchor(
+  elapsedSec: number,
+  sessions: SessionBoundary[] | undefined,
+  sampleRate: number,
+  fallbackStart?: Date | null,
+): { anchor: Date | null; localSec: number } {
+  if (sessions && sessions.length > 0 && sampleRate > 0) {
+    let s = sessions[0]!;
+    for (const cand of sessions) {
+      if (cand.startSampleIndex / sampleRate <= elapsedSec + 1e-6) s = cand;
+      else break;
+    }
+    const startSec = s.startSampleIndex / sampleRate;
+    return { anchor: new Date(s.startWallClockMs), localSec: elapsedSec - startSec };
+  }
+  return { anchor: fallbackStart ?? null, localSec: elapsedSec };
+}
+
+/**
+ * Wall-clock label for a chart-space elapsed time, session-aware.
+ * Returns e.g. "2:18 AM (3h 15m in)" anchored to the correct session.
+ */
+export function wallClockForElapsed(
+  elapsedSec: number,
+  sessions: SessionBoundary[] | undefined,
+  sampleRate: number,
+  fallbackStart?: Date | null,
+): string {
+  const { anchor, localSec } = resolveSessionAnchor(elapsedSec, sessions, sampleRate, fallbackStart);
+  return formatWallClockTime(anchor, localSec);
+}
+
+/**
+ * Short HH:MM wall-clock tick label, session-aware. Falls back to elapsed H:MM
+ * when no wall-clock anchor is available (old data / single-anchor unset).
+ */
+export function wallClockTickShort(
+  elapsedSec: number,
+  sessions: SessionBoundary[] | undefined,
+  sampleRate: number,
+  fallbackStart?: Date | null,
+): string {
+  const { anchor, localSec } = resolveSessionAnchor(elapsedSec, sessions, sampleRate, fallbackStart);
+  if (!anchor || !(anchor instanceof Date)) return formatElapsedTimeShort(elapsedSec);
+  const wc = new Date(anchor.getTime() + localSec * 1000);
+  return wc.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+
+/**
+ * Interior session boundaries as chart-space break points. Each is the
+ * machine-on elapsed time where a later session begins, plus the real
+ * (wall-clock) off-duration that preceded it. Empty for single-session nights.
+ */
+export function sessionBreaks(
+  sessions: SessionBoundary[] | undefined,
+  sampleRate: number,
+): { tSec: number; offSeconds: number }[] {
+  if (!sessions || sessions.length < 2 || sampleRate <= 0) return [];
+  const breaks: { tSec: number; offSeconds: number }[] = [];
+  for (let k = 1; k < sessions.length; k++) {
+    const prev = sessions[k - 1]!;
+    const cur = sessions[k]!;
+    const prevEndMs = prev.startWallClockMs + prev.durationSeconds * 1000;
+    breaks.push({
+      tSec: +(cur.startSampleIndex / sampleRate).toFixed(3),
+      offSeconds: Math.max(0, (cur.startWallClockMs - prevEndMs) / 1000),
+    });
+  }
+  return breaks;
+}
+
+/**
+ * Build per-session boundaries from the night's ordered sessions. The flow array
+ * is concatenated machine-on only, so `startSampleIndex` is the running sample
+ * offset; `startWallClockMs` keeps the real start so gaps can be reconstructed.
+ */
+export function buildSessionBoundaries(
+  sessions: { flowData: { length: number }; recordingDate: Date; durationSeconds: number }[],
+): SessionBoundary[] {
+  const out: SessionBoundary[] = [];
+  let offset = 0;
+  for (const s of sessions) {
+    out.push({
+      startSampleIndex: offset,
+      sampleCount: s.flowData.length,
+      startWallClockMs: s.recordingDate.getTime(),
+      durationSeconds: s.durationSeconds,
+    });
+    offset += s.flowData.length;
+  }
+  return out;
+}
+
+/** Format a machine-off gap duration compactly, e.g. "2h 13m" or "8m". */
+export function formatGapDuration(seconds: number): string {
+  const total = Math.max(0, Math.round(seconds));
+  const h = Math.floor(total / 3600);
+  const m = Math.round((total % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+/** A null row used to break a Recharts trace across a machine-off gap. */
+export interface ChartBreakRow { t: number; flow: null; pressure: null }
+
+/**
+ * Insert null break rows at the given chart-space times so a trace with
+ * connectNulls={false} breaks across each machine-off gap. Each break is placed
+ * just before the first point at/after its time. Returns the data unchanged when
+ * there are no breaks.
+ */
+export function insertBreakRows<T extends { t: number }>(
+  data: T[],
+  breakTimes: number[],
+): (T | ChartBreakRow)[] {
+  if (breakTimes.length === 0 || data.length === 0) return data;
+  const sorted = [...breakTimes].sort((a, b) => a - b);
+  const out: (T | ChartBreakRow)[] = [];
+  let bi = 0;
+  for (const point of data) {
+    while (bi < sorted.length && sorted[bi]! <= point.t) {
+      out.push({ t: sorted[bi]!, flow: null, pressure: null });
+      bi++;
+    }
+    out.push(point);
+  }
+  return out;
 }
 
 /**

--- a/lib/waveform-worker.ts
+++ b/lib/waveform-worker.ts
@@ -12,11 +12,13 @@ import {
   computeTidalVolume,
   computeRespiratoryRate,
   detectMShapeInWorker,
+  buildSessionBoundaries,
 } from './waveform-utils';
 import type {
   WaveformWorkerMessage,
   RawWaveformResult,
   WaveformEvent,
+  SessionBoundary,
 } from './waveform-types';
 import type { EDFFile } from './types';
 
@@ -42,6 +44,7 @@ self.onmessage = (e: MessageEvent<WaveformWorkerMessage>) => {
         respiratoryRate: [],
         leak: [],
         dateStr: targetDate,
+        sessions: [],
       };
       self.postMessage(response);
     }
@@ -58,6 +61,7 @@ self.onmessage = (e: MessageEvent<WaveformWorkerMessage>) => {
       respiratoryRate: [],
       leak: [],
       dateStr: e.data.targetDate,
+      sessions: [],
       error: err instanceof Error ? err.message : String(err),
     };
     self.postMessage(response);
@@ -99,10 +103,14 @@ function extractWaveform(
 
   if (!targetGroup) return null;
 
-  // Concatenate flow data from all sessions
+  // Concatenate flow data from all sessions. Sessions are concatenated machine-on
+  // only (the mid-night off period carries no samples), so we record each session's
+  // boundary + wall-clock start here — the one place that still knows them — so the
+  // viewer can place samples at true wall-clock time and break the trace across gaps.
   const sessions = targetGroup.sessions;
   const totalFlowSamples = sessions.reduce((sum, s) => sum + s.flowData.length, 0);
   const combinedFlow = new Float32Array(totalFlowSamples);
+  const sessionBoundaries: SessionBoundary[] = buildSessionBoundaries(sessions);
   let offset = 0;
   let avgSamplingRate = 0;
   let hasPressure = true;
@@ -193,6 +201,7 @@ function extractWaveform(
     respiratoryRate,
     leak,
     dateStr: targetDate,
+    sessions: sessionBoundaries,
   };
 }
 


### PR DESCRIPTION
## What & why
Fixes #1019. On nights where the PAP machine is turned off mid-night, the flow graph stitched the separate mask-on sessions back-to-back with **no visible gap**, and timestamps for the 2nd+ session were wrong.

**Root cause:** `lib/waveform-worker.ts` concatenates a night's sessions into one flat array (machine-on only) and discarded the per-session boundaries. Everything downstream rendered machine-on elapsed time, and the wall-clock tooltip used a single night-start anchor, so it ignored the off period.

## Approach (labelled break + true wall-clock labels)
The x-axis domain stays machine-on elapsed seconds (so **events and viewport are unchanged**), and we add the missing session info:

- **Worker** emits per-session boundaries → `StoredWaveform.sessions` (`SessionBoundary[]`: sample offset + wall-clock start + machine-on duration).
- **Chart** breaks the trace at each boundary (`connectNulls={false}` + null rows) and draws a divider labelled with the real off-duration ("Machine off 2h 13m").
- **Tick + tooltip** resolve wall-clock **per session** (`wallClockForElapsed` / `wallClockTickShort`), so session-2 points show their true clock time. The shared view gains wall-clock too (it had no `recordingStartTime`).
- **`ENGINE_VERSION` 0.9.0 → 0.10.0** so cached (IndexedDB) waveforms regenerate with the new field. No DB migration — the cache is client-side. Old/single-session data degrades gracefully (no breaks, single-anchor labels).

The gap is **not drawn to scale** (deliberate) so a long off-period doesn't squash the real waveform.

## ⚠ Clinical surface — needs `clinical-signoff`
Touches `lib/waveform-*`. Please review before merge; do not merge without `clinical-signoff`. A misaligned timeline can cause misreading of when events occurred relative to wall-clock and other channels — this PR corrects that.

## Verification
- `tsc --noEmit`: clean
- `eslint` on changed files: clean
- New unit tests `__tests__/waveform-session-gaps.test.ts` (boundary build, breaks, gap formatting, **session-aware wall-clock**, null-row insertion): pass
- Full `vitest run`: **2742 pass, 1 fail** — the 1 failure (`clinical-input-guards.test.ts`, a 1-ULP `periodicityIndex` float diff) **reproduces identically on clean `origin/main`** with these changes stashed, i.e. it is a pre-existing environment/Node float-precision artifact, not introduced here.
- Manual real-path check against a real multi-session night is still recommended before sign-off (no such SD-card fixture available in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
