### PR TITLE
fix(webhook): handle both legacy and new Resend webhook payload formats

### DIFF
--- a/__tests__/resend-webhook.test.ts
+++ b/__tests__/resend-webhook.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests the Resend webhook handler's payload validation.
+ *
+ * Covers both the legacy format (data.email_id) and the newer Resend API
+ * format (data.id) — JAVASCRIPT-NEXTJS-86 was caused by the new format
+ * failing validation.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// ── Mocks (must precede route import) ──────────────────────────────
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}))
+
+const mockFrom = vi.fn()
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseServiceRole: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  })),
+}))
+
+vi.mock('@/lib/email/sequences', () => ({
+  cancelAllPending: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/discord-webhook', () => ({
+  sendAlert: vi.fn().mockResolvedValue(undefined),
+  formatEmailAlertEmbed: vi.fn().mockReturnValue({}),
+}))
+
+vi.mock('@/lib/env', () => ({
+  serverEnv: {
+    RESEND_WEBHOOK_SECRET: 'test-secret',
+  },
+}))
+
+import { POST } from '@/app/api/webhooks/resend/route'
+import * as Sentry from '@sentry/nextjs'
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest(
+    new URL('http://localhost/api/webhooks/resend?secret=test-secret'),
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    }
+  )
+}
+
+function supabaseChain() {
+  return {
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    select: vi.fn().mockResolvedValue({ data: [], error: null }),
+  }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe('Resend webhook payload validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFrom.mockReturnValue(supabaseChain())
+  })
+
+  it('accepts legacy format with data.email_id', async () => {
+    const res = await POST(makeRequest({
+      type: 'email.delivered',
+      created_at: '2026-06-08T15:00:00.000Z',
+      data: {
+        email_id: 'legacy-id-123',
+        from: 'noreply@mail.airwaylab.app',
+        to: ['user@example.com'],
+        subject: 'Test',
+      },
+    }))
+    expect(res.status).toBe(200)
+    expect(Sentry.captureMessage).not.toHaveBeenCalledWith(
+      'Resend webhook: invalid payload',
+      expect.anything()
+    )
+  })
+
+  it('accepts new format with data.id (JAVASCRIPT-NEXTJS-86 regression)', async () => {
+    const res = await POST(makeRequest({
+      type: 'email.delivered',
+      created_at: '2026-06-08T17:00:00.000Z',
+      data: {
+        id: 'new-format-id-456',
+        object: 'email',
+        from: 'noreply@mail.airwaylab.app',
+        to: ['user@example.com'],
+        subject: 'Test',
+      },
+    }))
+    expect(res.status).toBe(200)
+    expect(Sentry.captureMessage).not.toHaveBeenCalledWith(
+      'Resend webhook: invalid payload',
+      expect.anything()
+    )
+  })
+
+  it('prefers email_id when both fields are present', async () => {
+    const chain = supabaseChain()
+    mockFrom.mockReturnValue(chain)
+
+    await POST(makeRequest({
+      type: 'email.delivered',
+      created_at: '2026-06-08T17:00:00.000Z',
+      data: {
+        email_id: 'legacy-takes-precedence',
+        id: 'new-format-id',
+        from: 'noreply@mail.airwaylab.app',
+        to: ['user@example.com'],
+      },
+    }))
+
+    // The eq() call on the Supabase chain should use the legacy email_id value
+    expect(chain.eq).toHaveBeenCalledWith('resend_id', 'legacy-takes-precedence')
+  })
+
+  it('rejects payload missing both email_id and id with 400', async () => {
+    const res = await POST(makeRequest({
+      type: 'email.delivered',
+      created_at: '2026-06-08T15:00:00.000Z',
+      data: {
+        from: 'noreply@mail.airwaylab.app',
+        to: ['user@example.com'],
+      },
+    }))
+    expect(res.status).toBe(400)
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'Resend webhook: invalid payload',
+      expect.anything()
+    )
+  })
+
+  it('rejects payload missing data entirely with 400', async () => {
+    const res = await POST(makeRequest({
+      type: 'email.delivered',
+      created_at: '2026-06-08T15:00:00.000Z',
+    }))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects payload missing created_at with 400', async () => {
+    const res = await POST(makeRequest({
+      type: 'email.delivered',
+      data: { email_id: 'some-id' },
+    }))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 401 for missing secret', async () => {
+    const req = new NextRequest(
+      new URL('http://localhost/api/webhooks/resend'),
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          type: 'email.delivered',
+          created_at: '2026-06-08T15:00:00.000Z',
+          data: { email_id: 'x' },
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      }
+    )
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('uses data.id as resend_id when looking up email_sequences', async () => {
+    const chain = supabaseChain()
+    mockFrom.mockReturnValue(chain)
+
+    await POST(makeRequest({
+      type: 'email.delivered',
+      created_at: '2026-06-08T17:00:00.000Z',
+      data: {
+        id: 'new-format-lookup-id',
+        from: 'noreply@mail.airwaylab.app',
+        to: ['user@example.com'],
+      },
+    }))
+
+    expect(chain.eq).toHaveBeenCalledWith('resend_id', 'new-format-lookup-id')
+  })
+})

