### PR TITLE
fix(stripe): right-size dunning alerts and gate the URGENT email to the final attempt

### DIFF
--- a/__tests__/critical-alert-email-fallback.test.ts
+++ b/__tests__/critical-alert-email-fallback.test.ts
@@ -44,8 +44,10 @@ describe('critical alert email fallback (AIR-1848)', () => {
   })
 
   describe('alertStripePaymentFailed', () => {
-    it('sends both Discord and Resend email', async () => {
-      await alertStripePaymentFailed()
+    it('sends both Discord and Resend email on the final attempt', async () => {
+      // No args (or nextAttemptAt == null) means the FINAL dunning attempt:
+      // the critical path (Discord #critical + ops email) must fire.
+      await alertStripePaymentFailed({ nextAttemptAt: null })
 
       // Discord fired
       expect(mockFetch).toHaveBeenCalledOnce()
@@ -60,20 +62,41 @@ describe('critical alert email fallback (AIR-1848)', () => {
         text: string
       }
       expect(emailArgs.to).toBe('d.voorhagen@gmail.com')
-      expect(emailArgs.subject).toBe('[AirwayLab URGENT] Stripe payment failed')
+      expect(emailArgs.subject).toBe('[AirwayLab URGENT] Final payment attempt failed — subscription will cancel')
       expect(emailArgs.text).toContain('Stripe')
     })
 
     it('fires email even when Discord webhook is not configured', async () => {
       delete process.env.DISCORD_WEBHOOK_CRITICAL
 
-      await alertStripePaymentFailed()
+      await alertStripePaymentFailed({ nextAttemptAt: null })
 
       // Discord skipped (no URL)
       expect(mockFetch).not.toHaveBeenCalled()
 
       // Email still fires independently
       expect(mockSendEmail).toHaveBeenCalledOnce()
+    })
+
+    it('posts a calm #revenue note with NO email when a retry is still pending', async () => {
+      // nextAttemptAt set = Stripe will retry again. Routine: #revenue only, no email.
+      process.env.DISCORD_REVENUE_WEBHOOK_URL = 'https://discord.com/api/webhooks/test/revenue'
+
+      await alertStripePaymentFailed({
+        amountCents: 900,
+        attemptCount: 1,
+        nextAttemptAt: 1_900_000_000, // far-future epoch seconds
+        customerEmail: 'patient@example.com',
+        subscriptionId: 'sub_abc123',
+      })
+
+      // Posted to #revenue, NOT #critical
+      expect(mockFetch).toHaveBeenCalledOnce()
+      const url = (mockFetch.mock.calls[0] as unknown[])[0] as string
+      expect(url).toBe('https://discord.com/api/webhooks/test/revenue')
+
+      // No ops email on a routine retry
+      expect(mockSendEmail).not.toHaveBeenCalled()
     })
   })
 

--- a/__tests__/discord-webhook.test.ts
+++ b/__tests__/discord-webhook.test.ts
@@ -291,6 +291,27 @@ describe('formatRevenueEmbed', () => {
     const embed = formatRevenueEmbed({ event: 'cancellation' });
     expect(embed.footer?.text).toBe('Stripe');
   });
+
+  it('uses green color and a recovered title for payment_recovered', () => {
+    const embed = formatRevenueEmbed({ event: 'payment_recovered', tier: 'supporter' });
+    expect(embed.color).toBe(COLORS.green);
+    expect(embed.title).toContain('Payment Recovered');
+  });
+
+  it('renders From → To for a real tier change, not a bare Tier', () => {
+    const embed = formatRevenueEmbed({ event: 'tier_change', fromTier: 'supporter', tier: 'champion' });
+    const field = (name: string) => embed.fields?.find((f) => f.name === name);
+    expect(field('From')?.value).toBe('supporter');
+    expect(field('To')?.value).toBe('champion');
+    expect(field('Tier')).toBeUndefined();
+  });
+
+  it('falls back to a single Tier field when fromTier equals the new tier', () => {
+    const embed = formatRevenueEmbed({ event: 'tier_change', fromTier: 'supporter', tier: 'supporter' });
+    const field = (name: string) => embed.fields?.find((f) => f.name === name);
+    expect(field('Tier')?.value).toBe('supporter');
+    expect(field('From')).toBeUndefined();
+  });
 });
 
 // ── formatRevenueEmbed: legible cancellation (Round 1) ─────────────────────

--- a/__tests__/stripe-webhook.test.ts
+++ b/__tests__/stripe-webhook.test.ts
@@ -2052,4 +2052,150 @@ describe('POST /api/webhooks/stripe', () => {
     expect(sendEmail).not.toHaveBeenCalled();
     expect(sendAlert).not.toHaveBeenCalled();
   });
+
+  // ---------- 46. Alert right-sizing: no false "Tier Change" on a no-op update ----------
+  // Regression lock for the dunning-noise bug: subscription.updated used to fire
+  // a "Tier Change" #revenue alert on EVERY event (renewal period-roll, status
+  // flip, the webhook's own dunning-metadata echo). Now it compares prior state
+  // and stays silent when nothing actually changed.
+  it('does NOT fire a revenue alert on a no-op subscription.updated (regression lock)', async () => {
+    const { formatRevenueEmbed, sendAlert } = await import('@/lib/discord-webhook');
+    const subscription = makeSubscriptionObject(); // supporter / price_supp_m / active
+    const event = makeStripeEvent('customer.subscription.updated', subscription);
+    mockWebhooksConstruct.mockReturnValue(event);
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'subscriptions') {
+        // Prior row identical to the incoming sub — nothing changed.
+        return createQueryBuilder({
+          data: { tier: 'supporter', stripe_price_id: 'price_supp_m', status: 'active' },
+          error: null,
+        });
+      }
+      return createQueryBuilder({ data: null, error: null });
+    });
+
+    const res = await callRoute(makeRequest('{}', { 'stripe-signature': 'sig_valid' }));
+    expect(res.status).toBe(200);
+
+    expect(formatRevenueEmbed).not.toHaveBeenCalled();
+    expect(sendAlert).not.toHaveBeenCalledWith('revenue', expect.anything(), expect.anything());
+  });
+
+  // ---------- 47. Alert right-sizing: real tier change renders From → To ----------
+  it('fires ONE tier_change alert with From → To when the tier actually changes', async () => {
+    const { formatRevenueEmbed, sendAlert } = await import('@/lib/discord-webhook');
+    const subscription = makeSubscriptionObject({
+      items: {
+        data: [{
+          price: { id: 'price_champ_m', unit_amount: 1900, recurring: { interval: 'month' } },
+          current_period_end: 1700000000,
+        }],
+      },
+    });
+    const event = makeStripeEvent('customer.subscription.updated', subscription);
+    mockWebhooksConstruct.mockReturnValue(event);
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'subscriptions') {
+        return createQueryBuilder({
+          data: { tier: 'supporter', stripe_price_id: 'price_supp_m', status: 'active' },
+          error: null,
+        });
+      }
+      return createQueryBuilder({ data: null, error: null });
+    });
+
+    const res = await callRoute(makeRequest('{}', { 'stripe-signature': 'sig_valid' }));
+    expect(res.status).toBe(200);
+
+    expect(formatRevenueEmbed).toHaveBeenCalledTimes(1);
+    expect(formatRevenueEmbed).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'tier_change', fromTier: 'supporter', tier: 'champion' })
+    );
+    expect(sendAlert).toHaveBeenCalledWith('revenue', '', expect.any(Array));
+  });
+
+  // ---------- 48. Alert right-sizing: recovery from dunning is good news, fired once ----------
+  it('fires a payment_recovered alert once when a past_due sub returns to active', async () => {
+    const { formatRevenueEmbed, sendAlert } = await import('@/lib/discord-webhook');
+    const subscription = makeSubscriptionObject(); // active, supporter
+    const event = makeStripeEvent('customer.subscription.updated', subscription);
+    mockWebhooksConstruct.mockReturnValue(event);
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'subscriptions') {
+        // Prior state was past_due; the incoming sub is active → recovery.
+        return createQueryBuilder({
+          data: { tier: 'supporter', stripe_price_id: 'price_supp_m', status: 'past_due' },
+          error: null,
+        });
+      }
+      return createQueryBuilder({ data: null, error: null });
+    });
+
+    const res = await callRoute(makeRequest('{}', { 'stripe-signature': 'sig_valid' }));
+    expect(res.status).toBe(200);
+
+    expect(formatRevenueEmbed).toHaveBeenCalledTimes(1);
+    expect(formatRevenueEmbed).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'payment_recovered', tier: 'supporter' })
+    );
+    expect(sendAlert).toHaveBeenCalledWith('revenue', '', expect.any(Array));
+  });
+
+  // ---------- 49. Alert right-sizing: non-final dunning attempt passes retry context ----------
+  // The webhook hands full context to alertStripePaymentFailed; the helper decides
+  // severity (calm #revenue note when a retry is pending, see discord-webhook tests).
+  it('passes retry context (nextAttemptAt set) to alertStripePaymentFailed on a non-final attempt', async () => {
+    const { alertStripePaymentFailed } = await import('@/lib/discord-webhook');
+    const invoice = {
+      amount_due: 900,
+      attempt_count: 1,
+      next_payment_attempt: 1900000000, // a retry is scheduled → not the final attempt
+      customer_email: 'patient@example.com',
+      parent: { subscription_details: { subscription: 'sub_test_123' } },
+    };
+    const event = makeStripeEvent('invoice.payment_failed', invoice);
+    mockWebhooksConstruct.mockReturnValue(event);
+    mockFrom.mockImplementation(() => createQueryBuilder({ data: null, error: null }));
+
+    const res = await callRoute(makeRequest('{}', { 'stripe-signature': 'sig_valid' }));
+    expect(res.status).toBe(200);
+
+    expect(alertStripePaymentFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amountCents: 900,
+        attemptCount: 1,
+        nextAttemptAt: 1900000000,
+        subscriptionId: 'sub_test_123',
+      })
+    );
+  });
+
+  // ---------- 50. Alert right-sizing: final dunning attempt flagged via nextAttemptAt:null ----------
+  it('passes nextAttemptAt:null to alertStripePaymentFailed on the final dunning attempt', async () => {
+    const { alertStripePaymentFailed } = await import('@/lib/discord-webhook');
+    const invoice = {
+      amount_due: 900,
+      attempt_count: 4,
+      next_payment_attempt: null, // Stripe exhausted retries → the sub will cancel
+      customer_email: 'patient@example.com',
+      parent: { subscription_details: { subscription: 'sub_test_123' } },
+    };
+    const event = makeStripeEvent('invoice.payment_failed', invoice);
+    mockWebhooksConstruct.mockReturnValue(event);
+    mockFrom.mockImplementation(() => createQueryBuilder({ data: null, error: null }));
+
+    const res = await callRoute(makeRequest('{}', { 'stripe-signature': 'sig_valid' }));
+    expect(res.status).toBe(200);
+
+    expect(alertStripePaymentFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextAttemptAt: null,
+        attemptCount: 4,
+        subscriptionId: 'sub_test_123',
+      })
+    );
+  });
 });

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -405,6 +405,17 @@ async function processStripeEvent(
         cancel_comment: cancelDetails.comment ?? null,
       } : {};
 
