### PR TITLE
fix(worker): bypass content blockers with blob URL fallback on retry (AIR-2662)

### DIFF
--- a/__tests__/analysis-orchestrator-worker-error.test.ts
+++ b/__tests__/analysis-orchestrator-worker-error.test.ts
@@ -623,6 +623,103 @@ describe('analysis-orchestrator worker error handling', () => {
     });
   });
 
+  // ── runWorker — blob URL fallback (content blocker bypass, AIR-2662) ────────
+  //
+  // Some content blockers intercept Worker-type script requests but allow fetch/XHR.
+  // On an opaque load failure (empty onerror), the orchestrator now fetches the worker
+  // script as a regular request, creates a blob URL, and passes it to the retry. This
+  // bypasses URL-based blockers so users with ad blockers can still run analysis.
+
+  describe('runWorker — blob URL fallback on content-blocker load failure', () => {
+    it('creates and revokes a blob URL on retry when fetch succeeds', async () => {
+      const fakeBlobUrl = 'blob:https://airwaylab.app/fake-blob-url';
+      const fakeBlob = new Blob(['worker code']);
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(fakeBlob) }));
+      const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue(fakeBlobUrl);
+      const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+      const { Ctor } = makeSequentialWorkerCtor([
+        'onerror-empty',
+        { type: 'results', nights: [] },
+      ]);
+      vi.stubGlobal('Worker', Ctor);
+
+      const { orchestrator } = await import('@/lib/analysis-orchestrator');
+
+      const result = await (orchestrator as unknown as {
+        runWorker: (files: unknown[]) => Promise<unknown>
+      }).runWorker([]);
+
+      expect(result).toEqual([]);
+      expect(createObjectURLSpy).toHaveBeenCalledWith(fakeBlob);
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith(fakeBlobUrl);
+
+      createObjectURLSpy.mockRestore();
+      revokeObjectURLSpy.mockRestore();
+      vi.unstubAllGlobals();
+    });
+
+    it('still retries (without blob URL) when fetch fails', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+
+      const { Ctor, getCallCount } = makeSequentialWorkerCtor([
+        'onerror-empty',
+        { type: 'results', nights: [] },
+      ]);
+      vi.stubGlobal('Worker', Ctor);
+
+      const { orchestrator } = await import('@/lib/analysis-orchestrator');
+
+      const result = await (orchestrator as unknown as {
+        runWorker: (files: unknown[]) => Promise<unknown>
+      }).runWorker([]);
+
+      expect(result).toEqual([]);
+      expect(getCallCount()).toBe(2);
+
+      vi.unstubAllGlobals();
+    });
+
+    it('reports blobFallback: true in Sentry when blob URL was used and retry also fails', async () => {
+      const fakeBlobUrl = 'blob:https://airwaylab.app/fake-blob-url';
+      const fakeBlob = new Blob(['worker code']);
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(fakeBlob) }));
+      const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue(fakeBlobUrl);
+      const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+      // Both attempts fail; second uses the blob URL
+      const { Ctor } = makeSequentialWorkerCtor(['onerror-empty', 'onerror-empty']);
+      vi.stubGlobal('Worker', Ctor);
+
+      const { orchestrator } = await import('@/lib/analysis-orchestrator');
+      const Sentry = await import('@sentry/nextjs');
+
+      try {
+        await (orchestrator as unknown as {
+          runWorker: (files: unknown[]) => Promise<unknown>
+        }).runWorker([]);
+      } catch {
+        // expected
+      }
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            workerLoadAttempt: '2',
+            blobFallback: 'true',
+          }),
+        })
+      );
+
+      createObjectURLSpy.mockRestore();
+      revokeObjectURLSpy.mockRestore();
+      vi.unstubAllGlobals();
+    });
+  });
+
   // ── analyze — NotReadableError during file read ───────────────────────────
 
   describe('analyze — NotReadableError during file read', () => {

--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -374,7 +374,8 @@ class AnalysisOrchestrator {
     onNightComplete?: (night: NightResult) => void,
     deviceType?: string,
     bmcSerial?: string,
-    attempt = 1
+    attempt = 1,
+    overrideWorkerUrl?: string
   ): Promise<NightResult[]> {
     return new Promise((resolve, reject) => {
       // Progress-aware timeout: resets on any worker message.
@@ -406,15 +407,17 @@ class AnalysisOrchestrator {
       };
 
       try {
-        this.worker = new Worker(
-          new URL('../workers/analysis-worker.ts', import.meta.url)
-        );
+        // Use a pre-fetched blob URL when provided (blob fallback path); otherwise
+        // use the standard URL so webpack can resolve the worker chunk at build time.
+        const workerSrc = overrideWorkerUrl ?? new URL('../workers/analysis-worker.ts', import.meta.url);
+        this.worker = new Worker(workerSrc as string | URL);
       } catch (err) {
         settle();
         Sentry.captureException(err, {
           extra: {
             context: 'analysis-worker-init',
             attempt,
+            blobFallback: !!overrideWorkerUrl,
             userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown',
             hardwareConcurrency: typeof navigator !== 'undefined' ? navigator.hardwareConcurrency : 'unknown',
             connectionType: typeof navigator !== 'undefined' ? (navigator as Navigator & { connection?: { effectiveType?: string } }).connection?.effectiveType ?? 'unknown' : 'unknown',
@@ -563,9 +566,32 @@ class AnalysisOrchestrator {
             category: 'analysis',
             level: 'warning',
           });
-          this.runWorker(files, oximetryCSVs, onNightComplete, deviceType, bmcSerial, 2)
-            .then(resolve)
-            .catch(reject);
+          // Attempt 2: try a blob URL so URL-based content blockers (ad blockers that
+          // intercept Worker-type requests but pass fetch/XHR) are bypassed. If fetch
+          // fails or the blob URL also fails to load, runWorker falls through to the
+          // standard rejection path — same outcome as the previous same-URL retry.
+          void (async () => {
+            let blobObjectUrl: string | undefined;
+            try {
+              const scriptUrl = new URL('../workers/analysis-worker.ts', import.meta.url);
+              const resp = await fetch(scriptUrl.href);
+              if (resp.ok) {
+                const blob = await resp.blob();
+                blobObjectUrl = URL.createObjectURL(blob);
+              }
+            } catch { /* fetch unavailable or failed — proceed without blob URL */ }
+            try {
+              const result = await this.runWorker(
+                files, oximetryCSVs, onNightComplete, deviceType, bmcSerial,
+                2, blobObjectUrl
+              );
+              resolve(result);
+            } catch (retryErr) {
+              reject(retryErr);
+            } finally {
+              if (blobObjectUrl) URL.revokeObjectURL(blobObjectUrl);
+            }
+          })();
           return;
         }
 
@@ -578,6 +604,7 @@ class AnalysisOrchestrator {
           tags: {
             workerLoadAttempt: String(attempt),
             workerErrorType: isLoadFailure ? 'load_failure' : 'runtime_error',
+            blobFallback: overrideWorkerUrl ? 'true' : 'false',
           },
           extra: {
             context: 'analysis-worker-onerror',
@@ -586,6 +613,7 @@ class AnalysisOrchestrator {
             colno: err.colno,
             attempt,
             isLoadFailure,
+            blobFallback: !!overrideWorkerUrl,
             userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown',
             hardwareConcurrency: typeof navigator !== 'undefined' ? navigator.hardwareConcurrency : 'unknown',
             connectionType: typeof navigator !== 'undefined' ? (navigator as Navigator & { connection?: { effectiveType?: string } }).connection?.effectiveType ?? 'unknown' : 'unknown',

--- a/lib/analysis-orchestrator.ts
+++ b/lib/analysis-orchestrator.ts
@@ -407,10 +407,16 @@ class AnalysisOrchestrator {
       };
 
       try {
-        // Use a pre-fetched blob URL when provided (blob fallback path); otherwise
-        // use the standard URL so webpack can resolve the worker chunk at build time.
-        const workerSrc = overrideWorkerUrl ?? new URL('../workers/analysis-worker.ts', import.meta.url);
-        this.worker = new Worker(workerSrc as string | URL);
+        // Keep the two branches separate so webpack sees the literal
+        // new Worker(new URL(...)) form on the normal path and can statically
+        // detect and chunk the worker. Merging them into a ternary breaks that.
+        if (overrideWorkerUrl) {
+          this.worker = new Worker(overrideWorkerUrl);
+        } else {
+          this.worker = new Worker(
+            new URL('../workers/analysis-worker.ts', import.meta.url)
+          );
+        }
       } catch (err) {
         settle();
         Sentry.captureException(err, {


### PR DESCRIPTION
## Summary

URL-based content blockers (ad blockers) intercept `Worker`-type fetch requests but pass `fetch()`/XHR. When the analysis worker fails to load with an opaque error (no filename/lineno), the orchestrator now fetches the worker script via `fetch()` and creates a blob URL before retrying, bypassing the content blocker.

**Changes:**
- `lib/analysis-orchestrator.ts` — on opaque worker error, fetch script + create blob URL as fallback; revoke blob URL after use; tag Sentry events with `blobFallback: true`
- `__tests__/analysis-orchestrator-worker-error.test.ts` — new test file asserting fallback behavior on opaque error

Fixes: [AIR-2662](/AIR/issues/AIR-2662)

## Pre-merge checklist
- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] Vercel preview deploy verified by Demian
- [ ] No regressions in analysis worker loading