### PR TITLE
feat(feedback): 5-min auto-ack email for paying-user contact submissions (AIR-1854)

### DIFF
--- a/__tests__/feedback-contact-ack.test.ts
+++ b/__tests__/feedback-contact-ack.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ─────────────────────────────────────────────────────
+
+vi.mock('@/lib/email/send', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/app/api/device-diagnostic/_dedup', () => ({
+  checkAndUpdateDedup: vi.fn().mockResolvedValue({ shouldFire: true, suppressedCount: 0 }),
+  DEDUP_WINDOW_MS: 24 * 60 * 60 * 1000,
+}))
+
+vi.mock('@/lib/discord-webhook', () => ({
+  sendAlert: vi.fn().mockResolvedValue(undefined),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
+
+const mockFrom = vi.fn()
+const _mockSelect = vi.fn()
+const _mockEq = vi.fn()
+const _mockSingle = vi.fn()
+const _mockIn = vi.fn()
+const _mockMaybeSingle = vi.fn()
+const mockInsert = vi.fn()
+
+const supabaseMock = {
+  from: mockFrom,
+}
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseAdmin: vi.fn(() => supabaseMock),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────
+
+import { sendEmail } from '@/lib/email/send'
+import { checkAndUpdateDedup } from '@/app/api/device-diagnostic/_dedup'
+
+const sendEmailMock = vi.mocked(sendEmail)
+const checkAndUpdateDedupMock = vi.mocked(checkAndUpdateDedup)
+
+function makeInput(overrides: Record<string, unknown> = {}) {
+  return {
+    message: 'Test message',
+    email: 'user@example.com',
+    type: 'support' as const,
+    page: '/contact',
+    user_id: null,
+    contact_ok: true,
+    metadata: {},
+    ...overrides,
+  }
+}
+
+function setupSupabaseMocks({
+  profileId = 'profile-1',
+  hasProfile = true,
+  hasActiveSub = false,
+  feedbackInsertOk = true,
+}: {
+  profileId?: string
+  hasProfile?: boolean
+  hasActiveSub?: boolean
+  feedbackInsertOk?: boolean
+} = {}) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === 'feedback') {
+      return {
+        insert: mockInsert.mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: feedbackInsertOk ? { id: 'fb-1' } : null,
+              error: feedbackInsertOk ? null : new Error('insert failed'),
+            }),
+          }),
+        }),
+      }
+    }
+    if (table === 'profiles') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: hasProfile ? { id: profileId } : null,
+              error: null,
+            }),
+          }),
+        }),
+      }
+    }
+    if (table === 'subscriptions') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: hasActiveSub ? { id: 'sub-1' } : null,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      }
+    }
+    if (table === 'kv_alert_dedup') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+        upsert: vi.fn().mockResolvedValue({ error: null }),
+      }
+    }
+    return {}
+  })
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe('maybeSendContactAck (via submitFeedback)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkAndUpdateDedupMock.mockResolvedValue({ shouldFire: true, suppressedCount: 0 })
+  })
+
+  it('sends ack for billing category regardless of subscription', async () => {
+    setupSupabaseMocks({ hasProfile: false, hasActiveSub: false })
+
+    const { submitFeedback } = await import('@/lib/services/feedback-service')
+    const input = makeInput({ metadata: { category: 'billing' } })
+
+    const result = await submitFeedback(input)
+    expect(result.isOk()).toBe(true)
+
+    // Allow microtasks to flush
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'user@example.com',
+        metadata: { emailType: 'contact_ack_paying' },
+      }),
+    )
+  })
+
+  it('sends ack for paying user with non-billing category', async () => {
+    setupSupabaseMocks({ hasProfile: true, hasActiveSub: true })
+
+    const { submitFeedback } = await import('@/lib/services/feedback-service')
+    const input = makeInput({ metadata: { category: 'general' } })
+
+    const result = await submitFeedback(input)
+    expect(result.isOk()).toBe(true)
+
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(sendEmailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'user@example.com',
+        metadata: { emailType: 'contact_ack_paying' },
+      }),
+    )
+  })
+
+  it('does NOT send ack for free-tier user with non-billing category', async () => {
+    setupSupabaseMocks({ hasProfile: true, hasActiveSub: false })
+
+    const { submitFeedback } = await import('@/lib/services/feedback-service')
+    const input = makeInput({ metadata: { category: 'general' } })
+
+    const result = await submitFeedback(input)
+    expect(result.isOk()).toBe(true)
+
+    await new Promise((r) => setTimeout(r, 50))
+
+    const ackCalls = sendEmailMock.mock.calls.filter(
+      (call) => call[0].metadata?.emailType === 'contact_ack_paying',
+    )
+    expect(ackCalls).toHaveLength(0)
+  })
+
+  it('does NOT send ack when email is absent', async () => {
+    setupSupabaseMocks()
+
+    const { submitFeedback } = await import('@/lib/services/feedback-service')
+    const input = makeInput({ email: null, metadata: { category: 'billing' } })
+
+    const result = await submitFeedback(input)
+    expect(result.isOk()).toBe(true)
+
+    await new Promise((r) => setTimeout(r, 50))
+
+    const ackCalls = sendEmailMock.mock.calls.filter(
+      (call) => call[0].metadata?.emailType === 'contact_ack_paying',
+    )
+    expect(ackCalls).toHaveLength(0)
+  })
+
+  it('suppresses second call within 30-min dedup window', async () => {
+    setupSupabaseMocks({ hasProfile: false, hasActiveSub: false })
+    checkAndUpdateDedupMock.mockResolvedValue({ shouldFire: false, suppressedCount: 1 })
+
+    const { submitFeedback } = await import('@/lib/services/feedback-service')
+    const input = makeInput({ metadata: { category: 'billing' } })
+
+    const result = await submitFeedback(input)
+    expect(result.isOk()).toBe(true)
+
+    await new Promise((r) => setTimeout(r, 50))
+
+    const ackCalls = sendEmailMock.mock.calls.filter(
+      (call) => call[0].metadata?.emailType === 'contact_ack_paying',
+    )
+    expect(ackCalls).toHaveLength(0)
+  })
+
+  it('sends ack to the correct email address (consent gate)', async () => {
+    setupSupabaseMocks({ hasProfile: false, hasActiveSub: false })
+
+    const { submitFeedback } = await import('@/lib/services/feedback-service')
+    const email = 'specific-user@example.com'
+    const input = makeInput({ email, metadata: { category: 'billing' } })
+
+    const result = await submitFeedback(input)
+    expect(result.isOk()).toBe(true)
+
+    await new Promise((r) => setTimeout(r, 50))
+
+    const ackCalls = sendEmailMock.mock.calls.filter(
+      (call) => call[0].metadata?.emailType === 'contact_ack_paying',
+    )
+    expect(ackCalls).toHaveLength(1)
+    expect(ackCalls[0]![0].to).toBe(email)
+  })
+})

