### PR TITLE
chore: remove DRY_RUN_TEST_TOKEN test artifact from credentials inventory (AIR-2605)

### DIFF
--- a/docs/ops/credentials.md
+++ b/docs/ops/credentials.md
@@ -115,10 +115,3 @@ curl -s -o /dev/null -w "%{http_code}" \
 | `#user-signals` | `DISCORD_USER_SIGNALS_WEBHOOK_URL` |
 | `#platform-health` | `DISCORD_PLATFORM_HEALTH_WEBHOOK_URL` |
 
----
-
-## Test Entry (dry-run only — remove after AIR-931 verification)
-
-| Name | Owner | Stored In | Cadence | Last Rotated | Next Rotation Due | Status |
-|------|-------|-----------|---------|--------------|-------------------|--------|
-| `DRY_RUN_TEST_TOKEN` | CTO | test-only | 90 days | 2026-02-05 | 2026-05-06 | test |


### PR DESCRIPTION
## Summary

Removes the `DRY_RUN_TEST_TOKEN` test row from `docs/ops/credentials.md`.

The AIR-931 verification period has passed. This row was a test artifact that was generating false-positive CRITICAL rotation alerts in the credentials inventory.

## Test plan

- [ ] `docs/ops/credentials.md` no longer contains `DRY_RUN_TEST_TOKEN`
- [ ] No other references to this test token exist in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)