### PR TITLE
chore(glasgow): label tab "Glasgow Index" and fix upstream attribution URL

### DIFF
--- a/.claude/rules/engine-reference.md
+++ b/.claude/rules/engine-reference.md
@@ -7,7 +7,7 @@ globs:
 # Analysis Engines Reference
 
 ### Glasgow Index (`lib/analyzers/glasgow-index.ts`)
-Ported from DaveSkvn/Glasgow-Index (GPL-3.0). Scores inspiratory flow shapes on 9 components (0–1 each): skew, spike, flatTop, topHeavy, multiPeak, noPause, inspirRate, multiBreath, variableAmp. Overall score = sum of all 9 components, range 0–9. Pipeline: findMins → findInspirations → calcCycleBasedIndicators → inspirationAmplitude → prepIndices. Multi-session nights use duration-weighted averaging.
+Ported from DaveSkvn/GlasgowIndex (GPL-3.0). Scores inspiratory flow shapes on 9 components (0–1 each): skew, spike, flatTop, topHeavy, multiPeak, noPause, inspirRate, multiBreath, variableAmp. Overall score = sum of all 9 components, range 0–9. Pipeline: findMins → findInspirations → calcCycleBasedIndicators → inspirationAmplitude → prepIndices. Multi-session nights use duration-weighted averaging.
 
 ### WAT — Wobble Analysis Tool (`lib/analyzers/wat-engine.ts`)
 Three metrics: FL Score (inspiratory flatness, 0–100, higher = worse), Regularity (Sample Entropy on minute ventilation, higher = more irregular), Periodicity Index (FFT power in 0.01–0.03 Hz band, detects periodic breathing at 30–100s cycles). Includes a Cooley-Tukey radix-2 FFT implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ airwaylab/
 ## Analysis Engines
 
 ### Glasgow Index (`lib/analyzers/glasgow-index.ts`)
-Ported from DaveSkvn/Glasgow-Index (GPL-3.0). Scores inspiratory flow shapes on 9 components (0–1 each): skew, spike, flatTop, topHeavy, multiPeak, noPause, inspirRate, multiBreath, variableAmp. Overall score = sum of all 9 components, range 0–9. Pipeline: findMins → findInspirations → calcCycleBasedIndicators → inspirationAmplitude → prepIndices. Multi-session nights use duration-weighted averaging.
+Ported from DaveSkvn/GlasgowIndex (GPL-3.0). Scores inspiratory flow shapes on 9 components (0–1 each): skew, spike, flatTop, topHeavy, multiPeak, noPause, inspirRate, multiBreath, variableAmp. Overall score = sum of all 9 components, range 0–9. Pipeline: findMins → findInspirations → calcCycleBasedIndicators → inspirationAmplitude → prepIndices. Multi-session nights use duration-weighted averaging.
 
 ### WAT — Wobble Analysis Tool (`lib/analyzers/wat-engine.ts`)
 Three metrics: FL Score (inspiratory flatness, 0–100, higher = worse), Regularity (Sample Entropy on minute ventilation, higher = more irregular), Periodicity Index (FFT power in 0.01–0.03 Hz band, detects periodic breathing at 30–100s cycles). Includes a Cooley-Tukey radix-2 FFT implementation.
@@ -150,7 +150,7 @@ Per-breath analysis: NED = (Qpeak − Qmid) / Qpeak × 100, Flatness Index = mea
 
 7. **Supabase EU region.** GDPR requirement. RLS must be enabled on every table before use. Auth is Supabase Auth only — no OAuth/social login.
 
-8. **Open-core model (GPL-3.0).** The Glasgow Index engine is ported from DaveSkvn/Glasgow-Index (GPL-3.0), which requires the entire project to be GPL-3.0. This aligns with the mission: open data, open code, verifiable trust.
+8. **Open-core model (GPL-3.0).** The Glasgow Index engine is ported from DaveSkvn/GlasgowIndex (GPL-3.0), which requires the entire project to be GPL-3.0. This aligns with the mission: open data, open code, verifiable trust.
 
 9. **Dark-default theme with light option.** Dark is the default clinical aesthetic. A light theme is available via Settings > Display Preferences for accessibility. Both themes use HSL CSS variables defined in `globals.css` (`:root` for dark, `[data-theme="light"]` for light) and referenced in `tailwind.config.ts`. Preference persists in `airwaylab_theme` localStorage key.
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ If AirwayLab helps you understand your therapy data:
 
 GPL-3.0. See [LICENSE](LICENSE).
 
