### PR TITLE
fix(analyze): de-duplicate Glasgow and Comparison tab labels

### DIFF
--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -1133,7 +1133,6 @@ function AnalyzePageInner() {
                   {/* Secondary tabs — abbreviated on mobile */}
                   <TabsTrigger value="glasgow" className="gap-1.5">
                     <Activity className="h-3.5 w-3.5" />
-                    Glasgow
                     <span className="sm:hidden text-[11px]">Glasgow</span>
                     <span className="hidden sm:inline">Glasgow</span>
                   </TabsTrigger>
@@ -1155,7 +1154,6 @@ function AnalyzePageInner() {
                   </TabsTrigger>
                   <TabsTrigger value="compare" className="gap-1.5">
                     <ArrowLeftRight className="h-3.5 w-3.5" />
-                    Compare
                     <span className="sm:hidden text-[11px]">Compare</span>
                     <span className="hidden sm:inline">Comparison</span>
                   </TabsTrigger>


### PR DESCRIPTION
## What

The analysis dashboard tab bar rendered two tab labels doubled — **"Glasgow Glasgow"** and **"Compare Comparison"** — at desktop width.

## Why

The `glasgow` and `compare` `TabsTrigger`s each carried a stray leading plain-text node on top of their two responsive `<span>`s (`sm:hidden` short label + `hidden sm:inline` full label). At/above the `sm` breakpoint the full-label span rendered next to the stray text node, so the label doubled. The Flow and Oximetry triggers already use the intended icon + two-span pattern, which is why only these two doubled.

## Change

Delete the two stray text nodes so both triggers match the Flow/Oximetry pattern. Presentation-only (`app/analyze/page.tsx`), no clinical-path or logic change.

## Verify

- `npm run typecheck` and `npm run lint` clean locally.
- Tab bar now reads `Glasgow` and `Comparison` once each (full label ≥ `sm`, abbreviated below).

Reported via Discord. Closes #1042