### PR TITLE
content: add 301 redirects for post-merge blog slugs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,6 +36,22 @@ const nextConfig = {
         destination: '/blog/understanding-flow-limitation',
         permanent: true,
       },
+      // Wave 2 duplicate-slug 301s (AIR-2695, post AIR-1754 content merge 2026-06-04)
+      {
+        source: '/blog/cpap-leak-rate-meaning',
+        destination: '/blog/cpap-leak-rate-explained',
+        permanent: true,
+      },
+      {
+        source: '/blog/oscar-alternative',
+        destination: '/blog/oscar-alternatives-web-cpap-2026',
+        permanent: true,
+      },
+      {
+        source: '/blog/how-to-export-understand-cpap-data',
+        destination: '/blog/how-to-export-and-understand-your-cpap-data',
+        permanent: true,
+      },
     ];
   },
 


### PR DESCRIPTION
## Summary

- Adds three permanent (301) redirects for loser blog slugs after [AIR-1754](https://github.com/airwaylab-app/airwaylab/pull/903) content merge went live on 2026-06-04
- Consolidates link equity to canonical winner pages for SEO

| Source (loser) | Destination (winner) |
|---|---|
| `/blog/cpap-leak-rate-meaning` | `/blog/cpap-leak-rate-explained` |
| `/blog/oscar-alternative` | `/blog/oscar-alternatives-web-cpap-2026` |
| `/blog/how-to-export-understand-cpap-data` | `/blog/how-to-export-and-understand-your-cpap-data` |

## Test plan

- [x] `npx tsc --noEmit` passes clean
- [x] `npm run lint` passes clean
- [x] `npm test` — 2792 tests pass across 187 test files
- [ ] Verify 301 + correct `Location` header in local dev for each slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)