--- a/app/api/webhooks/resend/route.ts
+++ b/app/api/webhooks/resend/route.ts
@@ -21,15 +21,25 @@ import { sendAlert, formatEmailAlertEmbed } from '@/lib/discord-webhook'
  * (opened_at is set once, not updated on re-opens).
  */
 
-const ResendEventSchema = z.object({
-  type: z.string(), // Accept any event type -- future-proof
-  created_at: z.string(),
-  data: z
-    .object({
-      email_id: z.string(),
-    })
-    .passthrough(),
-})
+const ResendEventSchema = z
+  .object({
+    type: z.string(), // Accept any event type -- future-proof
+    created_at: z.string(),
+    // Resend legacy format: data.email_id; newer API format: data.id
+    data: z
+      .object({
+        email_id: z.string().optional(),
+        id: z.string().optional(),
+      })
+      .passthrough()
+      .transform(d => ({
+        ...d,
+        emailId: d.email_id ?? d.id ?? '',
+      }))
+      .refine(d => d.emailId.length > 0, {
+        message: 'Missing email identifier (expected data.email_id or data.id)',
+      }),
+  })
 
 // Map Resend event types to timestamp columns (shared by both tables)
 const EVENT_COLUMN_MAP: Record<string, string> = {
@@ -85,7 +95,7 @@ export async function POST(request: NextRequest) {
       const { data: seqRow } = await supabase
         .from('email_sequences')
         .select('user_id')
-        .eq('resend_id', data.email_id)
+        .eq('resend_id', data.emailId)
         .limit(1)
         .single()
 
@@ -97,7 +107,7 @@ export async function POST(request: NextRequest) {
           await supabase
             .from('email_sequences')
             .update({ complained_at: new Date().toISOString() })
-            .eq('resend_id', data.email_id)
+            .eq('resend_id', data.emailId)
 
           await supabase
             .from('profiles')
@@ -108,15 +118,15 @@ export async function POST(request: NextRequest) {
         // Discord #ops-alerts (fire-and-forget)
         void sendAlert('ops', '', [formatEmailAlertEmbed({
           event: type === 'email.complained' ? 'complaint' : 'bounce',
-          email: data.email_id,
-          resendId: data.email_id,
+          email: data.emailId,
+          resendId: data.emailId,
           userId: seqRow.user_id,
         })])
 
         console.error(
           `[resend-webhook] ${type} for user ${seqRow.user_id}, cancelled pending emails`
         )
-        Sentry.captureMessage(`Email ${type}: ${data.email_id}`, {
+        Sentry.captureMessage(`Email ${type}: ${data.emailId}`, {
           level: 'warning',
           tags: { route: 'resend-webhook', event_type: type },
           extra: { userId: seqRow.user_id },
@@ -128,7 +138,7 @@ export async function POST(request: NextRequest) {
         await supabase
           .from('email_log')
           .update({ bounced_at: new Date().toISOString() })
-          .eq('resend_id', data.email_id)
+          .eq('resend_id', data.emailId)
       }
 
       return NextResponse.json({ received: true, tracked: true })
@@ -146,7 +156,7 @@ export async function POST(request: NextRequest) {
     const { data: seqResult } = await supabase
       .from('email_sequences')
       .update({ [column]: now })
-      .eq('resend_id', data.email_id)
+      .eq('resend_id', data.emailId)
       .is(column, null)
       .select('id')
 
@@ -155,12 +165,12 @@ export async function POST(request: NextRequest) {
       const { error } = await supabase
         .from('email_log')
         .update({ [column]: now })
-        .eq('resend_id', data.email_id)
+        .eq('resend_id', data.emailId)
         .is(column, null)
 
       if (error) {
         console.error(
-          `[resend-webhook] Failed to update ${column} for ${data.email_id}:`,
+          `[resend-webhook] Failed to update ${column} for ${data.emailId}:`,
           error.message
         )
         Sentry.captureException(error, {


### PR DESCRIPTION
## Summary

Resend's newer API sends `data.id` instead of `data.email_id`. The Zod schema now accepts either field and normalises to a single `emailId` for downstream use.

- Fixes Sentry error JAVASCRIPT-NEXTJS-86
- 8 unit tests covering both formats and error cases

## Test plan

- [ ] All resend-webhook tests pass
- [ ] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)