+      // Read prior tier/price/status BEFORE the update so we can tell a genuine
+      // tier change (upgrade/downgrade) apart from the many other reasons Stripe
+      // emits subscription.updated (renewal period-roll, status flips, and our
+      // own dunning-metadata write echoing back). Without this, every update is
+      // mislabelled as a "Tier Change" in #revenue.
+      const { data: priorSub } = await supabase
+        .from('subscriptions')
+        .select('tier, stripe_price_id, status')
+        .eq('stripe_subscription_id', subscription.id)
+        .maybeSingle();
+
       const subUpdatePromise = supabase
         .from('subscriptions')
         .update({
@@ -448,12 +459,27 @@ async function processStripeEvent(
         await syncDiscordForUser(supabase, userId!, tier, event.id);
       }
 
-      await sendAlert('revenue', '', [formatRevenueEmbed({
-        event: 'tier_change',
-        tier,
-        interval: updatedInterval,
-        mrrCents: computeMrrCents(updatedItem?.price.unit_amount ?? 0, updatedInterval),
-      })]);
+      // Alert only on a REAL tier/price change, or a recovery from dunning. A
+      // renewal, a →past_due flip (already covered by the payment_failed alert),
+      // and the dunning-metadata echo all stay silent. Email is masked inside
+      // formatRevenueEmbed; the recovery alert dedupes itself because the next
+      // update reads status='active' from the row we just wrote.
+      const tierChanged = !!priorSub && (priorSub.tier !== tier || priorSub.stripe_price_id !== priceId);
+      const recovered = !!priorSub
+        && (priorSub.status === 'past_due' || priorSub.status === 'unpaid')
+        && subscription.status === 'active';
+
+      if (tierChanged || recovered) {
+        const email = userId ? await getUserEmail(supabase, userId) : null;
+        await sendAlert('revenue', '', [formatRevenueEmbed({
+          event: tierChanged ? 'tier_change' : 'payment_recovered',
+          fromTier: tierChanged ? (priorSub!.tier ?? undefined) : undefined,
+          tier,
+          interval: updatedInterval,
+          mrrCents: computeMrrCents(updatedItem?.price.unit_amount ?? 0, updatedInterval),
+          email: email ?? undefined,
+        })]);
+      }
 
       break;
     }
@@ -626,8 +652,17 @@ async function processStripeEvent(
           source: 'dunning',
         });
 