--- a/app/api/device-diagnostic/_dedup.ts
+++ b/app/api/device-diagnostic/_dedup.ts
@@ -19,6 +19,7 @@ export async function checkAndUpdateDedup(
   supabase: NonNullable<ReturnType<typeof getSupabaseAdmin>>,
   key: string,
   now: Date,
+  windowMs?: number,
 ): Promise<{ shouldFire: boolean; suppressedCount: number }> {
   const { data: existing } = await supabase
     .from('kv_alert_dedup')
@@ -26,7 +27,7 @@ export async function checkAndUpdateDedup(
     .eq('key', key)
     .single<KvRow>()
 
-  const windowStart = new Date(now.getTime() - DEDUP_WINDOW_MS)
+  const windowStart = new Date(now.getTime() - (windowMs ?? DEDUP_WINDOW_MS))
   const lastFiredAt = existing ? new Date(existing.last_fired_at) : null
   const shouldFire = !lastFiredAt || lastFiredAt < windowStart
 

--- a/lib/email/transactional.ts
+++ b/lib/email/transactional.ts
@@ -177,3 +177,22 @@ export function remindDesktopEmail(
     `),
   }
 }
+
+// ── Paying-user contact acknowledgement ──────────────────────
+
+export function payingUserContactAckEmail(
+  name: string | null
+): { subject: string; html: string } {
+  const greeting = name ? `Hi ${name},` : 'Hi,'
+
+  return {
+    subject: `We received your message — someone from AirwayLab will follow up shortly`,
+    html: transactionalLayout(`
+      ${heading('Message received')}
+      ${paragraph(greeting)}
+      ${paragraph('Thanks for reaching out. We have received your message and a member of the AirwayLab team will respond within the hour.')}
+      ${paragraph('If your message is about billing or account access, this is our highest-priority queue and we aim to resolve it quickly.')}
+      ${paragraph('AirwayLab Team')}
+    `, `You're receiving this because you contacted AirwayLab. This is an automated acknowledgement — a team member will reply personally.`),
+  }
+}

--- a/lib/services/feedback-service.ts
+++ b/lib/services/feedback-service.ts
@@ -4,6 +4,9 @@ import { getSupabaseAdmin } from '@/lib/supabase/server'
 import { supabaseQuery } from './supabase-helpers'
 import { sendEmail } from '@/lib/email/send'
 import { sendAlert, formatUserSignalEmbed } from '@/lib/discord-webhook'
+import { payingUserContactAckEmail } from '@/lib/email/transactional'
+import { checkAndUpdateDedup } from '@/app/api/device-diagnostic/_dedup'
+import * as Sentry from '@sentry/nextjs'
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -24,6 +27,57 @@ const TYPE_LABELS: Record<string, string> = {
   bug: 'Bug report',
   support: 'Support request',
   feedback: 'Feedback',
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+async function maybeSendContactAck(
+  input: FeedbackInput,
+  supabase: NonNullable<ReturnType<typeof getSupabaseAdmin>>,
+): Promise<void> {
+  if (!input.email) return
+
+  const meta = (input.metadata ?? {}) as Record<string, unknown>
+  const category = typeof meta.category === 'string' ? meta.category : undefined
+  const isBillingCategory = category === 'billing'
+
+  let isPayingUser = false
+  if (!isBillingCategory) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('email', input.email)
+      .single()
+
+    if (profile) {
+      const { data: sub } = await supabase
+        .from('subscriptions')
+        .select('id')
+        .eq('user_id', profile.id)
+        .in('status', ['active', 'trialing'])
+        .maybeSingle()
+      isPayingUser = !!sub
+    }
+  }
+
+  if (!isBillingCategory && !isPayingUser) return
+
+  const now = new Date()
+  const { shouldFire } = await checkAndUpdateDedup(
+    supabase,
+    `contact_ack:${input.email}`,
+    now,
+    30 * 60 * 1000,
+  )
+  if (!shouldFire) return
+
+  const name = typeof meta.display_name === 'string' ? meta.display_name : null
+  const template = payingUserContactAckEmail(name)
+  await sendEmail({
+    to: input.email,
+    ...template,
+    metadata: { emailType: 'contact_ack_paying' },
+  })
 }
 
 // ── Service function ─────────────────────────────────────────
@@ -113,6 +167,10 @@ export function submitFeedback(
       email: input.email?.trim() ?? undefined,
       feedbackId,
     })])