-The Glasgow Index engine is based on [DaveSkvn's Glasgow Index](https://github.com/DaveSkvn/Glasgow-Index) (GPL-3.0).
+The Glasgow Index engine is based on [DaveSkvn's Glasgow Index](https://github.com/DaveSkvn/GlasgowIndex) (GPL-3.0).
 
 ## Disclaimer
 

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -1134,7 +1134,7 @@ function AnalyzePageInner() {
                   <TabsTrigger value="glasgow" className="gap-1.5">
                     <Activity className="h-3.5 w-3.5" />
                     <span className="sm:hidden text-[11px]">Glasgow</span>
-                    <span className="hidden sm:inline">Glasgow</span>
+                    <span className="hidden sm:inline">Glasgow Index</span>
                   </TabsTrigger>
                   <TabsTrigger value="flow" className="gap-1.5">
                     <Waves className="h-3.5 w-3.5" />

--- a/app/blog/posts/what-is-glasgow-index-cpap.tsx
+++ b/app/blog/posts/what-is-glasgow-index-cpap.tsx
@@ -61,7 +61,7 @@ export default function WhatIsGlasgowIndexCPAP() {
             means more breath shape irregularities were detected.
           </p>
           <p>
-            AirwayLab&apos;s implementation is an open-source port of the DaveSkvn/Glasgow-Index
+            AirwayLab&apos;s implementation is an open-source port of the DaveSkvn/GlasgowIndex
             algorithm (GPL-3.0). The code is publicly auditable -- you can verify exactly what it
             calculates.
           </p>
@@ -168,7 +168,7 @@ export default function WhatIsGlasgowIndexCPAP() {
         <div className="mt-4 text-sm text-muted-foreground">
           <p>
             AirwayLab implements an open-source port of the{' '}
-            <strong className="text-foreground">DaveSkvn/Glasgow-Index</strong> algorithm
+            <strong className="text-foreground">DaveSkvn/GlasgowIndex</strong> algorithm
             (GPL-3.0). The algorithm was developed to score nine features of the inspiratory flow
             waveform. Code is publicly auditable on GitHub.
           </p>


### PR DESCRIPTION
## What

Two small Glasgow-naming/attribution cleanups:

1. **Analyze tab label** `Glasgow` → `Glasgow Index` (desktop). It was the only surface using the bare name; the rest of the product (`/about/glasgow-index`, glossary, blog, README) already says "Glasgow Index", which is also the upstream repo name. Mobile keeps the short `Glasgow`.
2. **Fix a broken GPL attribution link.** The README credited `github.com/DaveSkvn/Glasgow-Index`, which **404s**. The real repo is **`github.com/DaveSkvn/GlasgowIndex`** (GPL-3.0, contains `FlowLimits.js`). Corrected the credit link and every `DaveSkvn/Glasgow-Index` text reference (README, blog post, `CLAUDE.md`, `engine-reference.md`).

The separate, correctly-hyphenated `VibeCoder75321/Multi-Night-Glasgow-Index-Analyzer` repo is intentionally left untouched.

## Why

A dead link on a copyleft attribution is bad form, and the lone bare-"Glasgow" tab was inconsistent with both the product's own terminology and the credited source.

## Verify

- `npm run typecheck` and `npm run lint` clean locally.
- No `DaveSkvn/Glasgow-Index` (hyphen) references remain; `VibeCoder75321/...` untouched.
- `https://github.com/DaveSkvn/GlasgowIndex` resolves (GPL-3.0); the hyphenated form returns 404.

No separate issue — self-contained consistency/correctness fix.