-        // Critical alert: Discord #critical + email to ops
-        await alertStripePaymentFailed();
+        // Right-sized alert: the URGENT email + #critical fire ONLY on Stripe's
+        // final dunning attempt (next_payment_attempt === null, sub about to be
+        // lost). Earlier retries go to #revenue as a calm "retry pending" note.
+        // Every alert carries amount, attempt #, masked customer, next retry.
+        await alertStripePaymentFailed({
+          amountCents: invoice.amount_due,
+          attemptCount: invoice.attempt_count ?? undefined,
+          nextAttemptAt: invoice.next_payment_attempt,
+          customerEmail: invoice.customer_email,
+          subscriptionId,
+        });
       }
 
       break;

--- a/lib/discord-webhook.ts
+++ b/lib/discord-webhook.ts
@@ -375,20 +375,66 @@ export async function alertCredentialExpiry(hoursLeft: number, credentialName: s
 }
 
 /**
- * Alert: Stripe payment failed on the board card.
- * Fires to Discord #critical and emails the ops contact.
+ * Alert: a subscription invoice payment failed (dunning).
+ *
+ * Severity is right-sized to Stripe's retry schedule. The URGENT email +
+ * #critical fire ONLY on the FINAL attempt (`nextAttemptAt == null`), when the
+ * subscription is about to be cancelled. Earlier retries are routine — Stripe
+ * keeps retrying and most self-heal — so they post a calm note to #revenue with
+ * NO email. Every alert carries amount, attempt #, masked customer, next retry.
+ *
+ * Called with no args (`{}`) it defaults to the critical path, so any future
+ * caller that omits context still errs on the side of alerting.
  */
