### PR TITLE
feat(analyze): post-purchase activation banner (AIR-229) [migration preservation]

### DIFF
--- a/__tests__/checkout-banner.test.ts
+++ b/__tests__/checkout-banner.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the post-purchase activation banner on /analyze?checkout=success
+ * Spec: AIR-229
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(__dirname, '..');
+
+function readSource(filePath: string): string {
+  return fs.readFileSync(path.join(ROOT, filePath), 'utf-8');
+}
+
+describe('Checkout success banner: state and analytics', () => {
+  const src = readSource('app/analyze/page.tsx');
+
+  it('reads checkout param from searchParams', () => {
+    expect(src).toContain("searchParams.get('checkout')");
+  });
+
+  it('initialises showCheckoutBanner from checkout param', () => {
+    expect(src).toContain("useState(checkoutParam === 'success')");
+  });
+
+  it('fires subscriptionStarted analytics event on mount', () => {
+    expect(src).toContain("events.subscriptionStarted('unknown', 'unknown', 'checkout_redirect')");
+  });
+
+  it('analytics useEffect has empty deps array (fires once)', () => {
+    // The subscriptionStarted call must be followed by an empty deps array
+    const analyticsEffectMatch = src.match(
+      /subscriptionStarted\('unknown',\s*'unknown',\s*'checkout_redirect'\)[\s\S]*?\},\s*\[\]\)/
+    );
+    expect(analyticsEffectMatch).not.toBeNull();
+  });
+});
+
+describe('Checkout success banner: rendering', () => {
+  const src = readSource('app/analyze/page.tsx');
+
+  it('renders banner when showCheckoutBanner is true', () => {
+    expect(src).toContain('{showCheckoutBanner && (');
+  });
+
+  it('banner has a dismiss button with aria-label', () => {
+    expect(src).toContain('aria-label="Dismiss"');
+    expect(src).toContain('setShowCheckoutBanner(false)');
+  });
+
+  it('banner copy says "is activating" not "is now active"', () => {
+    expect(src).toContain('Your subscription is activating');
+    expect(src).not.toContain('is now active');
+  });
+
+  it('banner copy mentions next upload', () => {
+    expect(src).toContain('next upload');
+  });
+
+  it('banner does not contain diagnostic or clinical language', () => {
+    // Extract the banner block to scope the check
+    const bannerStart = src.indexOf('{showCheckoutBanner && (');
+    const bannerEnd = src.indexOf(')}', bannerStart) + 2;
+    const bannerBlock = src.slice(bannerStart, bannerEnd);
+
+    expect(bannerBlock).not.toContain('normal');
+    expect(bannerBlock).not.toContain('abnormal');
+    expect(bannerBlock).not.toContain('diagnos');
+  });
+
+  it('banner links to account settings', () => {
+    expect(src).toContain('href="/account"');
+    expect(src).toContain('account settings');
+  });
+
+  it('dismiss button has visible focus indicator class', () => {
+    expect(src).toContain('focus-visible:outline');
+  });
+});
+
+describe('Checkout success banner: analytics contract', () => {
+  it('subscriptionStarted event is defined in analytics.ts', () => {
+    const analyticsSrc = readSource('lib/analytics.ts');
+    expect(analyticsSrc).toContain('subscriptionStarted: (tier: string, interval: string, source: string)');
+  });
+});

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
 import { FileUpload } from '@/components/upload/file-upload';
 import { ProgressDisplay } from '@/components/upload/progress-display';
 import { ContributionNudgeDialog } from '@/components/upload/contribution-nudge-dialog';
@@ -90,6 +91,8 @@ export default function AnalyzePage() {
 
 function AnalyzePageInner() {
   const searchParams = useSearchParams();
+  const checkoutParam = searchParams.get('checkout');
+  const [showCheckoutBanner, setShowCheckoutBanner] = useState(checkoutParam === 'success');
   const [state, setState] = useState<AnalysisState>(orchestrator.getState());
   const [selectedNight, setSelectedNight] = useState<number>(0);
   const [isDemo, setIsDemo] = useState(false);
@@ -163,6 +166,14 @@ function AnalyzePageInner() {
       : window.location.pathname;
     window.history.replaceState({}, '', cleanUrl);
   }, [searchParams]);
+
+  // Fire subscriptionStarted analytics event once on checkout redirect
+  useEffect(() => {
+    if (checkoutParam === 'success') {
+      events.subscriptionStarted('unknown', 'unknown', 'checkout_redirect');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Load lifetime night count from localStorage
   useEffect(() => {
@@ -787,6 +798,34 @@ function AnalyzePageInner() {
               </Button>
             </div>
           </div>
+
+          {/* Post-purchase activation banner — shown once per checkout redirect */}
+          {showCheckoutBanner && (
+            <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/[0.06] px-4 py-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-400" />
+                  <div>
+                    <p className="text-sm font-medium text-foreground">
+                      Your subscription is activating
+                    </p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      AI insights will appear automatically on your next upload.
+                      Manage your subscription in{' '}
+                      <Link href="/account" className="underline hover:text-foreground">account settings</Link>.
+                    </p>
+                  </div>
+                </div>
+                <button
+                  onClick={() => setShowCheckoutBanner(false)}
+                  className="shrink-0 rounded p-0.5 text-muted-foreground/50 hover:text-muted-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                  aria-label="Dismiss"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Tabbed Views — right after controls, above nudge banners */}
           <Tabs defaultValue="overview" onValueChange={(tab) => events.tabViewed(tab)}>


### PR DESCRIPTION
Adds a post-purchase activation banner on checkout=success, with a test.

Pushed during the 2026-06 public/private repo-split migration to preserve a local-only branch before clearing local checkouts. **Draft** — needs rebase onto current `main` and review before any merge.

Near-complete; verify against current checkout flow.