### PR TITLE
fix(waveform): prevent OOM when orchestrator falls back to all BRP files (AIR-2631)

### DIFF
--- a/__tests__/waveform-date-filter.test.ts
+++ b/__tests__/waveform-date-filter.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { isEdfRelevantForNight, localDateStr } from '@/lib/waveform-utils';
+
+describe('localDateStr', () => {
+  it('formats a Date as YYYY-MM-DD in local time', () => {
+    expect(localDateStr(new Date(2024, 9, 14, 22, 0))).toBe('2024-10-14');
+    expect(localDateStr(new Date(2024, 0, 1, 0, 0))).toBe('2024-01-01');
+  });
+});
+
+describe('isEdfRelevantForNight — OOM guard for large SD cards (AIR-2631)', () => {
+  it('accepts a recording that starts on the target date', () => {
+    // Session begins 22:00 on Oct 14 → belongs to night of Oct 14
+    expect(isEdfRelevantForNight(new Date(2024, 9, 14, 22, 0), '2024-10-14')).toBe(true);
+  });
+
+  it('accepts an early-morning recording on the next calendar day', () => {
+    // Session starts 02:00 on Oct 15 → grouped into night of Oct 14 by night grouper
+    expect(isEdfRelevantForNight(new Date(2024, 9, 15, 2, 0), '2024-10-14')).toBe(true);
+  });
+
+  it('accepts a late-morning recording on the next calendar day', () => {
+    // Session starts 11:59 on Oct 15 — still within the +1 day window
+    expect(isEdfRelevantForNight(new Date(2024, 9, 15, 11, 59), '2024-10-14')).toBe(true);
+  });
+
+  it('rejects a recording from the previous day', () => {
+    // Session starts 22:00 on Oct 13 → night of Oct 13, not Oct 14
+    expect(isEdfRelevantForNight(new Date(2024, 9, 13, 22, 0), '2024-10-14')).toBe(false);
+  });
+
+  it('rejects a recording from two days later', () => {
+    expect(isEdfRelevantForNight(new Date(2024, 9, 16, 0, 0), '2024-10-14')).toBe(false);
+  });
+
+  it('handles month-end overflow (Dec 31 → Jan 1)', () => {
+    // Session starts 02:00 Jan 1 2025 → belongs to night of Dec 31 2024
+    expect(isEdfRelevantForNight(new Date(2025, 0, 1, 2, 0), '2024-12-31')).toBe(true);
+    // Session starts 22:00 Dec 30 → belongs to Dec 30, not Dec 31
+    expect(isEdfRelevantForNight(new Date(2024, 11, 30, 22, 0), '2024-12-31')).toBe(false);
+  });
+
+  it('handles year-end overflow (Dec 31 target)', () => {
+    expect(isEdfRelevantForNight(new Date(2024, 11, 31, 22, 0), '2024-12-31')).toBe(true);
+  });
+
+  it('rejects an invalid recording date gracefully', () => {
+    // Invalid Date → localDateStr returns "NaN-aN-aN" → no match → false
+    expect(isEdfRelevantForNight(new Date('not-a-date'), '2024-10-14')).toBe(false);
+  });
+});

--- a/lib/waveform-orchestrator.ts
+++ b/lib/waveform-orchestrator.ts
@@ -302,6 +302,18 @@ class WaveformOrchestrator {
       this.worker.onerror = (err) => {
         settle();
         this.terminate();
+        // Capture ErrorEvent details before they are lost — onerror fires for
+        // uncaught worker exceptions (including OOM kills) and often carries an
+        // empty message. The captureMessage gives future triage filename/lineno.
+        Sentry.captureMessage('Waveform worker crashed', {
+          level: 'error',
+          extra: {
+            workerErrorMessage: err.message,
+            filename: err.filename,
+            lineno: err.lineno,
+            colno: err.colno,
+          },
+        });
         reject(new Error(err.message || 'Waveform worker failed'));
       };
 

--- a/lib/waveform-utils.ts
+++ b/lib/waveform-utils.ts
@@ -952,3 +952,29 @@ export function detectMShapeInWorker(inspFlow: Float32Array, qPeak: number): boo
 
   return false;
 }
+
+// ── Night-date helpers used by the waveform worker ───────────
+
+/** YYYY-MM-DD in local time (mirrors night-grouper.ts localDateStr, not exported there). */
+export function localDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/**
+ * Whether an EDF file's recording date falls within the calendar window that
+ * could contribute to the given target night.
+ *
+ * The night grouper assigns sessions starting before noon on day+1 to the
+ * target night (they belong to the early-morning portion of the same sleep
+ * period). Accepting both calendar days ensures we don't discard those files.
+ *
+ * Used in the waveform worker to skip EDF files from unrelated nights when
+ * the orchestrator falls back to sending all BRP files (OOM guard).
+ */
+export function isEdfRelevantForNight(recordingDate: Date, targetDate: string): boolean {
+  const dateStr = localDateStr(recordingDate);
+  if (dateStr === targetDate) return true;
+  const [tyStr, tmStr, tdStr] = targetDate.split('-');
+  const nextDay = new Date(parseInt(tyStr!, 10), parseInt(tmStr!, 10) - 1, parseInt(tdStr!, 10) + 1);
+  return dateStr === localDateStr(nextDay);
+}

--- a/lib/waveform-worker.ts
+++ b/lib/waveform-worker.ts
@@ -13,6 +13,7 @@ import {
   computeRespiratoryRate,
   detectMShapeInWorker,
   buildSessionBoundaries,
+  isEdfRelevantForNight,
 } from './waveform-utils';
 import type {
   WaveformWorkerMessage,
@@ -82,13 +83,18 @@ function extractWaveform(
 
   const brpFiles = filterBRPFiles(fileList);
 
-  // Parse all BRP files
+  // Parse BRP files — skip those from unrelated nights to prevent OOM.
+  // When the orchestrator's date-path filter finds no matches it falls back to
+  // sending all BRP files; for users with years of data that can be gigabytes.
+  // isEdfRelevantForNight limits parsing to the target date + next calendar day
+  // (the next day covers early-morning sessions grouped into the target night).
   const parsedEdfs: EDFFile[] = [];
   for (const brp of brpFiles) {
     const fileData = files.find((f) => f.path === brp.path);
     if (!fileData) continue;
     try {
       const edf = parseEDF(fileData.buffer, fileData.path);
+      if (!isEdfRelevantForNight(edf.recordingDate, targetDate)) continue;
       parsedEdfs.push(edf);
     } catch {
       // Skip unparseable files


### PR DESCRIPTION
## Summary

Fixes Sentry error JAVASCRIPT-NEXTJS-7V (AIR-2631): waveform worker silently killed by OOM when the DATALOG/{date} path filter finds no matches.

- Add `isEdfRelevantForNight()` to `waveform-utils`: accepts target date + next calendar day (early-morning sessions)
- Worker filters parsed EDFs by recording date before pushing to `parsedEdfs`, bounding memory to at most 2 calendar days of data
- Improve `onerror` handler: capture `ErrorEvent` filename/lineno to Sentry before lost in the generic rejection

## Test plan

- [ ] Waveform date filter tests pass (`__tests__/waveform-date-filter.test.ts`)
- [ ] TypeScript clean
- [ ] Verify in browser: upload SD card with flat folder structure (no DATALOG subdirs) — analysis should complete without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)