### PR TITLE
account: relabel destructive action as account deletion + guard paid users

### DIFF
--- a/__tests__/conversion-funnel.test.ts
+++ b/__tests__/conversion-funnel.test.ts
@@ -121,11 +121,17 @@ describe('Step 5: Account settings', () => {
     expect(src).toContain('Your Data');
   });
 
-  it('account page has data deletion flow', () => {
+  it('account page has account deletion flow', () => {
     const src = readSource('app/account/page.tsx');
-    expect(src).toContain('Delete all my data');
+    expect(src).toContain('Delete my account');
     expect(src).toContain('showDeleteConfirm');
     expect(src).toContain('handleDeleteData');
+  });
+
+  it('account deletion confirm warns it cancels the subscription for paid users', () => {
+    const src = readSource('app/account/page.tsx');
+    expect(src).toContain('subscription will be');
+    expect(src).toContain('deletes your entire account');
   });
 
   it('user menu has account settings link', () => {

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -84,6 +84,7 @@ export default function AccountPage() {
   const [portalError, setPortalError] = useState(false);
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [confirmText, setConfirmText] = useState('');
   const [deleteState, setDeleteState] = useState<
     'idle' | 'deleting' | 'success' | 'error'
   >('idle');
@@ -123,6 +124,11 @@ export default function AccountPage() {
       setShowDeleteConfirm(false);
       setStats({ fileCount: 0, totalBytes: 0, nightCount: 0 });
       events.dataDeletionCompleted();
+      // The auth user no longer exists — this session is now invalid. Send the
+      // user home rather than leave them on a page logged into a deleted account.
+      setTimeout(() => {
+        window.location.href = '/';
+      }, 2500);
     } catch (err) {
       Sentry.captureException(err, { tags: { action: 'delete-user-data' } });
       setDeleteState('error');
@@ -288,7 +294,7 @@ export default function AccountPage() {
             {deleteState === 'success' && (
               <div className="flex items-center gap-2 text-emerald-400 text-sm">
                 <CheckCircle2 className="h-4 w-4" />
-                All server-side data has been deleted.
+                Your account has been deleted. Redirecting...
               </div>
             )}
 
@@ -299,7 +305,7 @@ export default function AccountPage() {
               </div>
             )}
 
-            {!showDeleteConfirm && deleteState !== 'deleting' && (
+            {!showDeleteConfirm && deleteState !== 'deleting' && deleteState !== 'success' && (
               <Button
                 variant="destructive"
                 size="sm"
@@ -307,7 +313,7 @@ export default function AccountPage() {
                 className="w-full"
               >
                 <Trash2 className="h-4 w-4 mr-2" />
-                Delete all my data
+                Delete my account
               </Button>
             )}
 
@@ -315,19 +321,53 @@ export default function AccountPage() {
               <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-4 space-y-3">
                 <div className="flex items-start gap-2">
                   <AlertTriangle className="h-5 w-5 text-red-400 shrink-0 mt-0.5" />
-                  <p className="text-sm text-muted-foreground">
-                    This permanently deletes your health data from our servers
-                    &mdash; uploaded EDF files and stored analysis results.
-                    Anonymised research contributions are not affected.
-                    Browser-local data is not affected. This cannot be undone.
-                  </p>
+                  <div className="space-y-2 text-sm text-muted-foreground">
+                    <p className="font-medium text-foreground">
+                      This deletes your entire account, not just files.
+                    </p>
+                    <p>
+                      It permanently removes your AirwayLab account and all health
+                      data on our servers &mdash; uploaded EDF files and stored
+                      analysis results. You would need to sign up again to return.
+                    </p>
+                    {isPaid && (
+                      <p className="font-medium text-red-400">
+                        Your active {tierConfig.label} subscription will be
+                        cancelled &mdash; paid features end immediately, you will
+                        not be billed again, and you would need to subscribe again
+                        to restore it.
+                      </p>
+                    )}
+                    <p>
+                      Anonymised research contributions are not affected. This does
+                      not clear your browser-local data, so it will not fix a
+                      &ldquo;Storage limit reached&rdquo; message (that is your
+                      browser&rsquo;s cache, not your account). This cannot be undone.
+                    </p>
+                  </div>
                 </div>
+                {isPaid && (
+                  <div className="space-y-1">
+                    <label htmlFor="delete-confirm" className="text-xs text-muted-foreground">
+                      Type <span className="font-mono font-semibold text-foreground">DELETE</span> to confirm
+                    </label>
+                    <input
+                      id="delete-confirm"
+                      type="text"
+                      autoComplete="off"
+                      value={confirmText}
+                      onChange={(e) => setConfirmText(e.target.value)}
+                      disabled={deleteState === 'deleting'}
+                      className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-red-500"
+                    />
+                  </div>
+                )}
                 <div className="flex gap-2">
                   <Button
                     variant="destructive"
                     size="sm"
                     onClick={handleDeleteData}
-                    disabled={deleteState === 'deleting'}
+                    disabled={deleteState === 'deleting' || (isPaid && confirmText.trim().toUpperCase() !== 'DELETE')}
                     className="flex-1"
                   >
                     {deleteState === 'deleting' ? (
@@ -336,7 +376,7 @@ export default function AccountPage() {
                         Deleting...
                       </>
                     ) : (
-                      'Delete my data'
+                      'Delete my account'
                     )}
                   </Button>
                   <Button
@@ -344,12 +384,13 @@ export default function AccountPage() {
                     size="sm"
                     onClick={() => {
                       setShowDeleteConfirm(false);
+                      setConfirmText('');
                       setDeleteState('idle');
                     }}
                     disabled={deleteState === 'deleting'}
                     className="flex-1"
                   >
-                    Keep my data
+                    Keep my account
                   </Button>
                 </div>
               </div>


### PR DESCRIPTION
## Problem

The account-menu **"Delete all my data"** button calls `delete-user-data` which **cancels the user's Stripe subscription and deletes their auth account** — but the button and confirmation framed it as a *data cleanup* (\"deletes your health data... Browser-local data is not affected\").

A supporter (Discord: Damanhoury) reported repeatedly being downgraded supporter→community. Root cause, verified against `origin/main`:

1. The user-facing **"Storage limit reached"** message is a **browser-local localStorage 4MB cap** (`lib/persistence.ts`), not cloud storage (cloud is unlimited for all tiers, `lib/storage/quota.ts`).
2. To "free space," users reach for **"Delete all my data"** — which actually deletes their account and cancels their paid sub, and doesn't even touch the browser-local data that was the problem.
3. They re-sign-up at `community` tier → the downgrade repeats.

## This PR (harm reduction — stops the self-cancellation)

- Rename the button to **"Delete my account"**; success copy now says the account was deleted and **redirects home** (the session is invalid once the auth user is gone).
- Confirmation states plainly it **deletes the entire account**, and for **paid users** adds an explicit *"your `<tier>` subscription will be cancelled"* warning plus a **type-`DELETE`-to-confirm** guard.
- Clarify it does **not** clear browser-local data, so it will not fix a "Storage limit reached" message.

## Follow-ups (separate PRs)

- A real **"Clear browser storage"** remedy (the non-destructive escape hatch).
- Migrate the dashboard summary **localStorage → IndexedDB** to remove the 4MB ceiling that produces "Storage limit reached".
- Raise the per-file upload cap + bucket limit.

## Test

- `npx tsc --noEmit` clean, `eslint` clean.
- `conversion-funnel.test.ts` updated to the new copy + asserts the cancellation warning (64 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)