### PR TITLE
fix(upload): suppress AbortError false-positives and fix consent-fix classifier

### DIFF
--- a/__tests__/upload-orchestrator.test.ts
+++ b/__tests__/upload-orchestrator.test.ts
@@ -173,8 +173,11 @@ describe('classifyUploadError', () => {
     expect(classifyUploadError('Network timeout')).toBe('network');
   });
 
+  it('classifies consent-fix POST failures as consent', () => {
+    expect(classifyUploadError('Could not enable cloud storage. Please try again or check Account Settings.')).toBe('consent');
+  });
+
   it('returns unknown for unrecognised errors', () => {
-    expect(classifyUploadError('Could not enable cloud storage. Please try again or check Account Settings.')).toBe('unknown');
     expect(classifyUploadError('Unexpected error')).toBe('unknown');
     expect(classifyUploadError('')).toBe('unknown');
   });

--- a/lib/storage/upload-orchestrator.ts
+++ b/lib/storage/upload-orchestrator.ts
@@ -101,7 +101,7 @@ export type UploadErrorCategory = 'auth' | 'consent' | 'hash_worker' | 'network'
  */
 export function classifyUploadError(error: string): UploadErrorCategory {
   if (/sign in again/i.test(error)) return 'auth';
-  if (/not enabled|not available/i.test(error)) return 'consent';
+  if (/not enabled|not available|enable cloud storage/i.test(error)) return 'consent';
   if (/hash (failed|worker)/i.test(error)) return 'hash_worker';
   if (/failed to fetch|networkerror|network timeout/i.test(error)) return 'network';
   return 'unknown';
@@ -322,7 +322,10 @@ class UploadOrchestrator {
     } catch (err) {
       this.releasePageExit();
       const error = err instanceof Error ? err.message : String(err);
-      if (error !== 'Cancelled') {
+      // Skip Sentry for user-initiated cancels: explicit 'Cancelled' throws and
+      // AbortErrors raised by fetch when the AbortController signal fires.
+      const isCancelled = error === 'Cancelled' || (err instanceof Error && err.name === 'AbortError');
+      if (!isCancelled) {
         const errorCategory = classifyUploadError(error);
         console.error('[upload-orchestrator] Upload failed:', error);
         Sentry.captureMessage('cloud_upload_failed', {


### PR DESCRIPTION
## Summary

Two defects in the Sentry `cloud_upload_failed` reporting path:

1. AbortErrors from user-cancelled uploads were reported to Sentry as real failures (checked `!== 'Cancelled'` string but browser throws `AbortError` with a different message)
2. `'Could not enable cloud storage.'` fell through to `'unknown'` classifier — added `'enable cloud storage'` to the consent regex

## Test plan

- [ ] Upload orchestrator tests pass
- [ ] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)