### PR TITLE
fix(gdpr): add data-contribution consent withdrawal to §8 Rights (AIR-2622)

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -21,7 +21,7 @@ export default function PrivacyPolicyPage() {
       <div className="mb-10">
         <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">Privacy Policy</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Last updated: 31 May 2026
+          Last updated: 8 June 2026
         </p>
         <div className="mt-4 flex items-center gap-1.5 text-xs text-emerald-500">
           <Shield className="h-3.5 w-3.5 shrink-0" />
@@ -425,6 +425,12 @@ export default function PrivacyPolicyPage() {
               <strong>Withdraw consent:</strong> Delete all your data at any time from Account
               Settings. Unsubscribe from emails via the link in each email or from your
               dashboard. You can also contact us to request full account deletion.
+            </li>
+            <li>
+              <strong>Withdraw data contribution consent:</strong> If you have opted in to
+              anonymised research data contribution, you can withdraw consent at any time via
+              Account Settings &gt; Data &amp; Privacy. Withdrawal stops future sharing;
+              already-contributed rows are anonymised and retained (GDPR Art. 7(3)).
             </li>
             <li>
               <strong>Opt out of analytics:</strong> PostHog respects your browser&rsquo;s


### PR DESCRIPTION
## Summary

Adds a dedicated §8 (Your Rights) bullet for data-contribution consent withdrawal, citing GDPR Art. 7(3).

## Context

PR #1037 (G6 consent enforcement) introduces server-enforced consent withdrawal via Account Settings > Data & Privacy. Without this privacy policy update, users have no disclosed path to exercise this new withdrawal right.

## Change

- New bullet in §8: "**Withdraw data contribution consent:** If you have opted in to anonymised research data contribution, you can withdraw consent at any time via Account Settings > Data & Privacy. Withdrawal stops future sharing; already-contributed rows are anonymised and retained (GDPR Art. 7(3))."
- Last Updated date: 31 May 2026 → 8 June 2026

## Merge note

**Merge with or after PR #1037** — the Account Settings path it references does not exist until G6 lands. Also note: PR #1025 (AIR-2590) and PR #1029 (AIR-2525) both touch the date field; trivial conflict to resolve on whichever merges last.

## Test plan

- [ ] §8 shows new data contribution withdrawal bullet
- [ ] Bullet references Account Settings > Data & Privacy
- [ ] Art. 7(3) cited correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)