### PR TITLE
fix(persistence): handle NoModificationAllowedError from IDB filesystem (AIR-2661)

### DIFF
--- a/__tests__/persistence.test.ts
+++ b/__tests__/persistence.test.ts
@@ -11,7 +11,14 @@ vi.mock('@sentry/nextjs', () => ({
   captureException: vi.fn(),
 }));
 
+vi.mock('@/lib/summary-idb', () => ({
+  saveSummaryRecord: vi.fn().mockResolvedValue(undefined),
+  readSummaryRecord: vi.fn().mockResolvedValue(null),
+  clearSummaryRecord: vi.fn().mockResolvedValue(undefined),
+}));
+
 import * as Sentry from '@sentry/nextjs';
+import * as summaryIdb from '@/lib/summary-idb';
 
 // Mock localStorage
 const storage = new Map<string, string>();
@@ -294,6 +301,55 @@ describe('persistence', () => {
         (c) => c[0] === 'Persistence: total failure — cannot save any nights'
       );
       expect(totalFailureCalls).toHaveLength(0);
+    });
+
+    describe('NoModificationAllowedError (JAVASCRIPT-NEXTJS-88)', () => {
+      afterEach(() => {
+        vi.mocked(summaryIdb.saveSummaryRecord).mockResolvedValue(undefined);
+        // Remove the IDB stub so other tests keep idbAvailable() === false
+        (globalThis as Record<string, unknown>).indexedDB = undefined;
+        vi.clearAllMocks();
+      });
+
+      it('falls back to localStorage and returns a user-visible reason when IDB filesystem is read-only', async () => {
+        // Simulate idbAvailable() returning true by stubbing indexedDB
+        (globalThis as Record<string, unknown>).indexedDB = { open: vi.fn() };
+        vi.mocked(summaryIdb.saveSummaryRecord).mockRejectedValueOnce(
+          new DOMException('filesystem read-only', 'NoModificationAllowedError'),
+        );
+
+        const result = await persistResults(SAMPLE_NIGHTS, null);
+
+        // localStorage fallback should succeed
+        expect(result.saved).toBe(true);
+        // User should always get a reason so they know storage is degraded
+        expect(result.reason).toBeDefined();
+        expect(result.reason).toMatch(/restricted state|site data/i);
+        // Should NOT fire captureException (it's a browser state issue, not a code bug)
+        expect(Sentry.captureException).not.toHaveBeenCalled();
+        // Should fire captureMessage at warning level
+        expect(Sentry.captureMessage).toHaveBeenCalledWith(
+          expect.stringContaining('NoModificationAllowedError'),
+          expect.objectContaining({ level: 'warning' }),
+        );
+      });
+
+      it('preserves existing reason from localStorage when localStorage also fails during read-only IDB', async () => {
+        (globalThis as Record<string, unknown>).indexedDB = { open: vi.fn() };
+        vi.mocked(summaryIdb.saveSummaryRecord).mockRejectedValueOnce(
+          new DOMException('filesystem read-only', 'NoModificationAllowedError'),
+        );
+        const originalSetItem = localStorageMock.setItem;
+        (localStorageMock as { setItem: typeof localStorageMock.setItem }).setItem = vi.fn(() => {
+          throw new DOMException('quota exceeded', 'QuotaExceededError');
+        });
+
+        const result = await persistResults(SAMPLE_NIGHTS, null);
+
+        expect(result.saved).toBe(false);
+        expect(result.reason).toBeDefined();
+        (localStorageMock as { setItem: typeof localStorageMock.setItem }).setItem = originalSetItem;
+      });
     });
 
     it('strips _pldTrace dynamically attached by orchestrator', async () => {

--- a/lib/idb-core.ts
+++ b/lib/idb-core.ts
@@ -65,6 +65,16 @@ export function isQuotaError(err: unknown): boolean {
   );
 }
 
+/**
+ * True when the browser rejects an IDB write because the underlying filesystem
+ * is read-only or locked (e.g. corrupted Chrome profile, Chrome 149 regression).
+ * This is a browser/OS-level state issue, not a code bug — callers should surface
+ * a user-friendly message rather than reporting it as an unexpected exception.
+ */
+export function isStorageReadOnlyError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'NoModificationAllowedError';
+}
+
 // ── Single memoized connection ──────────────────────────────────────
 // One connection for the whole tab. We never close it per-op (I2).
 // If a newer-version connection is opened elsewhere, onversionchange

--- a/lib/persistence.ts
+++ b/lib/persistence.ts
@@ -6,7 +6,7 @@
 import * as Sentry from '@sentry/nextjs';
 import type { NightResult } from './types';
 import { ENGINE_VERSION, OXIMETRY_ENGINE_VERSION } from './engine-version';
-import { isQuotaError } from './idb-core';
+import { isQuotaError, isStorageReadOnlyError } from './idb-core';
 import { saveSummaryRecord, readSummaryRecord, clearSummaryRecord } from './summary-idb';
 
 const STORAGE_KEY = 'airwaylab_results';
@@ -158,7 +158,22 @@ export async function persistResults(
       }
       return { saved: true, nightsSaved: nights.length, nightsDropped: 0 };
     } catch (err) {
-      if (!isQuotaError(err)) {
+      if (isStorageReadOnlyError(err)) {
+        // Browser filesystem is read-only (corrupted Chrome profile, Chrome IDB regression).
+        // This is a browser/OS state issue — log as a warning, not an exception.
+        Sentry.captureMessage('IDB write blocked: storage read-only (NoModificationAllowedError)', {
+          level: 'warning',
+          extra: { context: 'persistResults:idb' },
+        });
+        // Fall back to localStorage and always surface a reason so the user knows
+        // storage is degraded even if the localStorage write succeeds.
+        const lsResult = persistToLocalStorage(nights, therapyChangeDate);
+        return {
+          ...lsResult,
+          reason: lsResult.reason ??
+            'Browser storage is in a restricted state. Your results are available for this session but may not persist after closing the tab. Try restarting your browser or clearing site data for airwaylab.app.',
+        };
+      } else if (!isQuotaError(err)) {
         Sentry.captureException(err, { extra: { context: 'persistResults:idb', totalNights: nights.length } });
       }
       // Fall through to the localStorage path.


### PR DESCRIPTION
## Summary

Chrome throws `NoModificationAllowedError` when the filesystem backing IndexedDB is read-only (corrupted profile or Chrome 149 regression). Previously this was sent to Sentry as a captured exception and silently succeeded without a user-visible message if the localStorage fallback worked.

**Changes:**
- `lib/idb-core.ts` — classify `NoModificationAllowedError` as a storage-unavailable signal
- `lib/persistence.ts` — log at warning level in Sentry (not as exception); always surface a reason to the user even when localStorage fallback succeeds
- `__tests__/persistence.test.ts` — assert the correct Sentry level and user-visible message

Fixes: [AIR-2661](/AIR/issues/AIR-2661)

## Pre-merge checklist
- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] No regressions in persistence/IDB flow