### PR TITLE
chore(baseline): restore share_analytics view + 2 sequences (close prod drift)

### DIFF
--- a/supabase/baseline.grants.sql
+++ b/supabase/baseline.grants.sql
@@ -13,11 +13,11 @@
 --   table grants:    information_schema.role_table_grants  (schema=public, grantee in the 3 roles)
 --   function grants:  pg_proc + aclexplode(proacl)         (EXECUTE; PUBLIC = grantee oid 0)
 --
--- NOT replicated (absent from the structure-only baseline, and untouched by the
--- current tests): the share_analytics VIEW, and the serial sequences
--- ai_insights_log_id_seq / symptom_contributions_id_seq (the dump rendered those
--- id columns as bare bigint, dropping the owned sequences). Flagged as a baseline
--- gap on the G5 PR; add their grants here if/when the baseline regains them.
+-- The share_analytics VIEW + the serial sequences ai_insights_log_id_seq /
+-- symptom_contributions_id_seq were restored to supabase/baseline.sql via the same
+-- MCP extraction (2026-06-08), so their grants are now included (see the bottom
+-- of this file). None are exercised by the current GATE tests; a future canonical
+-- `supabase db dump` supersedes both the baseline patch and these grants.
 
 set search_path to public, auth, storage, extensions;
 
@@ -114,3 +114,8 @@ grant execute on function public.update_storage_usage() to anon, authenticated, 
 grant execute on function public.update_symptom_contributions_updated_at() to anon, authenticated, service_role;
 grant execute on function public.update_updated_at() to anon, authenticated, service_role;
 
+
+-- ── Restored objects (MCP patch 2026-06-08): share_analytics view + sequences ──
+grant DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE on table public.share_analytics to anon, authenticated, service_role;
+grant SELECT, UPDATE, USAGE on sequence public.ai_insights_log_id_seq to anon, authenticated, service_role;
+grant SELECT, UPDATE, USAGE on sequence public.symptom_contributions_id_seq to anon, authenticated, service_role;

--- a/supabase/baseline.sql
+++ b/supabase/baseline.sql
@@ -2222,3 +2222,39 @@ create policy service_role_delete_shared_files on storage.objects as PERMISSIVE 
 create policy service_role_insert_shared_files on storage.objects as PERMISSIVE for INSERT to service_role with check ((bucket_id = 'shared-files'::text));
 create policy service_role_only on public.unsupported_device_submissions as PERMISSIVE for ALL to service_role using (true);
 create policy service_role_select_shared_files on storage.objects as PERMISSIVE for SELECT to service_role using ((bucket_id = 'shared-files'::text));
+
+-- ── MCP patch (2026-06-08): objects the structure-only dump dropped ──────────
+-- A canonical `supabase db dump` was unavailable (no local DB creds), so these
+-- were extracted from prod via the Supabase MCP to close the baseline↔prod gap
+-- (the share_analytics reporting view + two serial sequences). None are exercised
+-- by the current GATE tests; a future canonical dump supersedes this block.
+create sequence if not exists public.ai_insights_log_id_seq as bigint start with 1 increment by 1 minvalue 1 maxvalue 9223372036854775807 no cycle;
+create sequence if not exists public.symptom_contributions_id_seq as bigint start with 1 increment by 1 minvalue 1 maxvalue 9223372036854775807 no cycle;
+create view public.share_analytics as  SELECT date_trunc('day'::text, created_at) AS day,
+    count(*) AS shares_created,
+    sum(
+        CASE
+            WHEN share_scope = 'single'::text THEN 1
+            ELSE 0
+        END) AS single_night_shares,
+    sum(
+        CASE
+            WHEN share_scope = 'all'::text THEN 1
+            ELSE 0
+        END) AS all_nights_shares,
+    avg(nights_count) AS avg_nights_per_share,
+    sum(access_count) AS total_views,
+    avg(access_count) AS avg_views_per_share,
+    count(
+        CASE
+            WHEN access_count > 0 THEN 1
+            ELSE NULL::integer
+        END) AS shares_actually_viewed,
+    round(count(
+        CASE
+            WHEN access_count > 0 THEN 1
+            ELSE NULL::integer
+        END)::numeric / NULLIF(count(*), 0)::numeric * 100::numeric, 1) AS view_rate_pct
+   FROM shared_analyses
+  GROUP BY (date_trunc('day'::text, created_at))
+  ORDER BY (date_trunc('day'::text, created_at)) DESC;


### PR DESCRIPTION
Closes the `supabase/baseline.sql` ↔ prod drift surfaced during the G5 work.

The structure-only extraction dropped three prod objects:
- the **`share_analytics`** reporting view (over `shared_analyses`)
- the **`ai_insights_log_id_seq`** + **`symptom_contributions_id_seq`** sequences

A canonical `supabase db dump` needs the Postgres password (unavailable here — `.env.local` is deny-listed), so these were re-extracted from prod via the Supabase MCP and appended to `baseline.sql`, with their grants added to `baseline.grants.sql`. **A future canonical dump supersedes this patch** (noted in both files).

- `baseline.cut` unchanged (still `063` — no migration-boundary change; these objects belong to the baseline's existing era).
- Verified the view's referenced columns (`created_at`, `share_scope`, `nights_count`, `access_count`) all exist in the baseline `shared_analyses`.
- The real check is **`db-contract` staying green** — the view + sequences + grants must apply cleanly in the GATE replay, and the G5 PostgREST tests must still pass.

None of these objects are exercised by the current GATE tests (orphaned sequences, an unused analytics view) — this is fidelity/completeness, not a functional fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)