### PR TITLE
fix(uploads): map Storage 5xx to 503+Retry-After, throttle bulk-upload burst

### DIFF
--- a/__tests__/upload-orchestrator.test.ts
+++ b/__tests__/upload-orchestrator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isTransientServerError, getPartialFailureLevel, filterUploadableFiles, classifyUploadError } from '@/lib/storage/upload-orchestrator';
+import { isTransientServerError, getPartialFailureLevel, filterUploadableFiles, classifyUploadError, parseRetryAfterMs } from '@/lib/storage/upload-orchestrator';
 
 describe('isTransientServerError', () => {
   it('identifies 502 Bad Gateway as transient', () => {
@@ -183,5 +183,32 @@ describe('classifyUploadError', () => {
     expect(classifyUploadError('CLOUD SYNC REQUIRES AN ACTIVE SESSION. PLEASE SIGN IN AGAIN.')).toBe('auth');
     expect(classifyUploadError('HASH FAILED for file 1: error')).toBe('hash_worker');
     expect(classifyUploadError('FAILED TO FETCH')).toBe('network');
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  it('parses delta-seconds into milliseconds', () => {
+    expect(parseRetryAfterMs('5')).toBe(5000);
+    expect(parseRetryAfterMs('0')).toBe(0);
+    expect(parseRetryAfterMs('120')).toBe(120000);
+  });
+
+  it('returns undefined for a missing or empty header', () => {
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs('')).toBeUndefined();
+  });
+
+  it('returns undefined for an unparseable value', () => {
+    expect(parseRetryAfterMs('soon')).toBeUndefined();
+  });
+
+  it('clamps negative deltas to zero', () => {
+    expect(parseRetryAfterMs('-10')).toBe(0);
+  });
+
+  it('parses an HTTP-date into a non-negative delay', () => {
+    const ms = parseRetryAfterMs(new Date(Date.now() + 30_000).toUTCString());
+    expect(ms).toBeGreaterThanOrEqual(0);
+    expect(ms).toBeLessThanOrEqual(31_000);
   });
 });

--- a/app/api/contribute-oximetry-trace/route.ts
+++ b/app/api/contribute-oximetry-trace/route.ts
@@ -5,6 +5,7 @@ import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
 import { exceedsPayloadLimit } from '@/lib/api/payload-guard';
+import { upstreamErrorResponse } from '@/lib/api/upstream-error';
 
 const OximetryMetadataSchema = z.object({
   nightDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid night date format.'),
@@ -113,7 +114,11 @@ export async function POST(request: NextRequest) {
       }
       console.error('[contribute-oximetry-trace] Storage error:', storageError.message);
       Sentry.captureException(storageError, { tags: { route: 'contribute-oximetry-trace' } });
-      return NextResponse.json({ error: 'Storage error.' }, { status: 500 });
+      // Transient Storage 5xx → 503 + Retry-After; genuine failures stay 500.
+      return upstreamErrorResponse(storageError, {
+        retryable: 'Storage temporarily unavailable. Please try again shortly.',
+        fatal: 'Storage error.',
+      });
     }
 
     const { error: dbError } = await supabase.from('oximetry_trace_contributions').insert({

--- a/app/api/files/presign/route.ts
+++ b/app/api/files/presign/route.ts
@@ -5,10 +5,18 @@ import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server
 import { RateLimiter, getUserRateLimitKey } from '@/lib/rate-limit';
 import { validateOrigin } from '@/lib/csrf';
 import { exceedsPayloadLimit } from '@/lib/api/payload-guard';
+import { upstreamErrorResponse } from '@/lib/api/upstream-error';
 import { hasStorageConsent } from '@/lib/storage/quota';
 import { STORAGE_BUCKET, MAX_FILE_SIZE, SUPPORTED_EXTENSIONS } from '@/lib/storage/types';
 
+// Long-window guard: an upper bound on a single user's total presign volume.
 const rateLimiter = new RateLimiter({ windowMs: 3_600_000, max: 5000, persistent: true });
+
+// Short-window burst backstop: defence-in-depth behind the Vercel edge limit.
+// At client concurrency 4 a legit bulk sync peaks well under 6 req/s, so 60/10s
+// never trips a real user but caps a runaway client across serverless instances.
+// Upstash-backed and fails open, so it can never itself cause an outage.
+const burstLimiter = new RateLimiter({ windowMs: 10_000, max: 60, persistent: true });
 
 const presignSchema = z.object({
   filePath: z.string().min(1).max(500),
@@ -49,6 +57,14 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       { error: 'Too many upload requests. Please wait a few minutes and try again.' },
       { status: 429 }
+    );
+  }
+
+  // Burst backstop — distinct Upstash key so it can't collide with the hourly bucket.
+  if (await burstLimiter.isLimited(`${getUserRateLimitKey(user.id)}:burst`)) {
+    return NextResponse.json(
+      { error: 'Too many upload requests. Please wait a few minutes and try again.' },
+      { status: 429, headers: { 'Retry-After': '10' } }
     );
   }
 
@@ -192,6 +208,12 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     console.error('[files/presign] Error:', err);
     captureApiError(err, { route: 'files/presign' });
-    return NextResponse.json({ error: 'Failed to prepare upload' }, { status: 500 });
+    // A transient Storage 5xx (createSignedUploadUrl) maps to 503 + Retry-After
+    // so the client backs off and retries instead of treating it as fatal and
+    // tripping the fail-fast abort. Genuine internal errors stay 500.
+    return upstreamErrorResponse(err, {
+      retryable: 'Upload service is busy. Please retry shortly.',
+      fatal: 'Failed to prepare upload',
+    });
   }
 }

--- a/app/api/share/files/route.ts
+++ b/app/api/share/files/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { getSupabaseServer, getSupabaseServiceRole } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getUserRateLimitKey, getRateLimitKey } from '@/lib/rate-limit';
+import { upstreamErrorResponse } from '@/lib/api/upstream-error';
 
 const SHARED_FILES_BUCKET = 'shared-files';
 const MAX_FILE_SIZE = 200 * 1024 * 1024; // 200 MB per file (ResMed BRP.edf can exceed 100 MB for full SD cards)
@@ -152,10 +153,11 @@ export async function POST(request: NextRequest) {
       if (signError || !signedData) {
         console.error(`[share/files] Failed to create upload URL for ${storagePath}:`, signError?.message);
         Sentry.captureException(signError, { tags: { route: 'share-files-presign' } });
-        return NextResponse.json(
-          { error: 'Could not prepare file upload. Please try again.' },
-          { status: 500 }
-        );
+        // Transient Storage 5xx → 503 + Retry-After; genuine failures stay 500.
+        return upstreamErrorResponse(signError, {
+          retryable: 'Upload service is busy. Please try again shortly.',
+          fatal: 'Could not prepare file upload. Please try again.',
+        });
       }
 
       uploadUrls.push({
@@ -168,10 +170,10 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ uploadUrls }, { status: 200 });
   } catch (err) {
     Sentry.captureException(err, { tags: { route: 'share-files-presign' } });
-    return NextResponse.json(
-      { error: 'Something went wrong. Please try again.' },
-      { status: 500 }
-    );
+    return upstreamErrorResponse(err, {
+      retryable: 'Upload service is busy. Please try again shortly.',
+      fatal: 'Something went wrong. Please try again.',
+    });
   }
 }
 

--- a/lib/api/upstream-error.ts
+++ b/lib/api/upstream-error.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+
+// ============================================================
+// AirwayLab — Upstream error mapping
+// Classifies errors thrown by upstream dependencies (Supabase
+// Storage) into the right HTTP status so clients retry instead
+// of treating a transient outage as a fatal 500.
+// ============================================================
+
+/**
+ * Supabase Storage surfaces failures as `StorageApiError` (carries a numeric
+ * `status` + `__isStorageError`) or `StorageUnknownError` (network failure, no
+ * status). A 5xx from Storage — or a network-level failure — is transient and
+ * upstream, NOT a bug in this service, so it maps to 503 + Retry-After and the
+ * client backs off and retries. Anything else (DB constraint violations, our
+ * own bugs) stays 500.
+ *
+ * Duck-typed on the error shape rather than `instanceof` so it stays correct
+ * across @supabase/storage-js minor versions and bundler boundaries.
+ */
+export interface UpstreamErrorClass {
+  status: 503 | 500;
+  /** Seconds to advise the client to wait before retrying (503 only). */
+  retryAfterSeconds?: number;
+}
+
+const RETRY_AFTER_SECONDS = 5;
+
+export function classifyUpstreamError(err: unknown): UpstreamErrorClass {
+  if (err && typeof err === 'object') {
+    const e = err as {
+      name?: unknown;
+      status?: unknown;
+      statusCode?: unknown;
+      __isStorageError?: unknown;
+    };
+    const isStorage =
+      e.__isStorageError === true ||
+      (typeof e.name === 'string' && e.name.startsWith('Storage'));
+    if (isStorage) {
+      // Network-level / unknown storage failure has no HTTP status — transient.
+      if (e.name === 'StorageUnknownError' || e.name === 'StorageVectorsUnknownError') {
+        return { status: 503, retryAfterSeconds: RETRY_AFTER_SECONDS };
+      }
+      const status =
+        typeof e.status === 'number'
+          ? e.status
+          : typeof e.statusCode === 'string'
+            ? Number(e.statusCode)
+            : NaN;
+      if (Number.isFinite(status) && status >= 500 && status <= 599) {
+        return { status: 503, retryAfterSeconds: RETRY_AFTER_SECONDS };
+      }
+    }
+  }
+  return { status: 500 };
+}
+
+/**
+ * Build the JSON error response for an upstream failure: a transient Storage
+ * 5xx becomes 503 + Retry-After, everything else 500.
+ */
+export function upstreamErrorResponse(
+  err: unknown,
+  messages: { retryable: string; fatal: string }
+): NextResponse {
+  const mapped = classifyUpstreamError(err);
+  if (mapped.status === 503) {
+    return NextResponse.json(
+      { error: messages.retryable },
+      {
+        status: 503,
+        headers: { 'Retry-After': String(mapped.retryAfterSeconds ?? RETRY_AFTER_SECONDS) },
+      }
+    );
+  }
+  return NextResponse.json({ error: messages.fatal }, { status: 500 });
+}

--- a/lib/storage/upload-orchestrator.ts
+++ b/lib/storage/upload-orchestrator.ts
@@ -19,7 +19,10 @@ import { hasCloudSyncConsent } from '@/components/upload/cloud-sync-nudge';
 
 type UploadListener = (state: UploadState) => void;
 
-const CONCURRENCY = 10;
+// Lowered from 10 to 4 after a single user's multi-month backlog at 10-wide
+// overwhelmed Supabase Storage (502/504) and Vercel functions (5xx burst).
+// 4 keeps bulk sync reliable and is the everyday governor at the source.
+const CONCURRENCY = 4;
 const RETRY_DELAY_MS = 2000;
 /** Base delay for rate limit backoff (doubles each time) */
 const RATE_LIMIT_BASE_DELAY_MS = 5000;
@@ -29,13 +32,59 @@ const RATE_LIMIT_MAX_RETRIES = 4;
 const TRANSIENT_MAX_RETRIES = 3;
 /** Abort after this many consecutive failures with the same error */
 const FAIL_FAST_THRESHOLD = 3;
+/** Hard ceiling on total wall-clock spent retrying a single file across all
+ *  backoff attempts. Stops a slow-healing upstream from stalling the whole
+ *  bulk sync on one file. */
+const RETRY_WALL_CAP_MS = 120_000;
+/** Single-wait ceiling so a large Retry-After can't park a file for minutes. */
+const MAX_SINGLE_BACKOFF_MS = 60_000;
+/** HTTP statuses that are transient/upstream and safe to retry with backoff. */
+const TRANSIENT_RETRY_STATUSES = new Set([502, 503, 504, 520]);
 
 /**
  * Check if an error message indicates a transient server error.
  * These are typically CDN/proxy-level failures that resolve on retry.
+ * Message-based fallback used only when no typed HTTP status is available.
  */
 export function isTransientServerError(errorMessage: string): boolean {
   return /\b(502|503|504|520)\b/.test(errorMessage);
+}
+
+/**
+ * Parse a Retry-After header (delta-seconds or HTTP-date) into milliseconds.
+ * Returns undefined when absent or unparseable.
+ */
+export function parseRetryAfterMs(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const when = Date.parse(value);
+  if (!Number.isNaN(when)) return Math.max(0, when - Date.now());
+  return undefined;
+}
+
+/** Read the HTTP status an upload error was tagged with, if any. */
+function errorStatus(err: unknown): number | undefined {
+  return err instanceof Error ? (err as Error & { httpStatus?: number }).httpStatus : undefined;
+}
+
+/** Read the Retry-After (ms) an upload error was tagged with, if any. */
+function errorRetryAfterMs(err: unknown): number | undefined {
+  return err instanceof Error ? (err as Error & { retryAfterMs?: number }).retryAfterMs : undefined;
+}
+
+/**
+ * Whether an upload error is a transient/upstream server failure worth retrying.
+ * Prefers the typed HTTP status the server set (robust); falls back to scanning
+ * the message for a status code only when no status was tagged. Status-based
+ * classification is the structural fix for the regex-over-free-text bug where a
+ * 500-from-Storage slipped past the transient check.
+ */
+function isTransientServerErrorFor(err: unknown): boolean {
+  const status = errorStatus(err);
+  if (status !== undefined) return TRANSIENT_RETRY_STATUSES.has(status);
+  const msg = err instanceof Error ? err.message : String(err);
+  return isTransientServerError(msg);
 }
 
 /**
@@ -531,17 +580,24 @@ class UploadOrchestrator {
       } catch (firstErr) {
         // Rate limit: exponential backoff with multiple retries
         const isRateLimit = firstErr instanceof Error && (firstErr as Error & { isRateLimit?: boolean }).isRateLimit === true;
-        // Transient 5xx (502, 503, 504, 520): same exponential backoff but capped at fewer retries
-        const firstErrMsg = firstErr instanceof Error ? firstErr.message : String(firstErr);
-        const isTransient = !isRateLimit && isTransientServerError(firstErrMsg);
+        // Transient 5xx (502, 503, 504, 520): classify on the typed HTTP status
+        // the server set, not a regex over the message text.
+        const isTransient = !isRateLimit && isTransientServerErrorFor(firstErr);
         if (isRateLimit || isTransient) {
           const maxRetries = isRateLimit ? RATE_LIMIT_MAX_RETRIES : TRANSIENT_MAX_RETRIES;
           const retryLabel = isRateLimit ? 'Rate limited' : 'Transient server error';
+          const retryStart = Date.now();
+          // Honor a server Retry-After when present, else exponential backoff.
+          let nextRetryAfterMs = errorRetryAfterMs(firstErr);
           let uploaded = false;
           for (let attempt = 0; attempt < maxRetries; attempt++) {
-            const delay = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
+            const backoff = RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1000;
+            const delay = Math.min(nextRetryAfterMs ?? backoff, MAX_SINGLE_BACKOFF_MS);
             await new Promise(r => setTimeout(r, delay));
             if (signal.aborted) break;
+            // Stop retrying this file once the total retry budget is spent, so one
+            // slow-healing file can't stall the whole bulk sync.
+            if (Date.now() - retryStart > RETRY_WALL_CAP_MS) break;
             try {
               const ok = await this.uploadSingleFile(file, filePath, fileName, hash, nightDate, signal);
               if (ok) result.uploaded++;
@@ -554,7 +610,7 @@ class UploadOrchestrator {
               const retryErrMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
               const stillRetryable = isRateLimit
                 ? retryErr instanceof Error && (retryErr as Error & { isRateLimit?: boolean }).isRateLimit === true
-                : isTransientServerError(retryErrMsg);
+                : isTransientServerErrorFor(retryErr);
               if (!stillRetryable) {
                 // Different error — record and stop retrying this file
                 result.failed++;
@@ -562,7 +618,8 @@ class UploadOrchestrator {
                 uploaded = true; // prevent double-counting
                 break;
               }
-              // Still retryable — continue backoff
+              // Still retryable — refresh Retry-After for the next backoff iteration
+              nextRetryAfterMs = errorRetryAfterMs(retryErr);
             }
           }
           if (!uploaded) {
@@ -676,6 +733,10 @@ class UploadOrchestrator {
       (error as Error & { isRateLimit?: boolean }).isRateLimit = presignRes.status === 429;
       // Tag validation errors (400) so fail-fast can distinguish them from systemic failures
       (error as Error & { isValidation?: boolean }).isValidation = presignRes.status === 400;
+      // Tag the HTTP status so retry classification keys on it, not a message regex
+      (error as Error & { httpStatus?: number }).httpStatus = presignRes.status;
+      const retryAfterMs = parseRetryAfterMs(presignRes.headers.get('retry-after'));
+      if (retryAfterMs !== undefined) (error as Error & { retryAfterMs?: number }).retryAfterMs = retryAfterMs;
       // Attach parsed response body for Sentry context in reportFailures
       (error as Error & { presignBody?: unknown }).presignBody = { status: presignRes.status, body: err };
       throw error;
@@ -704,7 +765,13 @@ class UploadOrchestrator {
         credentials: 'same-origin',
         body: JSON.stringify({ fileId: presignData.fileId }),
       }).catch(() => { /* best effort cleanup */ });
