### PR TITLE
fix(auth): repair missing profile rows for existing sessions (AIR-1762)

### DIFF
--- a/__tests__/ensure-profile-route.test.ts
+++ b/__tests__/ensure-profile-route.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for /api/auth/ensure-profile (AIR-1762).
+ *
+ * This route repairs missing profile rows for authenticated users with
+ * existing sessions — the gap not covered by the auth callback upsert.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockCaptureMessage = vi.fn();
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+  captureException: vi.fn(),
+}));
+
+const mockGetUser = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseServer: vi.fn(async () => ({
+    auth: { getUser: () => mockGetUser() },
+  })),
+  getSupabaseServiceRole: vi.fn(() => ({
+    from: (_table: string) => ({ upsert: mockUpsert }),
+  })),
+}));
+
+const mockUpsert = vi.fn();
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => ({ getAll: vi.fn(() => []), set: vi.fn() })),
+}));
+
+// ── Setup ──────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://test.supabase.co');
+  vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'anon-key');
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-role-key');
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('POST /api/auth/ensure-profile (AIR-1762)', () => {
+  it('returns 200 and upserts the profile for an authenticated user', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-abc', email: 'test@example.com' } },
+      error: null,
+    });
+    mockUpsert.mockResolvedValue({ error: null });
+
+    const { POST } = await import('@/app/api/auth/ensure-profile/route');
+    const res = await POST();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'user-abc', email: 'test@example.com', storage_consent: true }),
+      expect.objectContaining({ onConflict: 'id', ignoreDuplicates: true })
+    );
+  });
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const { POST } = await import('@/app/api/auth/ensure-profile/route');
+    const res = await POST();
+
+    expect(res.status).toBe(401);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when getUser returns an auth error', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'JWT expired' },
+    });
+
+    const { POST } = await import('@/app/api/auth/ensure-profile/route');
+    const res = await POST();
+
+    expect(res.status).toBe(401);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 and reports to Sentry when upsert fails', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-abc', email: 'test@example.com' } },
+      error: null,
+    });
+    mockUpsert.mockResolvedValue({ error: { message: 'DB connection lost' } });
+
+    const { POST } = await import('@/app/api/auth/ensure-profile/route');
+    const res = await POST();
+
+    expect(res.status).toBe(500);
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'ensure-profile: upsert failed',
+      expect.objectContaining({ level: 'error', tags: expect.objectContaining({ route: 'ensure-profile' }) })
+    );
+  });
+
+  it('uses empty string when user.email is null', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-no-email', email: null } },
+      error: null,
+    });
+    mockUpsert.mockResolvedValue({ error: null });
+
+    const { POST } = await import('@/app/api/auth/ensure-profile/route');
+    await POST();
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'user-no-email', email: '' }),
+      expect.any(Object)
+    );
+  });
+
+  it('reports to Sentry with info level on successful repair', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-abc', email: 'test@example.com' } },
+      error: null,
+    });
+    mockUpsert.mockResolvedValue({ error: null });
+
+    const { POST } = await import('@/app/api/auth/ensure-profile/route');
+    await POST();
+
+    expect(mockCaptureMessage).toHaveBeenCalledWith(
+      'ensure-profile: repaired missing profile row',
+      expect.objectContaining({ level: 'info' })
+    );
+  });
+});

