### PR TITLE
fix(device-diagnostic): dedup unsupported_device alerts per model/24h [migration preservation]

### DIFF
--- a/__tests__/device-diagnostic-dedup.test.ts
+++ b/__tests__/device-diagnostic-dedup.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/discord-webhook', () => ({
+  sendAlert: vi.fn().mockResolvedValue(true),
+  formatUserSignalEmbed: vi.fn().mockReturnValue({}),
+}))
+
+vi.mock('@/lib/supabase/server', () => ({
+  getSupabaseAdmin: vi.fn().mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    }),
+  }),
+}))
+
+vi.mock('@/lib/csrf', () => ({
+  validateOrigin: vi.fn().mockReturnValue(true),
+}))
+
+vi.mock('@/lib/rate-limit', () => {
+  const isLimited = vi.fn().mockResolvedValue(false)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function RateLimiter(this: any) { this.isLimited = isLimited }
+  return { RateLimiter, getRateLimitKey: vi.fn().mockReturnValue('test-ip') }
+})
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}))
+
+import { POST } from '@/app/api/device-diagnostic/route'
+import { __resetForTests } from '@/app/api/device-diagnostic/_dedup'
+import { sendAlert } from '@/lib/discord-webhook'
+
+const mockSendAlert = sendAlert as ReturnType<typeof vi.fn>
+
+function makeRequest(deviceModel: string, hasStrFile = false): NextRequest {
+  return new NextRequest('http://localhost/api/device-diagnostic', {
+    method: 'POST',
+    body: JSON.stringify({
+      deviceModel,
+      signalLabels: ['Flow'],
+      identificationText: null,
+      hasStrFile,
+    }),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('device-diagnostic dedup', () => {
+  beforeEach(() => {
+    __resetForTests()
+    mockSendAlert.mockClear()
+  })
+
+  it('fires 1 alert for 10 calls with the same device model', async () => {
+    for (let i = 0; i < 10; i++) {
+      await POST(makeRequest('ResMed-AirSense10'))
+    }
+    expect(mockSendAlert).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires 2 alerts for two distinct device models (5 calls each)', async () => {
+    for (let i = 0; i < 5; i++) {
+      await POST(makeRequest('ResMed-AirSense10'))
+    }
+    for (let i = 0; i < 5; i++) {
+      await POST(makeRequest('Philips-DreamStation'))
+    }
+    expect(mockSendAlert).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-fires alert for same model after 24h TTL elapses', async () => {
+    let fakeNow = Date.now()
+    vi.spyOn(Date, 'now').mockImplementation(() => fakeNow)
+
+    await POST(makeRequest('ResMed-AirSense10'))
+    expect(mockSendAlert).toHaveBeenCalledTimes(1)
+
+    // Still within 24h — no second alert
+    await POST(makeRequest('ResMed-AirSense10'))
+    expect(mockSendAlert).toHaveBeenCalledTimes(1)
+
+    // Advance past 24h window
+    fakeNow += 24 * 60 * 60 * 1000 + 1
+
+    await POST(makeRequest('ResMed-AirSense10'))
+    expect(mockSendAlert).toHaveBeenCalledTimes(2)
+
+    vi.restoreAllMocks()
+  })
+
+  it('writes device_diagnostics row on every request regardless of dedup state', async () => {
+    const { getSupabaseAdmin } = await import('@/lib/supabase/server')
+    const insertSpy = vi.fn().mockResolvedValue({ error: null })
+    ;(getSupabaseAdmin as ReturnType<typeof vi.fn>).mockReturnValue({
+      from: vi.fn().mockReturnValue({ insert: insertSpy }),
+    })
+
+    const callCount = 10
+    for (let i = 0; i < callCount; i++) {
+      await POST(makeRequest('ResMed-AirSense10'))
+    }
+
+    expect(insertSpy).toHaveBeenCalledTimes(callCount)
+  })
+})

--- a/app/api/device-diagnostic/_dedup.ts
+++ b/app/api/device-diagnostic/_dedup.ts
@@ -1,0 +1,10 @@
+export const DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000
+
+export const deviceModelLastAlertTs = new Map<string, number>()
+export const deviceModelHitCount = new Map<string, number>()
+
+/** Exported only for unit tests — do not call in production code. */
+export function __resetForTests(): void {
+  deviceModelLastAlertTs.clear()
+  deviceModelHitCount.clear()
+}

--- a/app/api/device-diagnostic/route.ts
+++ b/app/api/device-diagnostic/route.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 import { getSupabaseAdmin } from '@/lib/supabase/server';
 import { validateOrigin } from '@/lib/csrf';
 import { RateLimiter, getRateLimitKey } from '@/lib/rate-limit';
+import { sendAlert, formatUserSignalEmbed } from '@/lib/discord-webhook';
+import { DEDUP_WINDOW_MS, deviceModelLastAlertTs, deviceModelHitCount } from './_dedup';
 
 const limiter = new RateLimiter({ windowMs: 3_600_000, max: 5 });
 
@@ -59,6 +61,20 @@ export async function POST(request: NextRequest) {
         console.error('[device-diagnostic] Supabase error:', error.message);
         Sentry.captureException(error, { tags: { route: 'device-diagnostic' } });
       }
+    }
+
+    const now = Date.now();
+    const lastAlert = deviceModelLastAlertTs.get(deviceModel) ?? 0;
+    const hitCount = (deviceModelHitCount.get(deviceModel) ?? 0) + 1;
+    deviceModelHitCount.set(deviceModel, hitCount);
+
+    if (now - lastAlert > DEDUP_WINDOW_MS) {
+      deviceModelLastAlertTs.set(deviceModel, now);
+      deviceModelHitCount.set(deviceModel, 0);
+      void sendAlert('user-signals', '', [formatUserSignalEmbed({
+        type: 'unsupported_device',
+        message: `Settings extraction failed — model: ${deviceModel}, hasStr: ${hasStrFile} (${hitCount} hit${hitCount !== 1 ? 's' : ''} in last 24h)`,
+      })]);
     }
 
     return NextResponse.json({ ok: true });


### PR DESCRIPTION
De-duplicates unsupported_device Discord alerts per model per 24h, with a test.

Pushed during the 2026-06 public/private repo-split migration to preserve a local-only branch before clearing local checkouts. **Draft** — needs rebase onto current `main` and review before any merge.

May be superseded by the diagnostic-routing fix in #1010 — reconcile before merge.