### PR TITLE
fix(ops): add DEVICE_ID_PEPPER to .env.example (AIR-2591)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,9 @@ PAPERCLIP_SIGNAL_WEBHOOK_SECRET=
 # routine webhook for any signals above threshold whose real-time webhook failed.
 PAPERCLIP_SIGNALS_WEBHOOK_URL=
 PAPERCLIP_SIGNALS_WEBHOOK_SECRET=
+
+# Device pseudonymisation (AIR-1020 device-capture)
+# HMAC-SHA256 pepper for device serial/GUID hashing. Long-lived secret — do NOT reuse
+# CRON_SECRET or any rotating secret. Rotating this value changes every device key and
+# permanently breaks per-device longitudinal grouping.
+DEVICE_ID_PEPPER=


### PR DESCRIPTION
## Summary

Adds `DEVICE_ID_PEPPER=` entry to `.env.example`, including comment explaining long-lived nature and rotation danger.

## Context

PR #1020 (`feat(device-capture)`) introduced `lib/device-id.ts` which requires `DEVICE_ID_PEPPER` at runtime, but `.env.example` was not updated. Compliance audit AIR-2589 flagged this as a FAIL. Developers standing up a local or staging environment would silently miss the required secret.

## Changes

- One block added to `.env.example` (5 lines: comment block + `DEVICE_ID_PEPPER=`)
- No code, no logic, no MDR risk

## Test plan

- [ ] `.env.example` contains `DEVICE_ID_PEPPER=` entry
- [ ] Comment explains long-lived vs rotating secret distinction
- [ ] Comment references AIR-1020
- [ ] CI passes (no code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)