-      throw new Error(`Upload failed: ${uploadRes.status}`);
+      const uploadErr = new Error(`Upload failed: ${uploadRes.status}`);
+      // Tag the HTTP status + Retry-After so a transient Storage PUT 5xx retries
+      // with backoff instead of being misread as a non-transient failure.
+      (uploadErr as Error & { httpStatus?: number }).httpStatus = uploadRes.status;
+      const putRetryAfterMs = parseRetryAfterMs(uploadRes.headers.get('retry-after'));
+      if (putRetryAfterMs !== undefined) (uploadErr as Error & { retryAfterMs?: number }).retryAfterMs = putRetryAfterMs;
+      throw uploadErr;
     }
 
     // Step 3: Confirm upload — marks the file as upload_confirmed in the DB.


### PR DESCRIPTION
## Why

Vercel alerted on a **5xx spike on `/api/files/presign`** (82 failed / 5 min, 0 baseline) plus a co-firing edge-request / function-invocation / CPU burst, with on-demand spend at 75% of budget.

**Root cause:** a single user's multi-month CPAP backlog uploaded at client **concurrency 10**, each presign ending in a Supabase Storage `createSignedUploadUrl`. The burst overwhelmed shared Storage (502/504 → `StorageApiError` in Sentry) and Vercel functions. Two compounding bugs turned a transient wobble into failed syncs:

