### PR TITLE
seo/content: Wave 2 301 redirects + privacy device-key disclosures (AIR-2298, AIR-2590)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,9 @@ PAPERCLIP_SIGNAL_WEBHOOK_SECRET=
 # routine webhook for any signals above threshold whose real-time webhook failed.
 PAPERCLIP_SIGNALS_WEBHOOK_URL=
 PAPERCLIP_SIGNALS_WEBHOOK_SECRET=
+
+# Device pseudonymisation (AIR-1020 device-capture)
+# HMAC-SHA256 pepper for device serial/GUID hashing. Long-lived secret — do NOT reuse
+# CRON_SECRET or any rotating secret. Rotating this value changes every device key and
+# permanently breaks per-device longitudinal grouping.
+DEVICE_ID_PEPPER=

--- a/app/blog/posts/cpap-data-analysis-browser-no-download.tsx
+++ b/app/blog/posts/cpap-data-analysis-browser-no-download.tsx
@@ -121,7 +121,7 @@ export default function CPAPDataAnalysisBrowserNoDownloadPost() {
           </p>
           <p>
             Read the full comparison:{' '}
-            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+            <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
               AirwayLab vs OSCAR: How They Complement Each Other
             </Link>
             .

--- a/app/blog/posts/cpap-data-privacy.tsx
+++ b/app/blog/posts/cpap-data-privacy.tsx
@@ -323,7 +323,7 @@ export default function CPAPDataPrivacyPost() {
             -- a deeper look at who can access your sleep data and your rights.
           </p>
           <p>
-            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+            <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
               AirwayLab vs OSCAR
             </Link>{' '}
             -- comparing privacy-first tools for PAP data analysis.

--- a/app/blog/posts/cpap-data-report-what-doctor-sees.tsx
+++ b/app/blog/posts/cpap-data-report-what-doctor-sees.tsx
@@ -410,7 +410,7 @@ export default function CPAPDataReportWhatDoctorSees() {
           </p>
           <p>
             <Link
-              href="/blog/cpap-leak-rate-meaning"
+              href="/blog/cpap-leak-rate-explained"
               className="text-primary hover:text-primary/80"
             >
               CPAP Leak Rate: What It Means and When to Worry

--- a/app/blog/posts/cpap-leak-rate-meaning.tsx
+++ b/app/blog/posts/cpap-leak-rate-meaning.tsx
@@ -308,7 +308,7 @@ export default function CPAPLeakRateMeaning() {
             <li className="flex gap-2">
               <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
               <Link
-                href="/blog/how-to-export-understand-cpap-data"
+                href="/blog/how-to-export-and-understand-your-cpap-data"
                 className="text-primary hover:text-primary/80"
               >
                 How to export and understand your CPAP data

--- a/app/blog/posts/free-cpap-data-analysis-software.tsx
+++ b/app/blog/posts/free-cpap-data-analysis-software.tsx
@@ -45,7 +45,7 @@ export default function FreeCPAPDataAnalysisSoftwarePost() {
               flow limitation levels
             </Link>{' '}
             or{' '}
-            <Link href="/blog/cpap-leak-rate-meaning" className="text-primary hover:text-primary/80">
+            <Link href="/blog/cpap-leak-rate-explained" className="text-primary hover:text-primary/80">
               leak rate trends
             </Link>
             , and have much more informed conversations with your clinician.

--- a/app/blog/posts/how-pap-therapy-works.tsx
+++ b/app/blog/posts/how-pap-therapy-works.tsx
@@ -1039,7 +1039,7 @@ export default function HowPAPTherapyWorksPost() {
             -- the evidence that AHI misses the majority of breathing problems.
           </p>
           <p>
-            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+            <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
               AirwayLab vs OSCAR
             </Link>{' '}
             -- how to use AirwayLab alongside OSCAR for a complete view of your therapy data.

--- a/app/blog/posts/how-to-download-resmed-cpap-data.tsx
+++ b/app/blog/posts/how-to-download-resmed-cpap-data.tsx
@@ -384,7 +384,7 @@ export default function HowToDownloadResMedCPAPData() {
               </p>
               <p className="mt-2 text-xs text-muted-foreground">
                 See also:{' '}
-                <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+                <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
                   OSCAR Alternative: Browser-Based CPAP Analysis
                 </Link>
               </p>
@@ -495,7 +495,7 @@ export default function HowToDownloadResMedCPAPData() {
         <div className="mt-4 space-y-2 text-sm text-muted-foreground">
           <p>
             <Link
-              href="/blog/how-to-export-understand-cpap-data"
+              href="/blog/how-to-export-and-understand-your-cpap-data"
               className="text-primary hover:text-primary/80"
             >
               How to Export and Understand Your CPAP Data
@@ -521,7 +521,7 @@ export default function HowToDownloadResMedCPAPData() {
             &mdash; the breathing pattern your flow waveform reveals beyond AHI.
           </p>
           <p className="mt-1">
-            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+            <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
               OSCAR Alternative: Browser-Based CPAP Analysis
             </Link>{' '}
             &mdash; comparing OSCAR and AirwayLab for ResMed data analysis.
@@ -561,7 +561,7 @@ export default function HowToDownloadResMedCPAPData() {
             Analyse Your CPAP Data <ArrowRight className="h-4 w-4" />
           </Link>
           <Link
-            href="/blog/how-to-export-understand-cpap-data"
+            href="/blog/how-to-export-and-understand-your-cpap-data"
             className="inline-flex items-center gap-2 rounded-lg border border-border px-5 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
           >
             How to Export CPAP Data

--- a/app/blog/posts/how-to-export-and-understand-your-cpap-data.tsx
+++ b/app/blog/posts/how-to-export-and-understand-your-cpap-data.tsx
@@ -592,7 +592,7 @@ export default function HowToExportAndUnderstandYourCPAPDataPost() {
           </p>
           <p>
             <Link
-              href="/blog/oscar-alternative"
+              href="/blog/oscar-alternatives-web-cpap-2026"
               className="text-primary hover:text-primary/80"
             >
               AirwayLab vs OSCAR

--- a/app/blog/posts/how-to-read-cpap-data.tsx
+++ b/app/blog/posts/how-to-read-cpap-data.tsx
@@ -304,7 +304,7 @@ export default function HowToReadCPAPDataPost() {
             leaves your device. It complements OSCAR rather than replacing it: OSCAR excels at
             detailed waveform browsing, while AirwayLab adds automated analysis across multiple
             nights.{' '}
-            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+            <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
               See how AirwayLab and OSCAR compare
             </Link>{' '}
             if you&apos;re deciding which tools to use.
@@ -362,7 +362,7 @@ export default function HowToReadCPAPDataPost() {
             — the limitations of AHI as a metric and what it misses.
           </p>
           <p>
-            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+            <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
               AirwayLab vs OSCAR
             </Link>{' '}
             — how the two open-source PAP tools compare and how to use both together.

--- a/app/blog/posts/how-to-read-cpap-therapy-report.tsx
+++ b/app/blog/posts/how-to-read-cpap-therapy-report.tsx
@@ -166,7 +166,7 @@ export default function HowToReadCPAPTherapyReport() {
           </div>
           <p>
             For a detailed look at how leak is calculated and displayed,{' '}
-            <Link href="/blog/cpap-leak-rate-meaning" className="text-primary hover:text-primary/80">
+            <Link href="/blog/cpap-leak-rate-explained" className="text-primary hover:text-primary/80">
               see the CPAP Leak Rate guide
             </Link>
             .

--- a/app/blog/posts/how-to-read-oscar-cpap-charts.tsx
+++ b/app/blog/posts/how-to-read-oscar-cpap-charts.tsx
@@ -431,7 +431,7 @@ export default function HowToReadOSCARCPAPChartsPost() {
             — why AHI isn&apos;t the whole story and what metrics to look at next.
           </p>
           <p>
-            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+            <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
               AirwayLab vs OSCAR
             </Link>{' '}
             — what each tool does best and how to use both together.

--- a/app/blog/posts/oscar-alternatives-web-cpap-2026.tsx
+++ b/app/blog/posts/oscar-alternatives-web-cpap-2026.tsx
@@ -384,7 +384,7 @@ export default function OSCARAlternativesWebCPAP2026() {
             Many users run AirwayLab and OSCAR side by side: AirwayLab for the automated overnight
             scores, OSCAR when they want to drill into a specific night that caught their attention.
             See{' '}
-            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+            <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
               how AirwayLab compares to OSCAR in detail
             </Link>
             .
@@ -570,7 +570,7 @@ export default function OSCARAlternativesWebCPAP2026() {
         </div>
         <div className="mt-4 space-y-2 text-sm text-muted-foreground">
           <p>
-            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+            <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
               AirwayLab vs OSCAR: What Each Tool Does Best
             </Link>{' '}
             &mdash; a detailed comparison of AirwayLab and OSCAR, the long-standing open-source

--- a/app/blog/posts/pap-data-privacy.tsx
+++ b/app/blog/posts/pap-data-privacy.tsx
@@ -324,7 +324,7 @@ export default function PAPDataPrivacyPost() {
           <div className="mt-4 border-t border-border/30 pt-4">
             <p className="mb-2 text-xs font-semibold text-foreground">Related articles</p>
             <p>
-              <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+              <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
                 AirwayLab vs OSCAR: What Each Tool Does Best
               </Link>{' '}
               -- comparing the two privacy-respecting PAP analysis tools.

--- a/app/blog/posts/resmed-sd-card-browser-analysis.tsx
+++ b/app/blog/posts/resmed-sd-card-browser-analysis.tsx
@@ -198,7 +198,7 @@ export default function ResMedSDCardBrowserAnalysisPost() {
           <p>
             Read more in{' '}
             <Link
-              href="/blog/oscar-alternative"
+              href="/blog/oscar-alternatives-web-cpap-2026"
               className="text-primary hover:text-primary/80"
             >
               AirwayLab vs OSCAR: How They Complement Each Other
@@ -257,7 +257,7 @@ export default function ResMedSDCardBrowserAnalysisPost() {
           </p>
           <p>
             <Link
-              href="/blog/oscar-alternative"
+              href="/blog/oscar-alternatives-web-cpap-2026"
               className="text-primary hover:text-primary/80"
             >
               AirwayLab vs OSCAR

--- a/app/blog/posts/sleephq-alternative.tsx
+++ b/app/blog/posts/sleephq-alternative.tsx
@@ -356,7 +356,7 @@ export default function SleepHQAlternativePost() {
           </p>
           <p>
             <Link
-              href="/blog/oscar-alternative"
+              href="/blog/oscar-alternatives-web-cpap-2026"
               className="text-primary hover:text-primary/80"
             >
               AirwayLab vs OSCAR: What Each Tool Does Best

--- a/app/blog/posts/what-are-reras-sleep-apnea.tsx
+++ b/app/blog/posts/what-are-reras-sleep-apnea.tsx
@@ -249,7 +249,7 @@ export default function WhatAreRerasSleepApnea() {
               How to Read Your CPAP Data
             </Link>{' '}
             and{' '}
-            <Link href="/blog/how-to-export-understand-cpap-data" className="text-primary hover:text-primary/80">
+            <Link href="/blog/how-to-export-and-understand-your-cpap-data" className="text-primary hover:text-primary/80">
               How to Export and Understand Your CPAP Data
             </Link>{' '}
             are good starting points.

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -184,7 +184,7 @@ export default function ChangelogPage() {
             <p className="mt-1 text-xs text-muted-foreground">Why AHI alone is not enough.</p>
           </Link>
           <Link
-            href="/blog/oscar-alternative"
+            href="/blog/oscar-alternatives-web-cpap-2026"
             className="group rounded-lg border border-border/50 bg-card/30 p-4 transition-all hover:border-primary/30"
           >
             <h3 className="text-sm font-semibold text-foreground group-hover:text-primary">AirwayLab vs OSCAR</h3>

--- a/app/compare/oscar/page.tsx
+++ b/app/compare/oscar/page.tsx
@@ -430,7 +430,7 @@ export default function CompareOscarPage() {
         </div>
         <div className="mt-4 space-y-2 text-sm text-muted-foreground">
           <p>
-            <Link href="/blog/oscar-alternative" className="text-primary hover:text-primary/80">
+            <Link href="/blog/oscar-alternatives-web-cpap-2026" className="text-primary hover:text-primary/80">
               OSCAR vs AirwayLab: A Deeper Dive
             </Link>
             {' -- '}full blog post exploring the relationship between both tools.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -146,7 +146,7 @@ const featuredSlugs = [
   'understanding-flow-limitation',
   'ahi-normal-still-tired',
   'pap-data-privacy',
-  'oscar-alternative',
+  'oscar-alternatives-web-cpap-2026',
 ] as const;
 const featuredPosts = featuredSlugs
   .map((slug) => blogPosts.find((p) => p.slug === slug))

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -21,7 +21,7 @@ export default function PrivacyPolicyPage() {
       <div className="mb-10">
         <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Privacy Policy</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Last updated: 31 May 2026
+          Last updated: 7 June 2026
         </p>
         <div className="mt-4 flex items-center gap-1.5 text-xs text-emerald-500">
           <Shield className="h-3.5 w-3.5 shrink-0" />
@@ -175,6 +175,18 @@ export default function PrivacyPolicyPage() {
               anonymised aggregate analysis metrics (device model, PAP mode, pressure range).
               No dates, timestamps, names, or identifiers are included.
             </li>
+            <li>
+              <strong>Device pseudonymisation:</strong> When you upload therapy data, your
+              device&rsquo;s serial number or GUID is used to derive a pseudonymous device key
+              (HMAC-SHA256 hash) and then immediately discarded &mdash; the raw value is never
+              stored. The device key is stored server-side and used for: upload deduplication,
+              distinct-device analytics, and per-device longitudinal research (if you have opted
+              in to data contribution). This is pseudonymous personal data under GDPR Recital 26.
+              Legal basis: legitimate interest (Art.&nbsp;6(1)(f)) for core upload deduplication;
+              consent (Art.&nbsp;6(1)(a)) for per-device ML analytics (covered by data contribution
+              consent). Device keys are deleted when you delete your account or submit an erasure
+              request.
+            </li>
           </ul>
 
           <h3 className="mt-4">3.5 Automatically Collected Data</h3>
@@ -209,7 +221,7 @@ export default function PrivacyPolicyPage() {
             <li>Browser fingerprints</li>
             <li>IP addresses for tracking (PostHog does not store IPs)</li>
             <li>Raw sleep waveforms (never transmitted unless you explicitly contribute them for research -- see section 3.4)</li>
-            <li>Device serial numbers or user names from PAP machines</li>
+            <li>Device serial numbers or user names from PAP machines (raw values are never stored &mdash; see Section 3.4 for device pseudonymisation)</li>
           </ul>
         </section>
 
@@ -232,7 +244,8 @@ export default function PrivacyPolicyPage() {
             </li>
             <li>
               <strong>Legitimate interest (Art. 6(1)(f)):</strong> Error monitoring (Sentry),
-              anonymous usage analytics (PostHog), and security protections.
+              anonymous usage analytics (PostHog), security protections, and upload deduplication
+              via pseudonymous device keys.
             </li>
           </ul>
         </section>
@@ -259,6 +272,10 @@ export default function PrivacyPolicyPage() {
             <li>
               <strong>Cloud-stored files:</strong> Retained until you delete them or request
               account deletion.
+            </li>
+            <li>
+              <strong>Device keys (pseudonymous):</strong> Retained until account deletion or
+              DSAR erasure request.
             </li>
             <li>
               <strong>Analytics (PostHog):</strong> Aggregate data only, no personal data
@@ -297,7 +314,7 @@ export default function PrivacyPolicyPage() {
                   <td className="py-2 pr-4 font-medium text-foreground">Supabase</td>
                   <td className="py-2 pr-4">Database &amp; authentication</td>
                   <td className="py-2 pr-4">EU (West)</td>
-                  <td className="py-2">Account data, subscriptions, EDF files, analysis data, contributed metrics, waveforms, and traces</td>
+                  <td className="py-2">Account data, subscriptions, EDF files, analysis data, contributed metrics, waveforms, traces, and pseudonymous device keys</td>
                 </tr>
                 <tr>
                   <td className="py-2 pr-4 font-medium text-foreground">Anthropic (Claude)</td>
@@ -418,8 +435,8 @@ export default function PrivacyPolicyPage() {
             </li>
             <li>
               <strong>Erasure:</strong> Delete all server-stored data instantly from Account
-              Settings. This removes EDF files, analysis data, and contributed metrics. Account
-              deletion requests are processed within 30 days.
+              Settings. This removes EDF files, analysis data, contributed metrics, and
+              pseudonymous device keys. Account deletion requests are processed within 30 days.
             </li>
             <li>
               <strong>Withdraw consent:</strong> Delete all your data at any time from Account

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -14,10 +14,14 @@ function clampToToday(date: Date): Date {
 // Slugs that now 301-redirect to a canonical winner must be excluded from the
 // sitemap so Google doesn't index the loser URL alongside the winner.
 // Wave 1 redirects (AIR-1609 task 3): no pending content merge, ship immediately.
+// Wave 2 redirects (AIR-2298): content merged into winner articles first (AIR-1751).
 const REDIRECTED_BLOG_SLUGS = new Set([
   'oscar-cpap-software-alternatives',
   'how-to-read-cpap-data',
   'what-is-flow-limitation-cpap',
+  'how-to-export-understand-cpap-data',
+  'oscar-alternative',
+  'cpap-leak-rate-meaning',
 ]);
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,6 +36,22 @@ const nextConfig = {
         destination: '/blog/understanding-flow-limitation',
         permanent: true,
       },
+      // Wave 2 duplicate-slug 301s (AIR-2298) — content merged into winner first (AIR-1751).
+      {
+        source: '/blog/how-to-export-understand-cpap-data',
+        destination: '/blog/how-to-export-and-understand-your-cpap-data',
+        permanent: true,
+      },
+      {
+        source: '/blog/oscar-alternative',
+        destination: '/blog/oscar-alternatives-web-cpap-2026',
+        permanent: true,
+      },
+      {
+        source: '/blog/cpap-leak-rate-meaning',
+        destination: '/blog/cpap-leak-rate-explained',
+        permanent: true,
+      },
     ];
   },
 


### PR DESCRIPTION
## Summary

- **AIR-2298 (Wave 2 301 redirects):** Adds server-side redirects for 3 remaining duplicate-slug URL pairs
- **AIR-2591:** Adds `DEVICE_ID_PEPPER` to `.env.example`
- **AIR-2590:** Updates `/privacy` page with device pseudonymisation disclosures required before device-key storage ships

> **Note:** This branch carries three concerns per the Compliance note. Wave 2 redirects were the originating work; the env and privacy additions were gated behind [AIR-2590](/AIR/issues/AIR-2590) which required Compliance sign-off before merge.

## AIR-2590 Privacy Changes

All 7 required changes applied to `app/privacy/page.tsx`:

- Section 3.4: New "Device pseudonymisation" bullet (HMAC-SHA256 derivation, GDPR Recital 26 classification, dual legal basis Art. 6(1)(f) + Art. 6(1)(a), deletion path)
- Section 3.6: Device serial bullet updated — raw values never stored, cross-ref to §3.4
- Section 4: Legitimate interest extended to include upload deduplication via pseudonymous device keys
- Section 5: New retention entry for device keys (pseudonymous)
- Section 6 (Supabase row): "pseudonymous device keys" added to Data Processed
- Section 8 (Erasure): pseudonymous device keys included in deletion description
- Last updated: 7 June 2026

**Compliance sign-off:** PASS ✅ by Head of Compliance (AIR-2590, comment 6187347c)

## Pre-Merge Checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [x] Bundle size impact checked (static page, no JS delta)
- [ ] Vercel preview deploy verified by Demian
- [x] Compliance sign-off received (Head of Compliance — PASS, no MUST violations)
- [x] PR contains related concerns (Wave 2 redirects + privacy gating pre-req)

## Compliance Note (non-blocking, future pass)

Section 2 reads "This is a single consent covering all data processing." Device deduplication now runs under legitimate interest, not consent. Fully disclosed in §3.4 and §4. Head of Compliance flagged as SHOULD-fix in a future pass — not blocking this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
