### PR TITLE
account/analyze: non-destructive "Clear browser storage" remedy

### DIFF
--- a/__tests__/clear-local-data.test.ts
+++ b/__tests__/clear-local-data.test.ts
@@ -1,0 +1,68 @@
+// ============================================================
+// AirwayLab — clearAllLocalData unit tests
+// Verifies the non-destructive "Clear browser storage" remedy wipes BOTH
+// the localStorage dashboard summary and every IndexedDB store, and that a
+// localStorage failure never blocks the IndexedDB clear (which holds the
+// bulk of the local footprint).
+// ============================================================
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const clearSpy = vi.fn();
+  const objectStore = vi.fn(() => ({ clear: clearSpy }));
+  const runTxMock = vi.fn((_stores: unknown, _mode: unknown, fn: (tx: unknown) => unknown) => {
+    fn({ objectStore });
+    return Promise.resolve();
+  });
+  const clearPersistedNights = vi.fn();
+  return { clearSpy, objectStore, runTxMock, clearPersistedNights };
+});
+
+vi.mock('@/lib/idb-core', () => ({
+  runTx: h.runTxMock,
+  WAVEFORM_STORE_NAME: 'waveforms',
+  OXIMETRY_STORE_NAME: 'oximetry-traces',
+  BREATH_DATA_STORE_NAME: 'breath-data',
+  PLD_TRACES_STORE_NAME: 'pld-traces',
+}));
+
+vi.mock('@/lib/persistence', () => ({
+  clearPersistedNights: h.clearPersistedNights,
+}));
+
+import { clearAllLocalData } from '@/lib/clear-local-data';
+
+describe('clearAllLocalData', () => {
+  beforeEach(() => {
+    h.clearSpy.mockClear();
+    h.objectStore.mockClear();
+    h.runTxMock.mockClear();
+    h.clearPersistedNights.mockReset();
+  });
+
+  it('clears the localStorage summary and every IndexedDB store', async () => {
+    await clearAllLocalData();
+
+    expect(h.clearPersistedNights).toHaveBeenCalledTimes(1);
+    expect(h.runTxMock).toHaveBeenCalledTimes(1);
+    expect(h.runTxMock.mock.calls[0]![0]).toEqual([
+      'waveforms',
+      'oximetry-traces',
+      'breath-data',
+      'pld-traces',
+    ]);
+    expect(h.runTxMock.mock.calls[0]![1]).toBe('readwrite');
+    expect(h.clearSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('still clears IndexedDB when the localStorage clear throws', async () => {
+    h.clearPersistedNights.mockImplementationOnce(() => {
+      throw new Error('localStorage unavailable');
+    });
+
+    await expect(clearAllLocalData()).resolves.toBeUndefined();
+    expect(h.runTxMock).toHaveBeenCalledTimes(1);
+    expect(h.clearSpy).toHaveBeenCalledTimes(4);
+  });
+});

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -20,7 +20,9 @@ import {
   AlertTriangle,
   CheckCircle2,
   XCircle,
+  HardDrive,
 } from 'lucide-react';
+import { clearAllLocalData } from '@/lib/clear-local-data';
 
 const TIER_CONFIG = {
   community: { label: 'Community', color: 'text-muted-foreground' },
@@ -88,6 +90,19 @@ export default function AccountPage() {
   const [deleteState, setDeleteState] = useState<
     'idle' | 'deleting' | 'success' | 'error'
   >('idle');
+
+  const [clearState, setClearState] = useState<'idle' | 'clearing' | 'cleared' | 'error'>('idle');
+
+  async function handleClearLocal() {
+    setClearState('clearing');
+    try {
+      await clearAllLocalData();
+      setClearState('cleared');
+    } catch (err) {
+      Sentry.captureException(err, { tags: { action: 'clear-local-data-account' } });
+      setClearState('error');
+    }
+  }
 
   useEffect(() => {
     if (!user) return;
@@ -289,6 +304,47 @@ export default function AccountPage() {
               </div>
             </div>
           )}
+
+          {/* Free up space — non-destructive, clears browser-local data only */}
+          <div className="border-t border-border pt-4 space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <div className="space-y-0.5">
+                <p className="text-sm font-medium flex items-center gap-2">
+                  <HardDrive className="h-4 w-4" />
+                  Browser storage
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Frees local space on this device and fixes a &ldquo;Storage limit
+                  reached&rdquo; message. Does <span className="font-medium">not</span> delete
+                  your account or your data on our servers.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                onClick={handleClearLocal}
+                disabled={clearState === 'clearing'}
+              >
+                {clearState === 'clearing' ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Clearing...
+                  </>
+                ) : (
+                  'Clear browser storage'
+                )}
+              </Button>
+            </div>
+            {clearState === 'cleared' && (
+              <p className="text-xs text-emerald-400">
+                Browser storage cleared. Re-upload your SD card to view your data again.
+              </p>
+            )}
+            {clearState === 'error' && (
+              <p className="text-xs text-red-400">Could not clear browser storage. Please try again.</p>
+            )}
+          </div>
 
           <div className="border-t border-border pt-4 space-y-3">
             {deleteState === 'success' && (

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -42,7 +42,8 @@ import { Button } from '@/components/ui/button';
 import { orchestrator } from '@/lib/analysis-orchestrator';
 import { SAMPLE_NIGHTS, SAMPLE_THERAPY_CHANGE_DATE } from '@/lib/sample-data';
 import type { AnalysisState, NightResult } from '@/lib/types';
-import { loadPersistedResults, clearPersistedNights, mergeNightsByDate } from '@/lib/persistence';
+import { loadPersistedResults, mergeNightsByDate } from '@/lib/persistence';
+import { clearAllLocalData } from '@/lib/clear-local-data';
 import { events, capturePostHog, setPostHogPersonProps } from '@/lib/analytics';
 import { useTierHistoryWindowDays } from '@/hooks/use-tier-history-window-days';
 import { contributeNights, trackContributedDates } from '@/lib/contribute';
@@ -571,8 +572,14 @@ function AnalyzePageInner() {
     }
   }, [isDemo]);
 
-  const handleClearLocalData = useCallback(() => {
-    clearPersistedNights();
+  const handleClearLocalData = useCallback(async () => {
+    // Clears the localStorage summary AND all IndexedDB stores (the bulk of
+    // the local footprint) — frees space without touching the account/server.
+    try {
+      await clearAllLocalData();
+    } catch (err) {
+      Sentry.captureException(err, { tags: { action: 'clear-local-data' } });
+    }
     orchestrator.reset();
     setPersistedData(null);
     setLocalDataCleared(true);
@@ -986,9 +993,9 @@ function AnalyzePageInner() {
                     variant="ghost"
                     size="sm"
                     className="h-7 shrink-0 text-xs text-amber-600 hover:bg-amber-500/10 hover:text-amber-700"
-                    onClick={handleClearLocalData}
+                    onClick={() => { void handleClearLocalData(); }}
                   >
-                    Clear saved data
+                    Free up space
                   </Button>
                 )}
               </div>

--- a/lib/clear-local-data.ts
+++ b/lib/clear-local-data.ts
@@ -1,0 +1,40 @@
+import {
+  runTx,
+  WAVEFORM_STORE_NAME,
+  OXIMETRY_STORE_NAME,
+  BREATH_DATA_STORE_NAME,
+  PLD_TRACES_STORE_NAME,
+} from '@/lib/idb-core';
+import { clearPersistedNights } from '@/lib/persistence';
+
+/**
+ * Wipe ALL browser-local AirwayLab data on this device: the localStorage
+ * dashboard summary (+ file manifest) AND every IndexedDB store
+ * (waveforms, oximetry traces, breath data, PLD traces).
+ *
+ * This is the non-destructive way to free local space and clear a
+ * "Storage limit reached" message. It does NOT touch the user's account
+ * or any server-side data — re-uploading the SD card restores everything.
+ *
+ * Best-effort across layers: a failure clearing localStorage never blocks
+ * the IndexedDB clear (which holds the bulk of the local footprint).
+ */
+export async function clearAllLocalData(): Promise<void> {
+  try {
+    clearPersistedNights();
+  } catch {
+    // Non-fatal — IndexedDB below holds the bulk of the space.
+  }
+
+  // Clear every store in a single transaction (one DB, one connection).
+  await runTx(
+    [WAVEFORM_STORE_NAME, OXIMETRY_STORE_NAME, BREATH_DATA_STORE_NAME, PLD_TRACES_STORE_NAME],
+    'readwrite',
+    (tx) => [
+      tx.objectStore(WAVEFORM_STORE_NAME).clear(),
+      tx.objectStore(OXIMETRY_STORE_NAME).clear(),
+      tx.objectStore(BREATH_DATA_STORE_NAME).clear(),
+      tx.objectStore(PLD_TRACES_STORE_NAME).clear(),
+    ],
+  );
+}


### PR DESCRIPTION
Follow-up to airwaylab-app/airwaylab#1044 (relabel). Part of airwaylab-app/airwaylab-app#125.

## Why

"Storage limit reached" is a **browser-local localStorage cap**, not server storage. Users had no in-app way to free that space except the destructive account deletion — which doesn't even clear browser-local data. This gives them the real escape hatch so they stop reaching for "Delete my account."

## What

- New `lib/clear-local-data.ts` → `clearAllLocalData()`: wipes the localStorage summary (+ manifest) **and all four IndexedDB stores** (`waveforms`, `oximetry-traces`, `breath-data`, `pld-traces`) in one transaction. Best-effort: a localStorage failure never blocks the IndexedDB clear.
- **Account page:** a "Clear browser storage" button above the delete-account action, framed as device-local only (no account/server impact).
- **Analyze page:** the storage-limit warning's button (now **"Free up space"**) upgraded to also clear IndexedDB, not just localStorage.

## Test

- `tsc --noEmit` + `eslint` clean.
- New `__tests__/clear-local-data.test.ts`: asserts it clears the summary + all four stores, and isolates a localStorage failure (119 tests green across affected suites).

## Follow-ups (#1045)

- Migrate the dashboard summary localStorage → IndexedDB (removes the 4MB ceiling for real).
- Raise per-file upload cap + bucket limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)