--- a/app/api/auth/ensure-profile/route.ts
+++ b/app/api/auth/ensure-profile/route.ts
@@ -1,0 +1,64 @@
+// ============================================================
+// AirwayLab — Ensure Profile Route
+// Idempotent profile repair for authenticated users whose
+// profile row is missing (trigger gap, stale session, etc.).
+// Called by auth-context when fetchProfile returns null.
+// ============================================================
+
+import { NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server';
+
+export async function POST() {
+  const supabase = await getSupabaseServer();
+  if (!supabase) {
+    return NextResponse.json({ error: 'Auth not configured' }, { status: 503 });
+  }
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthenticated' }, { status: 401 });
+  }
+
+  const adminClient = getSupabaseServiceRole();
+  if (!adminClient) {
+    Sentry.captureMessage('ensure-profile: service role client unavailable', {
+      level: 'error',
+      tags: { route: 'ensure-profile' },
+      extra: { userId: user.id },
+    });
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 });
+  }
+
+  const { error: upsertError } = await adminClient
+    .from('profiles')
+    .upsert(
+      {
+        id: user.id,
+        email: user.email ?? '',
+        storage_consent: true,
+        storage_consent_at: new Date().toISOString(),
+      },
+      { onConflict: 'id', ignoreDuplicates: true }
+    );
+
+  if (upsertError) {
+    console.error('[ensure-profile] Upsert failed:', upsertError.message);
+    Sentry.captureMessage('ensure-profile: upsert failed', {
+      level: 'error',
+      tags: { route: 'ensure-profile' },
+      extra: { userId: user.id, error: upsertError.message },
+    });
+    return NextResponse.json({ error: 'Profile repair failed' }, { status: 500 });
+  }
+
+  Sentry.captureMessage('ensure-profile: repaired missing profile row', {
+    level: 'info',
+    tags: { route: 'ensure-profile' },
+    extra: { userId: user.id },
+  });
+
+  console.error('[ensure-profile] Repaired missing profile for user:', user.id);
+  return NextResponse.json({ ok: true });
+}

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -161,7 +161,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         .maybeSingle();
     }
 
-    const { data: profileData, error: profileError } = profileResult;
+    const { data: fetchedProfileData, error: profileError } = profileResult;
 
     if (profileError) {
       // A1: a failed profile fetch must NOT silently downgrade a paid user.
@@ -184,17 +184,39 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       // A1: the subscription row is the server-side source of truth for paid
       // access and may be readable even when the profile read failed, so a
-      // previously-unseen paid user is not locked out on cold start.
+      // previously-unseen paid user is not logged out on cold start.
       await fetchSubscriptionTier(userId);
       return;
     }
 
+    // If no profile row, attempt a server-side repair then re-fetch once.
+    // Covers users with existing sessions whose profile row was never created
+    // (trigger gap, PKCE cross-context signup, stale pre-fix session).
+    let profileData = fetchedProfileData;
     if (!profileData) {
-      // Profile row missing — auth trigger may not have fired for this user.
-      // Treat as unknown (not a confirmed downgrade) so a paid user with a
-      // transiently-missing row keeps their last-known / subscription entitlement.
-      setEntitlementStatus('unknown');
       console.error('[auth-context] No profile row found for user:', userId);
+      try {
+        const repairRes = await fetch('/api/auth/ensure-profile', {
+          method: 'POST',
+          credentials: 'same-origin',
+        });
+        if (repairRes.ok) {
+          const retryResult = await supabase
+            .from('profiles')
+            .select(PROFILE_COLS)
+            .eq('id', userId)
+            .maybeSingle();
+          profileData = retryResult.data ?? null;
+        }
+      } catch {
+        // network error during repair — subscription fallback runs below
+      }
+    }
+
+    if (!profileData) {
+      // Repair failed or retry still found no row — treat as unknown so a paid
+      // user keeps their last-known entitlement.
+      setEntitlementStatus('unknown');
       Sentry.captureMessage('Profile row missing for authenticated user', {
         level: 'warning',
         tags: { context: 'auth-profile-fetch' },


### PR DESCRIPTION
## Summary

Follow-up to PR #911 — closes the remaining gap causing Sentry JAVASCRIPT-NEXTJS-6S (37 events / 7 users still firing 2026-06-09).

**Root cause (updated):** PR #911 added a profile upsert in the auth callback, which only fires when a user clicks a magic link (code exchange). Users with **existing sessions** who have no profile row hit `fetchProfile → null → Sentry` on **every page load** without any repair path.

**Changes:**
- `app/api/auth/ensure-profile/route.ts` — new POST endpoint: validates auth, uses service-role upsert with `ON CONFLICT (id) DO NOTHING`, logs repair to Sentry at `info` level, returns 200/401/500 appropriately.
- `lib/auth/auth-context.tsx` — in `fetchProfile`, when `profileData` is null: call `/api/auth/ensure-profile`, retry the profile read once. If repair succeeds the user is set up normally. If repair fails, fall through to the existing subscription fallback (A1 downgrade protection unchanged).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 2794/2794 passed
- [ ] Vercel preview deploy verified by Demian
- [ ] Confirm Sentry JAVASCRIPT-NEXTJS-6S event count drops after deploy

## Pre-merge checklist

- [x] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [x] Self-review: no regressions, A1 downgrade protection preserved
- [x] PR contains one concern only (profile repair path for existing sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)