+
+    void maybeSendContactAck(input, supabase).catch((err) => {
+      Sentry.captureException(err, { tags: { fn: 'maybeSendContactAck' } })
+    })
 
     return { ok: true as const }
   })


### PR DESCRIPTION
## Summary

- Adds `payingUserContactAckEmail()` template to `lib/email/transactional.ts`
- Wires `maybeSendContactAck()` in `lib/services/feedback-service.ts` — fires after Supabase insert for billing-category or paying-subscriber submissions
- Dedup via `kv_alert_dedup` table (`contact_ack:{email}`, 30-min window)
- Adds optional `windowMs` param to `checkAndUpdateDedup()` in `app/api/device-diagnostic/_dedup.ts`
- 5 new tests in `__tests__/feedback-contact-ack.test.ts` (billing trigger, paying-user trigger, free-user no-fire, no-email no-fire, dedup suppression)

## Pre-merge gate

**Board (Demian) approval required** — per standing email-send policy. Approval request will be posted in Paperclip.

## Pre-merge checklist

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Bundle size impact checked
- [ ] Vercel preview deploy verified by Demian
- [ ] Board y/n on email-send change (required per policy)
- [ ] Self-review: dedup window correct (30 min), no free-tier sends

🤖 Generated with [Claude Code](https://claude.com/claude-code)