### PR TITLE
fix(sentry): silence oximetry_insufficient_samples noise

### DIFF
--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -503,8 +503,11 @@ class AnalysisOrchestrator {
           case 'WARNING': {
             const isTruncated = msg.detail.includes('Truncated');
             // Truncated EDFs are common on SD cards (power loss, incomplete writes).
-            // Non-truncated warnings are actual parsing issues worth tracking.
-            if (!isTruncated) {
+            // oximetry_insufficient_samples fires once per night when the user's
+            // oximetry data is too sparse — user data quality, not a code bug.
+            // Both are silenced from Sentry; all other warnings are tracked.
+            const isDataQuality = msg.checkpoint === 'oximetry_insufficient_samples';
+            if (!isTruncated && !isDataQuality) {
               Sentry.captureMessage(msg.detail, {
                 level: 'warning',
                 tags: {
@@ -749,7 +752,9 @@ class AnalysisOrchestrator {
             // still returning OXIMETRY_RESULTS. Previously only RESULTS/ERROR were
             // handled, so a partial bad parse looked fully successful. Push the warning
             // to state so the UI can surface it instead of silently dropping it.
-            if (!msg.detail.includes('Truncated')) {
+            // oximetry_insufficient_samples is data quality (user's file is sparse),
+            // not a code bug — skip Sentry, surface to UI only.
+            if (!msg.detail.includes('Truncated') && msg.checkpoint !== 'oximetry_insufficient_samples') {
               Sentry.captureMessage(msg.detail, {
                 level: 'warning',
                 tags: { checkpoint: msg.checkpoint, ...msg.tags },


### PR DESCRIPTION
## Summary

- `oximetry_insufficient_samples` is a user data quality condition (oximetry file too sparse after cleaning) — not a code bug
- The worker emits this `WARNING` once per night; the orchestrator's general WARNING handler routed it to Sentry `captureMessage`, causing 1589 events across 9 users in 24 hours (AIR-2570)
- Fix: add `msg.checkpoint !== 'oximetry_insufficient_samples'` guard in both WARNING handlers, alongside the existing `Truncated` guard

**Root cause:** commit `00725dc` added `computeNightOximetry()` which correctly emits the warning for UI display. The orchestrator already forwarded all non-truncated warnings to Sentry — the combination made this noisy. The UI warning path is unaffected; users still see the warning.

## Test plan

- [x] TypeScript: `npx tsc --noEmit` — passes
- [x] Lint: `npm run lint` — passes
- [x] Tests: `npm test` — 2726 tests pass (180 test files)
- [ ] Vercel preview deploy verified by Demian

## Pre-merge checklist

- [x] Full pipeline passes (lint, typecheck, test)
- [ ] Vercel preview deploy verified by Demian
- [x] PR contains one concern only
- [x] No new regressions — WARNING still routes to Sentry for all other checkpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)