-export async function alertStripePaymentFailed(): Promise<boolean> {
-  const subject = `[AirwayLab URGENT] Stripe payment failed`
-  const body = `AirwayLab critical alert\n\nStripe invoice payment failed. Check the Stripe dashboard immediately — active subscriptions may be at risk.\n\nhttps://dashboard.stripe.com`
+export async function alertStripePaymentFailed(opts: {
+  amountCents?: number
+  attemptCount?: number
+  nextAttemptAt?: number | null
+  customerEmail?: string | null
+  subscriptionId?: string
+} = {}): Promise<boolean> {
+  const isFinal = opts.nextAttemptAt == null
+  const amount = opts.amountCents != null ? `$${(opts.amountCents / 100).toFixed(2)}` : 'unknown'
+  const nextRetry = opts.nextAttemptAt != null
+    ? `${new Date(opts.nextAttemptAt * 1000).toISOString().slice(0, 16).replace('T', ' ')} UTC`
+    : 'none — final attempt'
+  const customer = opts.customerEmail ? maskEmail(opts.customerEmail) : 'unknown'
+  const dashUrl = opts.subscriptionId
+    ? `https://dashboard.stripe.com/subscriptions/${opts.subscriptionId}`
+    : 'https://dashboard.stripe.com'
+
+  const fields: DiscordEmbedField[] = [
+    { name: 'Amount', value: amount, inline: true },
+    { name: 'Attempt', value: opts.attemptCount != null ? String(opts.attemptCount) : '?', inline: true },
+    { name: 'Customer', value: customer, inline: true },
+    { name: 'Next retry', value: nextRetry, inline: true },
+  ]
+
+  if (isFinal) {
+    // Final attempt — the subscription will be cancelled. Critical: #critical + email.
+    const subject = `[AirwayLab URGENT] Final payment attempt failed — subscription will cancel`
+    const body = `AirwayLab critical alert\n\nStripe's final retry failed (amount ${amount}, customer ${customer}, attempt ${opts.attemptCount ?? '?'}). The subscription will be cancelled.\n\n${dashUrl}`
+    const embed: DiscordEmbed = {
+      title: `:x: Final Payment Attempt Failed`,
+      description: 'Stripe has exhausted retries. The subscription will be cancelled.',
+      color: COLORS.red,
+      fields,
+      footer: { text: 'Stripe webhook' },
+      timestamp: new Date().toISOString(),
+    }
+    return sendCriticalAlert(subject, body, '', [embed])
+  }
+
+  // Non-final retry — routine. Calm note to #revenue, no email.
   const embed: DiscordEmbed = {
-    title: `:x: Stripe Payment Failed`,
-    description: 'Invoice payment failed. Check Stripe dashboard.',
-    color: COLORS.red,
+    title: `:warning: Payment Retry Pending`,
+    description: 'Payment failed; Stripe will retry automatically. No action needed yet.',
+    color: COLORS.amber,
+    fields,
     footer: { text: 'Stripe webhook' },
     timestamp: new Date().toISOString(),
   }
-  return sendCriticalAlert(subject, body, '', [embed])
+  return sendAlert('revenue', '', [embed])
 }
 
 /**
@@ -486,12 +532,14 @@ export function maskEmail(email: string): string {
  * (portal / dunning / account deletion) so two distinct churns never look alike.
  */
 export function formatRevenueEmbed(opts: {
-  event: 'new_subscription' | 'tier_change' | 'cancellation' | 'payment_failed'
+  event: 'new_subscription' | 'tier_change' | 'cancellation' | 'payment_failed' | 'payment_recovered'
   tier?: string
   interval?: string
   mrrCents?: number
   userId?: string
   email?: string
+  // tier_change-specific: the tier the sub moved away from (renders From → To)
+  fromTier?: string
   // cancellation-specific
   churnedFrom?: string
   landingTier?: string
@@ -506,6 +554,7 @@ export function formatRevenueEmbed(opts: {
     tier_change: ':arrows_counterclockwise: Tier Change',
     cancellation: ':wave: Cancellation',
     payment_failed: ':x: Payment Failed',
+    payment_recovered: ':white_check_mark: Payment Recovered',
   }
 
   const colors: Record<string, number> = {
@@ -513,6 +562,7 @@ export function formatRevenueEmbed(opts: {
     tier_change: COLORS.blue,
     cancellation: COLORS.amber,
     payment_failed: COLORS.red,
+    payment_recovered: COLORS.green,
   }
 
   const fields: DiscordEmbedField[] = []
@@ -528,7 +578,12 @@ export function formatRevenueEmbed(opts: {
     if (opts.landingTier) fields.push({ name: 'Now on', value: opts.landingTier, inline: true })
     if (opts.email) fields.push({ name: 'Email', value: maskEmail(opts.email), inline: true })
   } else {
-    if (opts.tier) fields.push({ name: 'Tier', value: opts.tier, inline: true })
+    if (opts.fromTier && opts.fromTier !== opts.tier) {
+      fields.push({ name: 'From', value: opts.fromTier, inline: true })
+      if (opts.tier) fields.push({ name: 'To', value: opts.tier, inline: true })
+    } else if (opts.tier) {
+      fields.push({ name: 'Tier', value: opts.tier, inline: true })
+    }
     if (opts.interval) fields.push({ name: 'Interval', value: opts.interval, inline: true })
     if (opts.mrrCents !== undefined) fields.push({ name: 'MRR', value: `$${(opts.mrrCents / 100).toFixed(2)}`, inline: true })
     if (opts.email) fields.push({ name: 'Email', value: maskEmail(opts.email), inline: true })


### PR DESCRIPTION
## What & why

Both of Demian's payment-notification complaints traced to **one real customer** (`supporter` \$9/mo) going through **normal Stripe dunning** on its June renewal. Nothing was broken or duplicated, the alerts were just **mislabelled and over-severe**.

Verified timeline (distinct `event_id`s, idempotency working):

| Time (CEST) | Stripe event | Old behaviour | Reality |
|---|---|---|---|
| 00:40 | `customer.subscription.updated` | "Tier Change" #1 | renewal period-roll. Tier unchanged. |
| 01:40 | `customer.subscription.updated` | "Tier Change" #2 | payment-attempt status flip. Tier unchanged. |
| 01:41 | `invoice.payment_failed` | URGENT email + #critical | real card failure (dunning) |
| 01:41 | `customer.subscription.updated` | "Tier Change" #3 | echo of the webhook's **own** `canceled_via:'dunning'` metadata write. Tier unchanged. |

### Q1 — three identical "Tier Change" messages
`customer.subscription.updated` fired `formatRevenueEmbed({event:'tier_change'})` on **every** event with **no old-vs-new comparison**, so renewals, status flips, and the handler's own metadata-write echo all showed up as identical "Tier Change" (same tier/MRR).

**Fix:** read prior `tier`/`stripe_price_id`/`status` before the update; alert only on a genuine tier change (rendered **From → To**) or a recovery from `past_due`/`unpaid` → `active` (a new green **Payment Recovered** note). Renewals, the flip to `past_due`, and the metadata echo stay **silent**. The local-row comparison dedupes the recovery alert naturally (the next update reads `status:'active'`).

### Q2 — alarmist payment-failed email on every retry
`alertStripePaymentFailed()` took no args and sent `[URGENT] Stripe payment failed … active subscriptions may be at risk` + #critical on **every** retry, with zero specifics.

**Fix:** it now takes context and branches on `next_payment_attempt`:
- **Final attempt** (`next_payment_attempt == null`, sub about to cancel) → URGENT email + #critical, subject names the cancellation, deep link to the subscription.
- **Earlier retries** → calm amber **Payment Retry Pending** note to #revenue, **no email**.
- Every alert carries amount, attempt #, masked customer, next-retry time.

## Scope / safety
- **No DB migration. No clinical surface** (`route.ts`, `lib/discord-webhook.ts`). No `clinical-signoff` needed.
- Backward-compatible: a no-arg `alertStripePaymentFailed()` still defaults to the critical path.

## Tests
+9 cases, all green locally (typecheck + lint clean):
- **route:** no-op update stays silent (regression lock), real tier change emits From→To, `past_due`→`active` fires Payment Recovered once, non-final vs final `payment_failed` pass the right context.
- **unit:** `formatRevenueEmbed` `payment_recovered` + From→To rendering, non-final calm-note/no-email branch, final-attempt subject.

> Note: local full-suite run was on Node 25; one pre-existing clinical golden-output test (`clinical-input-guards`) drifts on float fields under V8 25 and is byte-identical to `main`. CI runs Node 20 (`.nvmrc`) where it passes.

## Real-path verification (post-merge, per house rule)
Stripe test-mode triggers against a preview deploy: unchanged-tier `subscription.updated` → no #revenue alert; a tier change → one From→To; non-final `invoice.payment_failed` → calm note, no email; final attempt → URGENT email + #critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)