### PR TITLE
ci: switch Claude review + auto-fix workflows to OAuth token auth

### DIFF
--- a/.github/workflows/auto-fix-error.yml
+++ b/.github/workflows/auto-fix-error.yml
@@ -95,7 +95,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-opus-4-8"
           branch_prefix: "fix/sentry-"
           base_branch: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.PROMPT }}
           claude_args: "--model claude-opus-4-8"
           track_progress: true


### PR DESCRIPTION
Moves `claude-code-review.yml` and `auto-fix-error.yml` from `anthropic_api_key` to `claude_code_oauth_token`, matching `claude.yml`. All Claude CI then runs on one credential (`CLAUDE_CODE_OAUTH_TOKEN`), which is being rotated to the dedicated AirwayLab account. `ANTHROPIC_API_KEY` will be deleted from repo secrets once this is merged and verified.

No clinical modules touched. Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)