### PR TITLE
docs(guard): or-on-mutation failure mode is now SILENT, not 42703

### DIFF
--- a/scripts/check-no-mutation-or.mjs
+++ b/scripts/check-no-mutation-or.mjs
@@ -2,13 +2,19 @@
 /**
  * Fail CI if a Supabase mutation chains an `.or()` filter.
  *
- * PostgREST CANNOT build an `or` filter on a MUTATION (UPDATE/DELETE): it rejects
- * the request with Postgres `42703 "column … does not exist"` even when the
- * column exists. The same `or` works on a SELECT, which is why this slips past
- * unit tests + typecheck + a clean deploy (2026-06-04 billing incident — the
- * Stripe claim's `.update().or(status…)` stranded every checkout). Fix: move the
- * conditional UPDATE/DELETE into a SQL function (RPC). See migration 063 /
- * `claim_stripe_event`. Plain filters (`eq`, `in`, `neq`) ARE fine on mutations.
+ * `or` on a MUTATION (UPDATE/DELETE/upsert) is unsafe on the PostgREST stack and
+ * must never reach prod. The failure mode has CHANGED over time — both are bad:
+ *  - 2026-06-04 billing incident: PostgREST REJECTED the Stripe claim's
+ *    `.update().or(status…)` with Postgres `42703 "column … does not exist"`
+ *    (even though the column exists), stranding every checkout. Loud but fatal.
+ *  - Current PostgREST (v12.2.x+) no longer 42703s — it SILENTLY applies the
+ *    `or`, so a wrong filter now mis-updates rows QUIETLY instead of erroring
+ *    (verified by the db-contract harness). Silent corruption is arguably worse.
+ * Either way this static guard is the version-independent line of defense — do
+ * NOT relax it. The same `or` works on a SELECT, which is why this slips past
+ * unit tests + typecheck + a clean deploy. Fix: move the conditional
+ * UPDATE/DELETE into a SQL function (RPC). See migration 063 / `claim_stripe_event`.
+ * Plain filters (`eq`, `in`, `neq`) ARE fine on mutations.
  */
 import { readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
@@ -46,10 +52,11 @@ for (const file of files) {
 }
 
 if (violations.length) {
-  console.error('✖ or-on-mutation detected (PostgREST 42703 risk):');
+  console.error('✖ or-on-mutation detected (unsafe on PostgREST):');
   for (const v of violations) console.error('  ' + v);
-  console.error('\nPostgREST cannot do an `or` filter on a MUTATION. Move the conditional');
-  console.error('UPDATE/DELETE into a SQL function (RPC). See migration 063 / claim_stripe_event.');
+  console.error('\n`or` on a MUTATION is either rejected (legacy 42703) or SILENTLY mis-applied');
+  console.error('(current PostgREST) — never ship it. Move the conditional UPDATE/DELETE into');
+  console.error('a SQL function (RPC). See migration 063 / claim_stripe_event.');
   process.exit(1);
 }
 console.log('✓ no or-on-mutation patterns found');


### PR DESCRIPTION
Doc-only coherence fix for `scripts/check-no-mutation-or.mjs`. **Detection logic unchanged.**

The guard's header and failure message asserted PostgREST "CANNOT" build an `or` on a mutation and always rejects with `42703`. The G5 `db-contract` harness verified that current PostgREST (v12.2.x+) no longer 42703s — it **silently applies** the `or` (returns 200), so a wrong filter now mis-updates rows quietly instead of failing loudly. Silent corruption is arguably worse than the original loud failure.

Updated the header + failure text so the rationale matches reality and makes clear this static guard is the version-independent defense — never relax it. No behaviour change (the regex/scan is identical; CI run still prints `✓ no or-on-mutation patterns found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)