### PR TITLE
fix(analyze): settings-unavailable banner when STR.edf missing (AIR-2131)

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -1053,6 +1053,17 @@ function AnalyzePageInner() {
             </div>
           )}
 
+          {/* Settings unavailable banner — STR.edf missing or unreadable */}
+          {!isDemo && currentNight?.settings.settingsSource === 'unavailable' && (
+            <div className="flex items-start gap-2.5 rounded-xl border border-amber-500/20 bg-amber-500/5 px-4 py-3 animate-fade-in-up">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+              <p className="text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">Machine settings not found</span>
+                {' '}&mdash; The settings file (STR.edf) wasn&apos;t found in your upload. Mode, pressure, and therapy settings won&apos;t appear, but your breathing data analysis is complete and unaffected. STR.edf is at the SD card root &mdash; re-upload from the card root (not just the DATALOG folder) to include it.
+              </p>
+            </div>
+          )}
+
           {/* Cloud sync progress (non-dismissible, transient) */}
           <StorageProgressBanner />
 

--- a/lib/upload-validation.ts
+++ b/lib/upload-validation.ts
@@ -163,7 +163,7 @@ function validateResMedFiles(
     warnings.push('Folder structure doesn\'t look like a typical ResMed SD card. Make sure you selected the SD card itself, not a subfolder.');
   }
   if (!hasSTR) {
-    warnings.push('No STR.edf settings file found. Machine settings won\'t be available.');
+    warnings.push('No STR.edf settings file found — mode, pressure and therapy settings won\'t appear in results. STR.edf is at the SD card root, not inside the DATALOG folder.');
   }
 
   if (!hasFlowData) {


### PR DESCRIPTION
## Summary

- Adds amber banner in the analyze dashboard when `settings.settingsSource === 'unavailable'` (STR.edf missing or unreadable from upload)
- Improves STR.edf warning text in `upload-validation.ts` with actionable path guidance
- Affects ~34 users/day currently seeing `model:Unknown / hasStr:false` in device-diagnostic signals

**Note:** The PostHog privacy defaults (`ip: false`, `respect_dnt: true`) from [AIR-2134] are already on main — not included in this PR.

## CEO pre-approval

CEO reviewed both original commits on 2026-06-05 and issued **PASS** per AIR-2139 reviewer check. No additional review cycle needed.

## Test plan

- [x] 2726 tests passing
- [x] TypeScript compiles clean
- [x] Lint clean
- [ ] Vercel preview deploy verified by Demian
- [ ] Smoke test: upload SD card without STR.edf — confirm amber banner appears

## Pre-merge checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] ALL manual QA items checked
- [ ] Self-review: no regressions
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)