### PR TITLE
fix: do not remove storage object for recent in-flight uploads

### DIFF
--- a/__tests__/files-api-routes.test.ts
+++ b/__tests__/files-api-routes.test.ts
@@ -359,6 +359,45 @@ describe('POST /api/files/presign', () => {
     expect(body.skipped).toBe(true);
     expect(body.fileId).toBe('existing-id');
   });
+
+  it('deletes recent unconfirmed metadata row but does NOT remove storage object (AIR-2729 regression)', async () => {
+    // A concurrent upload may have already written to the storage path while its
+    // confirm step is still pending. Removing the storage object here would cause
+    // that in-flight confirm to find the file absent and fire JAVASCRIPT-NEXTJS-6F.
+    setupAuthenticatedUser();
+    mockHasStorageConsent.mockResolvedValue(true);
+
+    const recentUnconfirmed = {
+      id: 'in-flight-id',
+      storage_path: 'user-123/2026-01-01/BRP.edf',
+      upload_confirmed: false,
+      uploaded_at: new Date(Date.now() - 60_000).toISOString(), // 1 minute ago — recent
+    };
+    const deleteMock = vi.fn(() => chain);
+    const chain = createChain({ data: recentUnconfirmed, error: null });
+    chain.delete = deleteMock;
+    chain.insert = vi.fn(() => createChain({ data: { id: 'new-file-uuid' }, error: null }));
+    mockFrom.mockReturnValue(chain);
+
+    const removeMock = vi.fn().mockResolvedValue({ data: [], error: null });
+    mockStorageFrom.mockReturnValue({
+      createSignedUploadUrl: vi.fn().mockResolvedValue({
+        data: { signedUrl: 'https://storage.example.com/upload?token=xyz', token: 'xyz' },
+        error: null,
+      }),
+      remove: removeMock,
+    });
+
+    const res = await callPresign(makePostRequest('/api/files/presign', validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.uploadUrl).toBeDefined();
+    // Metadata row must be deleted to unblock the new upload attempt
+    expect(deleteMock).toHaveBeenCalled();
+    // Storage object must NOT be removed — the concurrent in-flight PUT may have
+    // already written to this path; removing it triggers a false-absent Sentry event.
+    expect(removeMock).not.toHaveBeenCalled();
+  });
 });
 
 // ── Confirm ─────────────────────────────────────────────────────

--- a/app/api/files/presign/route.ts
+++ b/app/api/files/presign/route.ts
@@ -128,10 +128,13 @@ export async function POST(request: NextRequest) {
         await serviceRole.from('user_files').delete().eq('id', existing.id);
       } else {
         // Unconfirmed but recent (< 10 min) — another upload may be in progress.
-        // Delete and re-create to avoid blocking this upload attempt.
-        // Also remove any partial storage object to avoid signed URL conflicts.
+        // Delete the metadata row to unblock this attempt. Do NOT remove the storage
+        // object: a concurrent upload may have already written to that path, and
+        // removing it would cause the in-flight confirm step to find the file absent,
+        // triggering a false-absent Sentry event (JAVASCRIPT-NEXTJS-6F, AIR-2729).
+        // createSignedUploadUrl succeeds regardless of whether the path already has an
+        // object; the subsequent PUT will overwrite it without conflict.
         await serviceRole.from('user_files').delete().eq('id', existing.id);
-        await serviceRole.storage.from(STORAGE_BUCKET).remove([existing.storage_path]);
       }
     }
 


### PR DESCRIPTION
## Summary

- Removes the `storage.remove` call from the presign route's "recent unconfirmed" branch (uploads <10 min old)
- A concurrent upload may have already written to the storage path before the second presign runs; removing the object causes the in-flight confirm step to find the file absent and fire a false-absent Sentry event (JAVASCRIPT-NEXTJS-6F)
- `createSignedUploadUrl` succeeds regardless of whether an object already exists at the target path; the new PUT overwrites it cleanly, so the removal was both unnecessary and harmful
- The stale-orphan branch (>10 min unconfirmed) retains its `storage.remove` — those uploads definitively never completed

## Root cause (AIR-2729)

JAVASCRIPT-NEXTJS-6F continued firing after AIR-1430 because presign was deleting the storage object for recent unconfirmed rows. Race window:
1. Upload 1 calls presign → metadata row created, PUT completes
2. Upload 2 calls presign for the same file (e.g. retry/double-tap) — sees recent unconfirmed row → deletes metadata row **and storage object**
3. Upload 1 calls confirm → storage list returns empty → Sentry event fires

The steady ~1-2/day event growth matches the frequency of user retries that hit this narrow race.

## Test plan

- [ ] Full pipeline passes (lint, typecheck, test, build)
- [ ] New regression test asserts `storage.remove` is not called on the recent-unconfirmed path
- [ ] Vercel preview deploy verified by Demian
- [ ] All manual QA items checked (partial pass = no merge)
- [ ] Self-review: no regressions, loading/error/empty states handled
- [ ] PR contains one concern only

🤖 Generated with [Claude Code](https://claude.com/claude-code)