1. **presign returned `500` for an upstream Storage 5xx.** The client's transient classifier matches only `502/503/504/520`, so a `500` was treated as non-transient → one flat retry, then it **counted toward the fail-fast threshold** — 3 in a row aborted the *entire* bulk sync.
2. **Retry classification scanned the error message text** for a status code (brittle: the 500-from-Storage slipped past, and a digit run in a filename could false-match).

## What

No clinical surface (`lib/parsers` / `lib/analyzers` untouched). Error-mapping + governors only.

- **New `lib/api/upstream-error.ts`** — classify Supabase Storage failures (duck-typed on `__isStorageError` / numeric `status`, version-tolerant across `@supabase/storage-js`): 5xx / network → **503 + `Retry-After`**, everything else stays **500**.
- **`presign`, `share/files`, `contribute-oximetry-trace`** — return `503 + Retry-After` for a transient Storage 5xx instead of a fatal 500. `contribute-waveforms` already did this and is **left untouched** (it's the reference).
- **`upload-orchestrator`**
  - `CONCURRENCY` **10 → 4** — the everyday governor at the source (~60% peak reduction).
  - Classify retries on the **typed HTTP status** the server set, not a message regex (structural fix for bug 2). `isTransientServerError(message)` kept as a fallback + for existing tests.
  - **Honor `Retry-After`** in backoff; cap total per-file retry **wall-time at 120s**.
- **`presign` burst backstop** — short-window per-user limiter (60 / 10s, distinct Upstash key, **fails open**) behind the Vercel edge limit. Defence-in-depth, sized so legit syncs at concurrency 4 never trip it.
- Tests for `parseRetryAfterMs`.

## Local verification

`tsc --noEmit` clean · `eslint` clean · mutation-guard clean · `vitest run __tests__/upload-orchestrator.test.ts` **39/39 pass**.

## Post-deploy (real-path, per verify-real-path-post-deploy)

Real multi-night bulk upload via the dashboard uploader; watch presign 5xx + `StorageApiError` drop, a forced Storage wobble no longer abort the sync, and on-demand spend flatten. Edge-side spend-pause cap + `/api/files/*` rate-limit handled in parallel in the Vercel dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)